### PR TITLE
Raise query answer output cap to 8192 tokens

### DIFF
--- a/src/app/api/query/stream/route.ts
+++ b/src/app/api/query/stream/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { hasLLMKey, callLLMStream } from "@/lib/llm";
+import { QUERY_MAX_OUTPUT_TOKENS } from "@/lib/constants";
 import { listWikiPages } from "@/lib/wiki";
 import {
   selectPagesForQuery,
@@ -106,7 +107,9 @@ export async function POST(request: NextRequest) {
     );
 
     // Stream the LLM response
-    const result = callLLMStream(systemPrompt, trimmedQuestion);
+    const result = callLLMStream(systemPrompt, trimmedQuestion, {
+      maxOutputTokens: QUERY_MAX_OUTPUT_TOKENS,
+    });
 
     return result.toTextStreamResponse({
       headers: {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -95,6 +95,12 @@ export const LLM_MAX_OUTPUT_TOKENS = 4096;
  */
 export const INGEST_MAX_OUTPUT_TOKENS = 8192;
 
+/**
+ * Output-token cap for query answers. Higher than the default so multi-section
+ * answers, tables, and longer syntheses aren't truncated mid-response.
+ */
+export const QUERY_MAX_OUTPUT_TOKENS = 8192;
+
 // ---- Graph ----------------------------------------------------------------
 
 /** Default canvas height (px) for the wiki graph visualisation. */

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,4 +1,5 @@
 import { callLLM, hasLLMKey } from "./llm";
+import { QUERY_MAX_OUTPUT_TOKENS } from "./constants";
 import {
   listWikiPages,
   writeWikiPageWithSideEffects,
@@ -222,7 +223,9 @@ export async function query(
       format,
     );
 
-    const answer = await callLLM(systemPrompt, question);
+    const answer = await callLLM(systemPrompt, question, {
+      maxOutputTokens: QUERY_MAX_OUTPUT_TOKENS,
+    });
 
     // All slugs in the wiki are valid citation targets
     const allSlugs = entries.map((e) => e.slug);


### PR DESCRIPTION
## Summary

Bump the query answer output cap from the 4096 default to **8192** so longer/multi-section answers (tables, "summarize into slides", multi-part syntheses) aren't truncated mid-response.

- New `QUERY_MAX_OUTPUT_TOKENS = 8192` applied to both answer paths: `POST /api/query` synthesis (`query.ts`) and the streaming route (`/api/query/stream`).
- The rerank call in `query-search.ts` is intentionally **left at the default** — it only emits a short JSON array of slugs, so a higher cap would be wasteful.

Pairs with #267 (ingest at 8192). DeepSeek-v4-flash supports up to 384K output and output is ~$0.28/M, so the extra headroom is effectively free; the only real cost of a higher cap is latency on long answers.

## Testing

`pnpm lint` clean, `pnpm build:cloudflare` builds, **2072 tests pass**. Deployed and verified the bindings/version live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)