### PR TITLE
Add CJK (Chinese) tokenization to BM25 search

### DIFF
--- a/src/lib/__tests__/bm25.test.ts
+++ b/src/lib/__tests__/bm25.test.ts
@@ -62,6 +62,42 @@ describe("tokenize", () => {
     expect(tokens).toContain("section");
     expect(tokens).toContain("100");
   });
+
+  // --- CJK (Chinese) support ---
+
+  it("tokenizes Chinese into word tokens (not dropped)", () => {
+    const tokens = tokenize("中文分词很重要");
+    // ICU word segmentation produces real words...
+    expect(tokens).toContain("中文");
+    expect(tokens).toContain("分词");
+    expect(tokens).toContain("重要");
+    // ...and it is NOT empty (the old tokenizer dropped all CJK).
+    expect(tokens.length).toBeGreaterThan(0);
+  });
+
+  it("emits CJK bigrams as a recall safety net", () => {
+    const tokens = tokenize("知识库");
+    // Bigrams cover the run even if segmentation splits it.
+    expect(tokens).toContain("知识");
+    expect(tokens).toContain("识库");
+  });
+
+  it("indexes a single CJK character as a unigram", () => {
+    expect(tokenize("茶")).toContain("茶");
+  });
+
+  it("a Chinese query shares tokens with matching content (index==query tokenizer)", () => {
+    const docTokens = new Set(tokenize("知识库是共享的第二大脑"));
+    const queryTokens = tokenize("知识库");
+    // At least one query token must appear in the document's tokens.
+    expect(queryTokens.some((t) => docTokens.has(t))).toBe(true);
+  });
+
+  it("handles mixed Latin + Chinese", () => {
+    const tokens = tokenize("DeepSeek 大语言模型");
+    expect(tokens).toContain("deepseek");
+    expect(tokens).toContain("语言");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/bm25.ts
+++ b/src/lib/bm25.ts
@@ -26,14 +26,74 @@ const STOP_WORDS = new Set([
 // ---------------------------------------------------------------------------
 
 /**
- * Tokenize a string into lowercase words, filtering out stop words and
- * very short tokens.
+ * Matches runs of CJK characters (Han incl. Ext-A + compatibility, Japanese
+ * kana, Korean hangul). The Latin tokenizer drops these (they aren't a-z0-9),
+ * so they need a dedicated path or Chinese/Japanese/Korean text indexes nothing.
+ */
+const CJK_RUN_RE =
+  /[\u3400-\u9fff\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]+/g;
+
+/**
+ * Word segmenter for CJK, created once (construction is relatively costly).
+ * `Intl.Segmenter` with Chinese word granularity uses the runtime's ICU
+ * dictionary — the same dictionary-based approach as jieba, but with zero
+ * dependency/bundle cost. Verified available on both Node and Cloudflare
+ * workerd. `null` only on a runtime without Intl.Segmenter (then bigrams alone
+ * carry CJK recall).
+ */
+const cjkSegmenter: Intl.Segmenter | null =
+  typeof Intl !== "undefined" && typeof Intl.Segmenter === "function"
+    ? new Intl.Segmenter("zh", { granularity: "word" })
+    : null;
+
+/**
+ * Tokenize CJK runs into search terms. Emits two complementary token kinds:
+ *   1. **Word tokens** from `Intl.Segmenter` (jieba-class precision).
+ *   2. **Character bigrams** (and a unigram for a 1-char run) — a recall safety
+ *      net that matches substrings even when segmentation mis-splits an
+ *      out-of-vocabulary term (names, new jargon). Bigrams also make
+ *      single-character queries work against multi-char content.
+ */
+function tokenizeCJK(text: string): string[] {
+  const tokens: string[] = [];
+  const runs = text.match(CJK_RUN_RE);
+  if (!runs) return tokens;
+
+  for (const run of runs) {
+    if (cjkSegmenter) {
+      for (const seg of cjkSegmenter.segment(run)) {
+        if (seg.isWordLike) tokens.push(seg.segment);
+      }
+    }
+    const chars = [...run];
+    if (chars.length === 1) {
+      tokens.push(chars[0]);
+    } else {
+      for (let i = 0; i < chars.length - 1; i++) {
+        tokens.push(chars[i] + chars[i + 1]);
+      }
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Tokenize a string into search terms.
+ *
+ * - **Latin/numeric**: lowercase, split on non-alphanumerics, drop stop words
+ *   and 1-char tokens (unchanged behavior).
+ * - **CJK**: word segmentation + character bigrams (see {@link tokenizeCJK}),
+ *   so Chinese/Japanese/Korean text is indexed instead of silently dropped.
+ *
+ * The same tokenizer runs at index time and query time, so tokens align.
  */
 export function tokenize(text: string): string[] {
-  return text
-    .toLowerCase()
+  const lower = text.toLowerCase();
+  const latin = lower
     .split(/[^a-z0-9]+/)
     .filter((w) => w.length >= 2 && !STOP_WORDS.has(w));
+  const cjk = tokenizeCJK(lower);
+  return latin.concat(cjk);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

BM25's tokenizer split on `/[^a-z0-9]+/`, so **every CJK character was treated as a delimiter** — Chinese/Japanese/Korean text produced *zero* keyword tokens and was invisible to lexical search. Only the bge-m3 vector half saw Chinese; the BM25 half of the hybrid (BM25 + vector RRF) contributed nothing for Chinese queries.

This adds a CJK path to `tokenize()`:
- **Word segmentation via `Intl.Segmenter("zh", { granularity: "word" })`** — ICU dictionary-based, the *same class* as jieba, with **zero dependency / zero bundle cost**. Verified available on both Node and Cloudflare **workerd** (tested directly: `中文分词很重要知识库 → ["中文","分词","很","重要","知识","库"]`).
- **Character bigrams** (+ a unigram for single-char runs) as a **recall safety net** for out-of-vocabulary terms (names, new jargon) and single-character queries — coverage jieba alone lacks.

## Why not jieba / segmentit (PR #252's approach)

jieba/segmentit ship a multi-MB dictionary → risks the Worker bundle-size limit (~3 MB free / ~10 MB paid gzipped). `Intl.Segmenter` gives jieba-class word segmentation from the platform's ICU at no bundle cost. Net: **≥ jieba on recall (bigram net), ≈ jieba on precision (ICU words), and no bundle risk.** PR #252 was closed unmerged; nothing to revert.

## Notes

- No new dependency.
- BM25 corpus is tokenized from page content **at query time**, so this applies to existing pages with **no reindex**.
- Same tokenizer runs at index and query time, so tokens align.

## Testing

`pnpm lint` clean, `pnpm build:cloudflare` builds, **2077 tests pass** (added Chinese word/bigram/unigram/mixed-script + index==query alignment tests). Deployed and live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)