### PR TITLE
Fix DeepSeek 404 (use Chat Completions) + sourceUrl on text ingest

### DIFF
--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -9,12 +9,21 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    const { url, title, content, preview, generatedContent, triggeredBy, tags } = body;
+    const { url, title, content, preview, generatedContent, triggeredBy, tags, sourceUrl } = body;
 
     // Validate triggeredBy if provided
     if (triggeredBy !== undefined && typeof triggeredBy !== "string") {
       return NextResponse.json(
         { error: "triggeredBy must be a string if provided" },
+        { status: 400 },
+      );
+    }
+
+    // Validate sourceUrl if provided (text path provenance — the URL path
+    // records its own source automatically)
+    if (sourceUrl !== undefined && (typeof sourceUrl !== "string" || !isUrl(sourceUrl.trim()))) {
+      return NextResponse.json(
+        { error: "sourceUrl must be a valid URL if provided" },
         { status: 400 },
       );
     }
@@ -42,6 +51,9 @@ export async function POST(request: NextRequest) {
     }
     if (Array.isArray(tags) && tags.length > 0) {
       options.tags = tags;
+    }
+    if (typeof sourceUrl === "string" && sourceUrl.trim().length > 0) {
+      options.sourceUrl = sourceUrl.trim();
     }
 
     // URL path takes precedence

--- a/src/lib/__tests__/llm-deepseek.test.ts
+++ b/src/lib/__tests__/llm-deepseek.test.ts
@@ -4,8 +4,14 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 // models without any network calls. We assert HOW the deepseek model is built:
 // via createOpenAI pointed at the DeepSeek base URL.
 // `vi.hoisted` so the mock fn exists before the hoisted vi.mock factory runs.
+// The provider is both callable (default = Responses API) AND exposes `.chat()`
+// (Chat Completions); deepseek must use `.chat()`, so we assert on it.
 const { createOpenAIMock } = vi.hoisted(() => ({
-  createOpenAIMock: vi.fn(() => vi.fn((id: string) => ({ id }))),
+  createOpenAIMock: vi.fn(() =>
+    Object.assign((id: string) => ({ id, api: "responses" }), {
+      chat: vi.fn((id: string) => ({ id, api: "chat" })),
+    }),
+  ),
 }));
 vi.mock("@ai-sdk/openai", () => ({ createOpenAI: createOpenAIMock }));
 vi.mock("@ai-sdk/anthropic", () => ({ createAnthropic: vi.fn(() => vi.fn()) }));
@@ -42,7 +48,11 @@ beforeEach(() => {
   process.env.DATA_DIR = "/tmp/llm-wiki-ds-test-nonexistent";
   vi.clearAllMocks();
   // clearAllMocks keeps implementations, but re-assert the factory impl to be safe.
-  createOpenAIMock.mockImplementation(() => vi.fn((id: string) => ({ id })));
+  createOpenAIMock.mockImplementation(() =>
+    Object.assign((id: string) => ({ id, api: "responses" }), {
+      chat: vi.fn((id: string) => ({ id, api: "chat" })),
+    }),
+  );
   _resetConfigCache();
 });
 
@@ -65,9 +75,10 @@ describe("DeepSeek getModel construction", () => {
       apiKey: "sk-ds",
       baseURL: "https://api.deepseek.com",
     });
-    // Default model is deepseek-v4-flash.
-    const modelFactory = createOpenAIMock.mock.results[0].value;
-    expect(modelFactory).toHaveBeenCalledWith("deepseek-v4-flash");
+    // Must use Chat Completions (.chat), NOT the default Responses API —
+    // DeepSeek doesn't implement /responses. Default model deepseek-v4-flash.
+    const provider = createOpenAIMock.mock.results[0].value;
+    expect(provider.chat).toHaveBeenCalledWith("deepseek-v4-flash");
   });
 
   it("honors LLM_MODEL=deepseek-v4-pro", async () => {
@@ -77,7 +88,7 @@ describe("DeepSeek getModel construction", () => {
 
     await callLLM("system", "message");
 
-    const modelFactory = createOpenAIMock.mock.results[0].value;
-    expect(modelFactory).toHaveBeenCalledWith("deepseek-v4-pro");
+    const provider = createOpenAIMock.mock.results[0].value;
+    expect(provider.chat).toHaveBeenCalledWith("deepseek-v4-pro");
   });
 });

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -246,11 +246,15 @@ function getModel() {
       // DeepSeek exposes an OpenAI-compatible endpoint, so we reuse the
       // OpenAI provider with a custom baseURL rather than adding a new
       // dependency. Default model is deepseek-v4-flash (see DEFAULT_MODELS).
+      //
+      // Use `.chat()` (Chat Completions, /chat/completions) explicitly: the
+      // provider's default callable targets OpenAI's Responses API
+      // (/responses), which DeepSeek does not implement — it would 404.
       const deepseek = createOpenAI({
         apiKey: creds.apiKey!,
         baseURL: DEEPSEEK_BASE_URL,
       });
-      return deepseek(model);
+      return deepseek.chat(model);
     }
     case "google": {
       const google = createGoogleGenerativeAI({ apiKey: creds.apiKey! });


### PR DESCRIPTION
## Summary

Hotfix for two issues found while bringing the live deployment up on DeepSeek.

1. **DeepSeek 404 (critical regression from #265).** Every generation call failed with a 500/"Not Found". Root cause: `@ai-sdk/openai@3.0.50`'s default callable `openai(modelId)` builds an `OpenAIResponsesLanguageModel` that POSTs to `/responses` — the OpenAI Responses API, which **DeepSeek does not implement**. Fix: construct the deepseek model with `.chat()` (`/chat/completions`), which DeepSeek supports. Confirmed by code inspection (`@ai-sdk/openai` dist: default → `createLanguageModel` → Responses, `path: "/responses"`).
2. **Text-ingest provenance.** `POST /api/ingest` ignored `sourceUrl` on the text path, even though `IngestOptions.sourceUrl` exists and the URL path uses it. Wire it through (with validation) so pasted/text content can carry a proper source citation.

## Verification

- Reproduced the 404 against the live Worker, applied the fix, redeployed, and **ingested yopedia's first article** (Karpathy's LLM Wiki gist) end-to-end: fetch → DeepSeek-v4-flash (`/chat/completions`) → bge-m3 embedding → indexed page. ✅
- `pnpm lint` clean, `pnpm build:cloudflare` builds, **2072 tests pass** (added `.chat()` assertion to the deepseek getModel test).

## Note

The deployed instance is already running this fix (deployed from this branch). Merging brings `main` back in sync — `main` currently has the broken `deepseek(model)` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)