### PR TITLE
Preserve CJK characters in slugs

### DIFF
--- a/src/lib/__tests__/slugify.test.ts
+++ b/src/lib/__tests__/slugify.test.ts
@@ -47,4 +47,14 @@ describe("slugify", () => {
     expect(slugify("What is GPT-4?")).toBe("what-is-gpt-4");
     expect(slugify("C++ & Rust: A Comparison")).toBe("c-rust-a-comparison");
   });
+
+  it("preserves CJK characters (Chinese titles no longer collapse to empty)", () => {
+    expect(slugify("知识库")).toBe("知识库");
+    expect(slugify("大语言模型")).toBe("大语言模型");
+  });
+
+  it("keeps CJK while hyphenating around Latin/punctuation", () => {
+    expect(slugify("RAG 检索增强生成")).toBe("rag-检索增强生成");
+    expect(slugify("你好 World")).toBe("你好-world");
+  });
 });

--- a/src/lib/slugify.ts
+++ b/src/lib/slugify.ts
@@ -3,16 +3,31 @@
 // ---------------------------------------------------------------------------
 
 /**
- * Convert a title into a URL-safe slug (lowercase, hyphens, no special chars).
+ * Characters allowed in a slug: ASCII alphanumerics plus CJK (Han incl. Ext-A
+ * and compatibility ideographs, Japanese kana, Korean hangul). Everything else
+ * (punctuation, whitespace, symbols) acts as a separator.
  *
- * The `[^a-z0-9]+` regex replaces *runs* of non-alphanumeric characters with a
- * single hyphen, so inputs like `"hello--world"` or `"hello  world"` both
- * produce `"hello-world"` without needing a separate dedup step.
+ * CJK is preserved rather than stripped/transliterated so Chinese/Japanese/
+ * Korean titles produce meaningful slugs (e.g. "知识库" → "知识库"), the way
+ * Wikipedia does. Pinyin transliteration was rejected: it needs a dictionary
+ * that would bloat the Worker bundle. UTF-8 slugs are valid in URLs
+ * (percent-encoded), R2 keys, and file paths.
+ */
+const SLUG_SEPARATOR_RE =
+  /[^a-z0-9\u3400-\u9fff\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]+/g;
+
+/**
+ * Convert a title into a URL-safe slug: lowercase, runs of disallowed
+ * characters collapse to a single hyphen, leading/trailing hyphens trimmed.
+ * CJK characters are kept (see {@link SLUG_SEPARATOR_RE}).
+ *
+ * Runs of non-allowed characters collapse to a single hyphen, so `"hello--world"`
+ * and `"hello  world"` both produce `"hello-world"`.
  */
 export function slugify(title: string): string {
   return title
     .toLowerCase()
     .trim()
-    .replace(/[^a-z0-9]+/g, "-")
+    .replace(SLUG_SEPARATOR_RE, "-")
     .replace(/^-+|-+$/g, "");
 }


### PR DESCRIPTION
## Summary

`slugify()` stripped everything outside `[a-z0-9]`, so **Chinese titles collapsed to an empty slug** (`知识库` → `""`) and mixed titles lost the CJK part (`RAG 检索增强生成` → `rag`). This blocked Chinese *content* (every Chinese-titled page would get an empty/colliding slug) — separate from the search fix in #269.

Keep CJK (Han incl. Ext-A/compat, kana, hangul) alongside alphanumerics, Wikipedia-style:
- `知识库` → `知识库`
- `大语言模型` → `大语言模型`
- `RAG 检索增强生成` → `rag-检索增强生成`
- ASCII slugs unchanged; punctuation/whitespace still collapse to `-`.

Pinyin transliteration was rejected (dictionary → Worker bundle bloat). UTF-8 slugs are valid in URLs (percent-encoded), R2 keys, and file paths.

## Testing
`pnpm lint` clean, `pnpm build:cloudflare` builds, **2079 tests pass** (added CJK + mixed-script slug tests). Deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)