### PR TITLE
Tune ingest synthesis for higher fidelity (Details section + larger output cap)

### DIFF
--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -1538,6 +1538,9 @@ describe("schema-aware ingest prompt", () => {
     const prompt = await buildIngestSystemPrompt();
     expect(prompt).toContain("You are a wiki editor");
     expect(prompt).toContain("Output pure markdown and nothing else");
+    // Fidelity section: the prompt asks for a Details section that preserves
+    // substantive source content (not just a thin summary).
+    expect(prompt).toContain("## Details");
   });
 });
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -88,6 +88,13 @@ export const LLM_RETRY_MAX_MS = 10_000;
 /** Default maximum output tokens for LLM generation calls. */
 export const LLM_MAX_OUTPUT_TOKENS = 4096;
 
+/**
+ * Output-token cap for ingest synthesis. Higher than the default so the
+ * `## Details` section can faithfully preserve substantive source content
+ * rather than being truncated into a thin summary.
+ */
+export const INGEST_MAX_OUTPUT_TOKENS = 8192;
+
 // ---- Graph ----------------------------------------------------------------
 
 /** Default canvas height (px) for the wiki graph visualisation. */

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -17,6 +17,7 @@ import {
 } from "./sources";
 import {
   MAX_LLM_INPUT_CHARS,
+  INGEST_MAX_OUTPUT_TOKENS,
 } from "./constants";
 import { slugify } from "./slugify";
 import { loadPageConventions } from "./schema";
@@ -342,6 +343,12 @@ Include:
 - A brief summary section (## Summary)
 - Key points or takeaways (## Key Points)
 - Notable entities, concepts, or terms worth remembering (## Concepts)
+- A detailed section (## Details) that faithfully preserves the source's
+  substantive content — important explanations, definitions, examples, steps,
+  data, and notable passages — written as readable prose and lists, not just
+  one-line bullets. Aim to retain what a reader would need so the page can
+  stand in for the source. Do not pad, repeat the summary, or invent anything
+  not supported by the source.
 
 Output pure markdown and nothing else. Do not wrap in code fences.`;
 
@@ -464,19 +471,24 @@ export async function ingest(
     const systemPrompt = await buildIngestSystemPrompt();
     const chunks = chunkText(content, MAX_LLM_INPUT_CHARS);
 
+    // Larger output budget so the ## Details section can preserve substantive
+    // source content instead of being truncated.
+    const llmOptions = { maxOutputTokens: INGEST_MAX_OUTPUT_TOKENS };
+
     if (chunks.length === 1) {
       // Short content — single LLM call (no behaviour change)
-      wikiContent = await callLLM(systemPrompt, chunks[0]);
+      wikiContent = await callLLM(systemPrompt, chunks[0], llmOptions);
     } else {
       // Long content — call LLM per chunk, merge results
       // First chunk produces the primary page structure
-      wikiContent = await callLLM(systemPrompt, chunks[0]);
+      wikiContent = await callLLM(systemPrompt, chunks[0], llmOptions);
 
       // Subsequent chunks add supplemental content
       for (let i = 1; i < chunks.length; i++) {
         const continuation = await callLLM(
           CONTINUATION_SYSTEM_PROMPT,
           `# Existing article so far\n\n${wikiContent}\n\n# Additional source material (part ${i + 1} of ${chunks.length})\n\n${chunks[i]}`,
+          llmOptions,
         );
         wikiContent += "\n\n" + continuation;
       }


### PR DESCRIPTION
## Summary

Make ingested pages preserve more of the source instead of distilling to a thin summary.

- **`## Details` section** added to the ingest prompt (`INGEST_SYSTEM_PROMPT_BASE`): faithfully preserves the source's substantive content — explanations, definitions, examples, steps, data, notable passages — as readable prose/lists, not just one-line bullets. Explicit guardrail: don't pad or invent beyond the source.
- **`INGEST_MAX_OUTPUT_TOKENS = 8192`** (vs the 4096 default), used only for the ingest calls so the richer Details section isn't truncated on dense sources. Query/default output cap is unchanged.

## Result

Re-ingesting Karpathy's LLM Wiki gist: the page grew **~3,641 → ~11,004 chars** (≈the source's full substance), now structured as Summary / Key Points / Concepts / **Details** (with an `### Architecture` subsection). Verified live on the deployed Worker.

## Testing

`pnpm lint` clean, `pnpm build:cloudflare` builds, **2072 tests pass** (added a `## Details` assertion to the prompt-composition test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)