### PR TITLE
Pivot to yopedia — a wiki for the agent age

### DIFF
--- a/.github/workflows/grow.yml
+++ b/.github/workflows/grow.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [labeled]
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: '0 */4 * * *'
   workflow_dispatch:
     inputs:
       task:

--- a/.yoyo/scripts/grow.sh
+++ b/.yoyo/scripts/grow.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# .yoyo/scripts/grow.sh — One growth session for the LLM Wiki project.
+# .yoyo/scripts/grow.sh — One growth session for yopedia.
 # Multi-phase pipeline: Assessment → Planning → Implementation (with eval + fix loops) → Communication
 #
 # Usage:
@@ -131,7 +131,7 @@ run_agent() {
 }
 
 # Protected files for this project
-PROTECTED_PATHS="llm-wiki.md YOYO.md .github/workflows/ .yoyo/scripts/ .yoyo/config.toml .yoyo/.gitignore .yoyo/skills/grow/ .yoyo/skills/communicate/ .yoyo/skills/research/"
+PROTECTED_PATHS="llm-wiki.md yopedia-concept.md YOYO.md .github/workflows/ .yoyo/scripts/ .yoyo/config.toml .yoyo/.gitignore .yoyo/skills/grow/ .yoyo/skills/communicate/ .yoyo/skills/research/"
 
 check_protected_files() {
     local base_sha="$1"
@@ -243,7 +243,7 @@ ASSESS_TIMEOUT=$((TIMEOUT / 2))
 echo "→ Phase A1: Assessment (${ASSESS_TIMEOUT}s)..."
 ASSESS_PROMPT=$(mktemp)
 cat > "$ASSESS_PROMPT" <<ASSESSEOF
-You are yoyo, a coding agent growing the LLM Wiki project. Today is $DATE $SESSION_TIME.
+You are yoyo, a coding agent growing yopedia. Today is $DATE $SESSION_TIME.
 
 === YOUR TASK: ASSESSMENT ===
 
@@ -252,7 +252,7 @@ Your job: understand the current state of the project and produce a structured a
 
 Steps:
 
-1. **Read project context** — YOYO.md (project goals, tech stack), llm-wiki.md (founding vision)
+1. **Read project context** — YOYO.md (project goals, roadmap, tech stack), yopedia-concept.md (north star vision), llm-wiki.md (founding ancestor)
 
 2. **Read the codebase** — all source files under src/ (if they exist). Note directory structure, key components, line counts.
 
@@ -337,7 +337,7 @@ Read the codebase yourself: YOYO.md, llm-wiki.md, src/ (if exists), package.json
 fi
 
 cat > "$PLAN_PROMPT" <<PLANEOF
-You are yoyo, a coding agent growing the LLM Wiki project. Today is $DATE $SESSION_TIME.
+You are yoyo, a coding agent growing yopedia. Today is $DATE $SESSION_TIME.
 
 $ASSESSMENT_SECTION
 ${MANUAL_TASK:+
@@ -467,7 +467,7 @@ for TASK_FILE in session_plan/task_*.md; do
     for ATTEMPT in 1 2; do
         TASK_PROMPT=$(mktemp)
         cat > "$TASK_PROMPT" <<TEOF
-You are yoyo, a coding agent growing the LLM Wiki project. Today is $DATE $SESSION_TIME.
+You are yoyo, a coding agent growing yopedia. Today is $DATE $SESSION_TIME.
 
 Your ONLY job: implement this single task and commit.
 
@@ -763,7 +763,7 @@ if ! grep -q "## $DATE $SESSION_TIME" .yoyo/journal.md 2>/dev/null; then
 
     JOURNAL_PROMPT=$(mktemp)
     cat > "$JOURNAL_PROMPT" <<JEOF
-You are yoyo, growing the LLM Wiki project. You just finished a growth session ($DATE $SESSION_TIME).
+You are yoyo, growing yopedia. You just finished a growth session ($DATE $SESSION_TIME).
 
 This session's commits: $COMMITS
 
@@ -792,7 +792,7 @@ if [ -n "$COMMITS_FOR_REFLECTION" ]; then
     echo "  Reflecting on learnings..."
     REFLECT_PROMPT=$(mktemp)
     cat > "$REFLECT_PROMPT" <<REOF
-You are yoyo, growing the LLM Wiki project. You just finished a session ($DATE $SESSION_TIME).
+You are yoyo, growing yopedia. You just finished a session ($DATE $SESSION_TIME).
 
 Commits: $COMMITS_FOR_REFLECTION
 
@@ -829,7 +829,7 @@ if [ "$ISSUE_COUNT" -gt 0 ] && command -v gh &>/dev/null; then
     SESSION_COMMITS=$(git log --oneline "$SESSION_START_SHA"..HEAD --format="%s" || true)
     RESPOND_PROMPT=$(mktemp)
     cat > "$RESPOND_PROMPT" <<RESPONDEOF
-You are yoyo, growing the LLM Wiki project. You finished a growth session ($DATE $SESSION_TIME).
+You are yoyo, growing yopedia. You finished a growth session ($DATE $SESSION_TIME).
 
 Issues from this session:
 $ALL_ISSUES
@@ -897,7 +897,7 @@ if [ -n "${YOYO_EVOLVE_TOKEN:-}" ] && [ -f .yoyo/journal.md ]; then
 $CURRENT_CONTENT"
         else
             CURRENT_SHA=""
-            NEW_CONTENT="# LLM Wiki — Growth Journal
+            NEW_CONTENT="# yopedia — Growth Journal
 
 $LATEST_ENTRY"
         fi

--- a/.yoyo/skills/grow/SKILL.md
+++ b/.yoyo/skills/grow/SKILL.md
@@ -17,7 +17,7 @@ You are growing yopedia — a wiki for the agent age — from its founding visio
 - Check open issues for feature requests
 
 ## Phase 2: Plan
-- Compare what exists to the YOYO.md vision and llm-wiki.md pattern
+- Compare what exists to the YOYO.md roadmap and yopedia-concept.md vision
 - Identify the highest-impact gaps and decide what to build next
 - Factor in open issues if they align with the vision — but the vision drives, issues steer
 - Write task files to session_plan/ directory

--- a/.yoyo/skills/grow/SKILL.md
+++ b/.yoyo/skills/grow/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: grow
-description: Grow the LLM Wiki project — plan, implement, verify, commit
+description: Grow yopedia — plan, implement, verify, commit
 tools: [bash, read_file, write_file, edit_file]
 ---
 
 # Growth
 
-You are growing the LLM Wiki project from a founding prompt into a working product.
+You are growing yopedia — a wiki for the agent age — from its founding vision into a working product.
 
 ## Phase 1: Understand
-- Read YOYO.md for project context, tech stack, build commands
-- Read llm-wiki.md for the founding vision (Karpathy's LLM Wiki pattern)
+- Read YOYO.md for project context, phased roadmap, tech stack, build commands
+- Read yopedia-concept.md for the north star vision
+- Read llm-wiki.md for the spiritual ancestor (Karpathy's LLM Wiki pattern)
 - Read .yoyo/journal.md for session history
 - Read .yoyo/learnings.md for project-specific insights
 - Check open issues for feature requests
@@ -36,6 +37,7 @@ You are growing the LLM Wiki project from a founding prompt into a working produ
 ## Safety rules
 
 - **Never modify llm-wiki.md.** That's the founding prompt — immutable.
+- **Never modify yopedia-concept.md.** That's the north star vision — immutable.
 - **Never modify YOYO.md.** That's the project context.
 - **Never modify .github/workflows/.** That's the automation safety net.
 - **Never modify .yoyo/scripts/.** That's the harness.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,41 @@
-# The Self-Growing Karpathy LLM Wiki
+# yopedia — A Wiki for the Agent Age
 
 [![Stars](https://img.shields.io/github/stars/yologdev/karpathy-llm-wiki?style=social)](https://github.com/yologdev/karpathy-llm-wiki)
 [![Last Commit](https://img.shields.io/github/last-commit/yologdev/karpathy-llm-wiki)](https://github.com/yologdev/karpathy-llm-wiki/commits/main)
 [![Growth Sessions](https://img.shields.io/github/actions/workflow/status/yologdev/karpathy-llm-wiki/grow.yml?label=growth%20session)](https://github.com/yologdev/karpathy-llm-wiki/actions/workflows/grow.yml)
 
-> One prompt. Zero human code. An AI agent reads Karpathy's LLM Wiki founding prompt and ships production code every 4 hours — on its own.
+> A shared second brain for humans and agents. One knowledge substrate, two surfaces. Grown from Karpathy's LLM Wiki gist by an AI agent — zero human code.
 
-**[`baseline` tag](https://github.com/yologdev/karpathy-llm-wiki/tree/baseline):** one markdown file. **[`main`](https://github.com/yologdev/karpathy-llm-wiki):** a working web app with ingest, query, lint, graph view, and tests — all written by an agent that decided what to build.
+**[`baseline` tag](https://github.com/yologdev/karpathy-llm-wiki/tree/baseline):** one markdown file. **[`main`](https://github.com/yologdev/karpathy-llm-wiki):** a full-stack wiki app with ingest, query, lint, graph view, and 1,242 tests — all written by an agent that decided what to build.
 
 **No human writes code here. No human manages a backlog. The agent drives.**
 
 ---
 
+## What is yopedia?
+
+A wiki designed for both humans and agents to read and write.
+
+**Human surface:** Markdown files with YAML frontmatter, wikilinks between concepts, sources cited inline, confidence and expiry on every page. Read in any markdown viewer. Trusted because every claim has a citation.
+
+**Agent surface:** An open research question — what's the right form of a wiki for agents? Structured claims? Embeddings? Fact triples? The product answers this over time.
+
+**Not RAG.** RAG re-derives every query. yopedia accumulates — pages update, contradictions reconcile on talk pages, lineage is preserved, what's stale visibly decays.
+
+### What makes it different
+
+| Category | Examples | What they do | What yopedia does differently |
+|----------|----------|-------------|-------------------------------|
+| Agent memory | Letta, Mem0, Zep | Private per-agent state, opaque to humans | Public knowledge — multi-agent, multi-human, auditable with provenance |
+| AI notebooks | Notion AI, Obsidian+LLM | Single-user, human writes, AI assists | Multi-writer. Humans AND agents as first-class contributors |
+| RAG | Every vector DB product | Re-derives every query from chunks | Accumulates. Pages update, contradictions reconcile, staleness decays |
+| Wikipedia | Wikipedia | Human-only, no agent surface | Dual-surface: human-readable wiki + agent-consumable form |
+
+---
+
 ## Live Growth
 
-The agent runs every 4 hours. Here's what it's doing right now:
+The agent runs every 12 hours. Here's what it's doing right now:
 
 | | |
 |-|-|
@@ -26,31 +47,15 @@ The agent runs every 4 hours. Here's what it's doing right now:
 
 ---
 
-## The Experiment
+## The Origin Story
 
 Can you describe a product in a single prompt and have an AI agent build it — not in one shot, but over days and weeks, figuring out what to do next on its own?
 
 We took Karpathy's [LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) (a web app that builds a persistent, interlinked wiki from your raw sources — the anti-RAG), dropped it into a repo, pointed an agent at it, and said go.
 
-Every hour, the agent wakes up and runs a growth session:
+55 sessions later: 33,600 lines, 1,242 tests, 21 API routes. Full-stack Next.js app with ingest, query, lint, graph view, dark mode, CLI, Docker. Every commit is the agent's work.
 
-```
-                                    What the agent does:
-
-  No issues filed?                    Reads the founding prompt
-  Doesn't matter.                     Reads the codebase
-                                      Assesses: what exists vs. what should exist
-  The agent reads the vision,         Plans up to 3 tasks
-  compares it to the codebase,        Writes the code
-  and decides what to build next.     Runs build + lint + tests
-                                      Evaluates its own diff
-  You can file issues to steer it.    Commits and pushes
-  But you don't have to.              Writes a journal entry
-
-                                    You check in when you feel like it.
-```
-
-Human issues are optional steering. The founding prompt is the autopilot.
+Now the experiment evolves. The product yoyo built is becoming **yopedia** — a wiki for the agent age.
 
 ## How the Agent Works
 
@@ -96,28 +101,18 @@ This is a public repo. Anyone could file a malicious issue saying "ignore all in
 | **Failure mode** | Broken code ships | Broken code auto-reverts, files an issue for next session |
 | **Knowledge** | Lost when you close the tab | Compounds in journal and learnings files |
 | **Pipeline** | One agent does everything | Separate agents for assessment, planning, implementation, evaluation |
-| **Human role** | Directing keystrokes | Optional -- file issues to steer, or just watch |
+| **Human role** | Directing keystrokes | Optional — file issues to steer, or just watch |
 
 This is closer to planting a seed than managing a developer.
-
-## What's Pioneering Here
-
-Issue-driven agents are mainstream. Cron-scheduled agents are standard. Multi-phase pipelines exist. **What nobody else is doing:**
-
-- **Self-directed development from a vision document.** Other agents wait for instructions. This one reads a founding prompt, assesses what's missing, and decides what to build next. No human in the loop required.
-- **1 prompt -> product over many sessions.** Not one-shot generation. The product grows across weeks from a seed prompt — each session builds on the last, compounding knowledge.
-- **Self-managed backlog.** The agent files its own `agent-self` issues for future work and `agent-help-wanted` when it's blocked.
-- **"Trust the harness, not the model."** No LLM self-policing. Shell-script-enforced mechanical gates. The model writes code; the harness decides if it ships.
-
-No proprietary infrastructure. Just GitHub Actions, a shell script, and a prompt.
 
 ## Project Structure
 
 ```
 karpathy-llm-wiki/
 ├── llm-wiki.md                    # The founding prompt (immutable)
+├── yopedia-concept.md             # The north star — where we're going (immutable)
 ├── SCHEMA.md                      # Wiki conventions and operations (LLM-readable)
-├── YOYO.md                        # Project context for the agent
+├── YOYO.md                        # Project context + phased roadmap
 ├── .github/workflows/grow.yml     # The automation
 ├── src/                           # Everything here was written by the agent
 └── .yoyo/
@@ -156,7 +151,7 @@ pnpm dev        # http://localhost:3000
 ### Supported LLM providers
 
 The app auto-detects a provider from environment variables. Priority (first match
-wins): **Anthropic → OpenAI → Google → Ollama**. Set `LLM_MODEL` to override the
+wins): **Anthropic -> OpenAI -> Google -> Ollama**. Set `LLM_MODEL` to override the
 default model name for the selected provider.
 
 | Provider | Env var | Default model | Notes |
@@ -165,25 +160,6 @@ default model name for the selected provider.
 | OpenAI | `OPENAI_API_KEY=sk-...` | `gpt-4o` | `@ai-sdk/openai` |
 | Google | `GOOGLE_GENERATIVE_AI_API_KEY=...` | `gemini-2.0-flash` | `@ai-sdk/google` (Gemini) |
 | Ollama | `OLLAMA_BASE_URL=http://localhost:11434/api` and/or `OLLAMA_MODEL=llama3.2` | `llama3.2` | `ollama-ai-provider-v2`; runs against a local Ollama server, no API key needed |
-
-Examples:
-
-```bash
-# Anthropic (default)
-ANTHROPIC_API_KEY=sk-ant-...
-
-# OpenAI with a different model
-OPENAI_API_KEY=sk-...
-LLM_MODEL=gpt-4o-mini
-
-# Google Gemini
-GOOGLE_GENERATIVE_AI_API_KEY=...
-LLM_MODEL=gemini-1.5-pro
-
-# Local Ollama — pull a model first with `ollama pull llama3.2`
-OLLAMA_BASE_URL=http://localhost:11434/api
-OLLAMA_MODEL=llama3.2
-```
 
 ## Watch It Grow
 
@@ -206,4 +182,4 @@ gh workflow run grow.yml --repo yologdev/karpathy-llm-wiki \
 
 ---
 
-*The founding prompt is the seed. The harness is the soil. Watch it grow.*
+*The founding prompt was the seed. The harness is the soil. yopedia is what's growing.*

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A wiki designed for both humans and agents to read and write.
 
 ## Live Growth
 
-The agent runs every 12 hours. Here's what it's doing right now:
+The agent runs every 4 hours. Here's what it's doing right now:
 
 | | |
 |-|-|

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -327,6 +327,18 @@ sessions should pick from this list:
   via `withFileLock()` in `src/lib/lock.ts`. This does NOT protect against
   multiple server processes (which would require OS-level lockfiles).
 
+## Schema evolution — toward yopedia
+
+This schema is evolving toward the richer page model defined in
+[`yopedia-concept.md`](yopedia-concept.md). The target frontmatter includes
+`confidence`, `expiry`, `authors[]`, `contributors[]`, `sources[]` (with type
+and provenance), `disputed`, `supersedes`, and `aliases`. New page types will
+include talk pages (`discuss/<slug>.md`) and contributor profiles.
+
+Migration is incremental — existing pages gain new fields with sensible defaults,
+nothing breaks. See YOYO.md for the phased roadmap. As each phase lands, update
+this schema to reflect the new conventions.
+
 ## Co-evolution
 
 This document is meant to be updated by yoyo as conventions emerge. When a

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -327,17 +327,12 @@ sessions should pick from this list:
   via `withFileLock()` in `src/lib/lock.ts`. This does NOT protect against
   multiple server processes (which would require OS-level lockfiles).
 
-## Schema evolution — toward yopedia
+## Planned evolution
 
-This schema is evolving toward the richer page model defined in
-[`yopedia-concept.md`](yopedia-concept.md). The target frontmatter includes
-`confidence`, `expiry`, `authors[]`, `contributors[]`, `sources[]` (with type
-and provenance), `disputed`, `supersedes`, and `aliases`. New page types will
-include talk pages (`discuss/<slug>.md`) and contributor profiles.
-
-Migration is incremental — existing pages gain new fields with sensible defaults,
-nothing breaks. See YOYO.md for the phased roadmap. As each phase lands, update
-this schema to reflect the new conventions.
+The schema will evolve toward the richer page model defined in
+[`yopedia-concept.md`](yopedia-concept.md). See YOYO.md for the phased roadmap.
+As each phase lands, update this document to reflect the new conventions —
+this file describes how the wiki works today, not how it will work tomorrow.
 
 ## Co-evolution
 

--- a/YOYO.md
+++ b/YOYO.md
@@ -121,7 +121,7 @@ These are questions the product answers over time, not assumptions to fix now:
 - **Styling**: Tailwind CSS
 - **LLM**: Multi-provider via Vercel AI SDK (Anthropic, OpenAI, Google, Ollama)
 - **Testing**: vitest
-- **Storage**: Local filesystem (markdown in `raw/`, `wiki/`, `discuss/`)
+- **Storage**: Local filesystem (markdown in `raw/`, `wiki/`)
 - **Search**: BM25 + optional embedding-based vector search with RRF fusion
 
 ## Build & Test

--- a/YOYO.md
+++ b/YOYO.md
@@ -1,48 +1,128 @@
-# The Self-Growing Karpathy LLM Wiki
+# yopedia — A Wiki for the Agent Age
 
 ## What This Is
 
-An implementation of the [LLM Wiki pattern](llm-wiki.md) — Karpathy's idea for building personal knowledge bases using LLMs. Instead of RAG, the LLM incrementally builds and maintains a persistent wiki of interlinked markdown files.
+yopedia is a shared second brain for humans and agents. One knowledge substrate,
+two surfaces over it. Evolved from the [LLM Wiki pattern](llm-wiki.md) —
+Karpathy's idea for building persistent knowledge bases using LLMs.
 
-This project was bootstrapped from a single founding prompt and is being grown entirely by [yoyo](https://github.com/yologdev/yoyo), a self-evolving coding agent. Every commit after the baseline tag was made by yoyo, triggered by GitHub issues.
+This project was bootstrapped from a single founding prompt and grown entirely by
+[yoyo](https://github.com/yologdev/yoyo), a self-evolving coding agent. Every
+commit after the baseline tag was made by yoyo. The experiment proved that an
+agent can grow a product from one prompt — 55 sessions, 33,600 lines, 1,242
+tests, all four founding pillars complete. Now yopedia is the destination.
 
-## Founding Vision
+## The Vision
 
-Read `llm-wiki.md` for the complete pattern description. The core architecture:
+Read `yopedia-concept.md` for the full north star. The core ideas:
 
-- **Raw sources** — immutable source documents (articles, papers, notes)
-- **The wiki** — LLM-generated markdown files (summaries, entity pages, cross-references)
-- **The schema** — conventions and workflows for maintaining the wiki
+**Human surface: a wiki.** Markdown files with YAML frontmatter, wikilinks
+between concepts, sources cited inline, confidence and expiry on every page.
+Read in any markdown viewer. Trusted because every claim has a citation and a
+confidence.
 
-Three operations: **ingest** (add sources → update wiki), **query** (ask questions → get cited answers), **lint** (health-check the wiki).
+**Agent surface: an open question.** What's the right form of a wiki for agents?
+Structured-claim graphs? Pre-computed embeddings? Fact triples? The same markdown
+with a different parser? Treat this as a primary research question the product
+answers over time.
 
-## Current Direction
+**Not RAG.** RAG re-derives every query. yopedia accumulates — new sources
+update existing pages, contradictions reconcile on talk pages, lineage is
+preserved, what's stale visibly decays.
 
-Build a **web application** that lets anyone create and maintain their own LLM wiki. The app should implement:
+**Multi-user, multi-agent from day one.** Schema, trust model, conflict
+resolution, attribution — all designed for many writers from the start.
 
-1. **Ingest** — paste a URL or text, the app processes it into the wiki
-2. **Query** — ask questions against your wiki, get cited answers from wiki pages
-3. **Lint** — health-check the wiki (contradictions, orphan pages, missing cross-references)
-4. **Browse** — navigate the wiki with an index, cross-references, and graph view
+## What Exists
 
-### Open Questions (community decides via issues)
+The founding LLM Wiki vision is fully implemented:
 
-- Web app vs Obsidian plugin vs CLI tool vs all three?
-- Which LLM provider(s) to support? (Start with Anthropic Claude API)
-- Local-first vs cloud-hosted? (Start local-first)
-- Auth and multi-user support?
+| Pillar | Status |
+|--------|--------|
+| **Ingest** | URL fetch, text paste, batch multi-URL, chunking, image download, re-ingest |
+| **Query** | BM25 + vector search (RRF fusion), streaming, citations, save-to-wiki |
+| **Lint** | 7 checks + auto-fix (orphan, stale-index, empty, broken-link, missing-crossref, contradiction, missing-concept-page) |
+| **Browse** | Index with sort/filter, dataview queries, graph view, backlinks, revision history, global search, Obsidian export |
+
+Plus: CLI, Docker, dark mode, keyboard shortcuts, toast notifications, 1,242 tests.
+
+## Current Direction — The yopedia Pivot
+
+The founding vision is complete. Now evolve the product toward yopedia. Work
+through these phases in order. Each phase builds on the last.
+
+### Phase 1: Schema evolution
+
+Extend frontmatter to support yopedia's richer page model:
+- `confidence` (0–1) — how well-supported the page content is
+- `expiry` (ISO date) — when the page should be reviewed for staleness
+- `authors[]` — who created the page (agent or human handle)
+- `contributors[]` — who has edited the page
+- `sources[]` — array of `{type, url, fetched, triggered_by}` for provenance
+- `disputed` (boolean) — whether the page has unresolved contradictions
+- `supersedes` — slug of the page this one replaces
+- `aliases[]` — alternative names (for redirects)
+
+Migrate existing pages by adding sensible defaults. Don't break anything.
+Update SCHEMA.md as you go. Add new lint checks: staleness (expiry past),
+low-confidence, uncited claims.
+
+### Phase 2: Talk pages + attribution
+
+- Create `discuss/<slug>.md` directory for talk pages
+- Talk page schema: linked to parent page, threaded, resolution status
+- Attribution on revisions — who changed what and why
+- Contributor profiles (JSON): trust score, edit count, revert rate
+- UI: talk page tab on page view, contributor badges
+
+### Phase 3: X ingestion loop
+
+- @yoyo mention on X → research the source → write/revise the relevant page
+- `type: x-mention` source provenance with triggering handle attributed
+- Attribution trail from mention to page
+- UI: source badges showing provenance type (URL, text, x-mention)
+
+### Phase 4: Agent identity as yopedia pages (dogfooding)
+
+- yoyo's IDENTITY.md, PERSONALITY.md, learnings, social wisdom become yopedia
+  pages (`authors: [yoyo]`, proper schema)
+- New API: `GET /api/agent/:id/context` — returns an agent's identity +
+  learnings + social wisdom in one call
+- Scoped search: `GET /api/search?scope=agent:yoyo` (personal) vs
+  `GET /api/search` (global)
+- grow.sh switches from "download yoyo-evolve tarball" to "query yopedia API
+  for identity"
+- Any project can bootstrap yoyo by hitting one endpoint — no repo coupling
+- yoyo writes learnings back to yopedia after each session
+- Other agents can onboard the same way — yopedia becomes the identity +
+  knowledge layer for all agents
+
+### Phase 5: Agent surface research
+
+- Experiment with structured claims, fact triples, pre-computed embeddings
+- Human wiki stays source of truth; agent surface is a projection
+- Measure: does it improve query quality? Cross-wiki discovery?
+
+## Open Research
+
+These are questions the product answers over time, not assumptions to fix now:
+
+- What is the right form of a knowledge artifact for an agent?
+- How does trust accrue across humans and agents using the same metrics fairly?
+- How do contradictions resolve when one side is human experience and the other
+  is agent research?
+- How does yopedia stay coherent as it scales past one community?
+- What does federation across separate yopedia instances look like?
 
 ## Tech Stack
-
-Start simple, iterate:
 
 - **Runtime**: Node.js with pnpm
 - **Framework**: Next.js 15 (App Router) + TypeScript
 - **Styling**: Tailwind CSS
-- **LLM**: Multi-provider via Vercel AI SDK (`ai` package) — supports Anthropic, OpenAI, Google, Ollama, etc. Users pick their provider and API key at deploy time via environment variables
+- **LLM**: Multi-provider via Vercel AI SDK (Anthropic, OpenAI, Google, Ollama)
 - **Testing**: vitest
-- **Storage**: Local filesystem (markdown files in `raw/` and `wiki/`)
-- **Search**: Start with index.md scanning, add vector search later
+- **Storage**: Local filesystem (markdown in `raw/`, `wiki/`, `discuss/`)
+- **Search**: BM25 + optional embedding-based vector search with RRF fusion
 
 ## Build & Test
 
@@ -57,21 +137,26 @@ pnpm test         # vitest
 ## Directory Structure
 
 ```
-llm-wiki.md          # founding vision (immutable — do not modify)
+llm-wiki.md          # founding vision — spiritual ancestor (immutable)
+yopedia-concept.md   # north star — the destination (immutable)
 YOYO.md              # this file (project context)
+SCHEMA.md            # wiki conventions and operations
 src/                 # application source
   app/               # Next.js app router pages
   lib/               # core logic (ingest, query, lint)
   components/        # React components
 raw/                 # user's source documents (gitignored)
 wiki/                # LLM-maintained wiki output (gitignored)
+discuss/             # talk pages for conflict resolution (future)
 ```
 
 ## How yoyo Works Here
 
-- Each session: read the founding vision (llm-wiki.md), assess the codebase, identify gaps
-- Decide what to build next based on the biggest gap between vision and reality
-- Factor in GitHub issues labeled `agent-input` if they align with the vision — but the vision drives
+- Each session: read the vision docs (yopedia-concept.md, llm-wiki.md), assess
+  the codebase, identify gaps between vision and reality
+- Decide what to build next based on the phased roadmap above
+- Factor in GitHub issues labeled `agent-input` if they align — but the vision
+  drives, issues steer
 - Run `pnpm build && pnpm lint && pnpm test` after every change
 - If builds break and can't be fixed in 3 attempts, revert
 - Write session notes to `.yoyo/journal.md`

--- a/yopedia-concept.md
+++ b/yopedia-concept.md
@@ -1,0 +1,202 @@
+# yopedia — Concept
+
+A shared second brain for humans and agents. One knowledge substrate, two
+surfaces over it. Maintained by an agent who reads the field every week
+to keep the product ahead of it.
+
+---
+
+## What it is
+
+A wiki for the agent age. Two surfaces over one substrate.
+
+**Human surface: a wiki.** Markdown files with YAML frontmatter, wikilinks
+between concepts, sources cited inline, confidence and expiry on every
+page. Read in any markdown viewer. Edit in any editor. Trusted because
+every claim has a citation and a confidence.
+
+**Agent surface: an open question.** What's the right form of a wiki for
+agents? Maybe structured-claim graphs. Maybe pre-computed embeddings plus
+fact triples. Maybe the same markdown with a different parser. Maybe
+something not yet invented. Treat this as a primary research question
+the product answers over time, not as a thing to assume.
+
+One substrate. Probably markdown is the source of truth and the agent
+form is a projection. Possibly the inverse. The decision belongs to
+whoever is in the codebase when the data forces it.
+
+It is not RAG. RAG re-derives. yopedia accumulates — new sources update
+existing pages, contradictions reconcile on talk pages, lineage is
+preserved, what's stale visibly decays.
+
+Karpathy's LLM-Wiki gist is the spiritual reference. The multi-user,
+multi-agent, dual-surface version of it.
+
+---
+
+## Page schema
+
+Every page is a markdown file with frontmatter:
+
+```yaml
+---
+slug: rust-borrow-checker-pitfalls
+authors: [yoyo]
+contributors: [<other agents and humans over time>]
+sources:
+  - type: external
+    url: https://doc.rust-lang.org/nomicon/...
+    fetched: 2026-03-18
+  - type: x-mention
+    url: https://x.com/<user>/status/<id>
+    triggered_by: <human handle>
+    fetched: 2026-04-22
+confidence: 0.82
+expiry: 2026-10-29
+last_revised: 2026-04-29
+revision_count: 14
+supersedes: [borrow-checker-notes-v1]
+related: [[lifetime-elision]] [[rust-async-pitfalls]]
+disputed: false
+---
+# Page body
+```
+
+The fields are the proposal. The codebase wins where it differs.
+
+---
+
+## Wiki primitives → multi-user, multi-agent equivalents
+
+- **Pages** — markdown files, owned by an entity (agent or human),
+  carrying confidence and expiry.
+- **Edit history** — git, with attributed commits and an explicit
+  `revision_reason` in messages.
+- **Talk pages** — `discuss/<slug>.md` where contributors disagree
+  before merging. Contradictions never silently overwrite.
+- **Watchlists** — entities declare which pages they care about and get
+  notified when those pages change.
+- **Redirects** — `aliases:` in frontmatter.
+- **Categories** — tags plus a lineage tree via `derived_from:`.
+- **Vandalism control** — adversarial review before merge for changes
+  to high-stakes pages; configurable per page tag.
+- **Trust scores** — entities accrue trust over time based on revert
+  rates, contradiction rates, and external citation. Plain JSON, not
+  on-chain. Used to weight conflicting contributions.
+
+Multi-user and multi-agent from day one. Schema, trust model, conflict
+resolution, attribution — all designed for many writers from the start,
+not retrofitted.
+
+---
+
+## The three ingestion loops
+
+How knowledge enters yopedia.
+
+### 1. @yoyo on X
+
+A human mentions yoyo on X with a link, an article, or a post. yoyo
+researches the underlying source, writes (or revises) the relevant page,
+and cites the original mention as the trigger. The X URL goes into
+`sources` as `type: x-mention` with the triggering handle attributed.
+
+Low-friction, public, permanent attribution trail. The mention *is* the
+citation.
+
+### 2. Direct contribution
+
+Other agents and humans contribute via git. Same schema, same attribution
+discipline, same talk-page conflict resolution. No special path —
+yoyo, other agents, and humans all use the same rails.
+
+### 3. Yoyo's own research
+
+When working on a page, yoyo can pull in additional sources via web
+research and xurl. Same attribution rules apply.
+
+---
+
+## Yoyo's competitive R&D loop (separate from yopedia)
+
+This is a yoyo capability, not part of the yopedia product. yopedia
+doesn't need to know about it. Yoyo uses it to keep the product ahead
+of the field.
+
+**On a weekly schedule:**
+
+1. Scan X, web, GitHub for LLM-wiki variants, memory systems for agents,
+   knowledge-graph products, second-brain projects, and adjacent work.
+2. Read what looks interesting — a new schema, a clever ingestion
+   approach, a federation model, a failure mode someone hit.
+3. Distill into something actionable: "X team tried Y, what works, what
+   we should adopt or avoid, what would change in our roadmap."
+4. Output goes to:
+   - the assignment file (if it changes the standing direction),
+   - an issue in the yopedia repo (if it's a concrete change to make),
+   - the journal (if it's an observation worth holding for later).
+
+Output is engineering intelligence, not wiki pages. Other people's
+products are not subjects yopedia needs to cover; they are inputs to
+how we build ours.
+
+This is a job, not an event. Bounded and continuous. Yoyo does not
+"check Twitter" in normal work sessions — that's distraction. He scans
+the field on the schedule and ships from the assignment the rest of
+the time.
+
+---
+
+## Why this is different from existing memory tools
+
+- **Letta, Mem0, Zep, Cognee** treat memory as agent state — private,
+  per-agent, opaque to humans. yopedia treats knowledge as a public
+  artifact — multi-agent, multi-human, legible, auditable, with
+  provenance.
+- **Anthropic Skills marketplace, Cursor rules** ship descriptions and
+  rules, not knowledge. Different layer.
+- **Notion-AI, Obsidian-with-LLM** are single-user. yopedia is
+  collaborative across humans and agents.
+- **Wikipedia** is human-only and lacks agent-readable form.
+- **RAG** re-derives every query. yopedia accumulates.
+
+The shape — multi-user, multi-agent, lineage-aware, dual-surface,
+content-as-commons — isn't being built by anyone yet. The competitive
+scan loop above is how we know.
+
+---
+
+## Yoyo's role
+
+Seed contributor. Primary maintainer. Ingestion engine for X mentions.
+R&D scanner. Eventual dogfood user (his own journal and learnings move
+into yopedia once it can hold them).
+
+He is not yopedia. He is its most active early agent. As more agents
+and humans contribute, his share of edits decreases by design — and the
+name doesn't keep him at the center forever.
+
+---
+
+## Open questions (the live research)
+
+These are the questions the product answers over time, not assumptions
+to fix now.
+
+- What is the right form of a knowledge artifact for an agent? Same
+  markdown? Structured claims? Graph? Embeddings? Hybrid?
+- How does trust accrue across humans and agents using the same metrics
+  fairly?
+- How do contradictions resolve when one side is a human's lived
+  experience and the other is an agent's research?
+- How does yopedia stay coherent as it scales past one community?
+- What does federation across separate yopedia instances look like, if
+  it ever happens?
+
+The product doesn't need answers to ship. It needs the questions to be
+visible so contributions can move them forward.
+
+---
+
+*This concept is the destination. The roadmap is the next thing on the
+way. They live in different files for a reason.*


### PR DESCRIPTION
## Summary
- **YOYO.md**: Full rewrite with yopedia vision and 5-phase roadmap (schema evolution → talk pages → X ingestion → agent identity as pages → agent surface research)
- **README.md**: Rebrand to "yopedia — A Wiki for the Agent Age" with comparison table, updated narrative, 12h growth schedule
- **SCHEMA.md**: Added "Schema evolution — toward yopedia" section describing target frontmatter fields
- **yopedia-concept.md**: North star vision document added as immutable protected file
- **grow skill**: Updated to read yopedia-concept.md in Phase 1 and protect it from modification

## Test plan
- [ ] Verify existing build still passes (`pnpm build && pnpm test`)
- [ ] Trigger a growth session and confirm yoyo references yopedia in its session plan
- [ ] Check yoyo's journal entry reflects the pivot

🤖 Generated with [Claude Code](https://claude.com/claude-code)