### PR TITLE
Allow CJK in validateSlug() safe-slug pattern

### DIFF
--- a/src/lib/__tests__/wiki.test.ts
+++ b/src/lib/__tests__/wiki.test.ts
@@ -301,6 +301,12 @@ describe("validateSlug", () => {
     expect(() => validateSlug("x1")).not.toThrow();
   });
 
+  it("accepts CJK slugs", () => {
+    expect(() => validateSlug("检索增强生成")).not.toThrow();
+    expect(() => validateSlug("知识库")).not.toThrow();
+    expect(() => validateSlug("你好-world")).not.toThrow();
+  });
+
   it("rejects empty string", () => {
     expect(() => validateSlug("")).toThrow(/non-empty/);
   });

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -54,8 +54,17 @@ export function rawRelPath(filename: string): string {
 // Slug validation — path traversal protection
 // ---------------------------------------------------------------------------
 
-/** Safe slug pattern: lowercase alphanumeric, may contain hyphens, cannot start/end with hyphen. */
-const SAFE_SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+/**
+ * Safe slug pattern: lowercase alphanumeric **or CJK** (Han incl. Ext-A and
+ * compatibility ideographs, Japanese kana, Korean hangul), may contain hyphens,
+ * cannot start/end with hyphen. CJK is allowed so Chinese/Japanese/Korean
+ * titles can have meaningful slugs (matches {@link slugify}); path-safety is
+ * enforced separately below (null bytes, separators, `..`).
+ */
+const SLUG_CHAR = "a-z0-9\\u3400-\\u9fff\\uf900-\\ufaff\\u3040-\\u30ff\\uac00-\\ud7af";
+const SAFE_SLUG_RE = new RegExp(
+  `^[${SLUG_CHAR}][${SLUG_CHAR}-]*[${SLUG_CHAR}]$|^[${SLUG_CHAR}]$`,
+);
 
 /**
  * Validate that a slug is safe to use as a filename inside the wiki/raw dirs.


### PR DESCRIPTION
Follow-up to #270. `slugify()` preserves CJK but `validateSlug()` still enforced ASCII, so ingesting a Chinese-titled page threw "does not match the safe pattern". Extends `SAFE_SLUG_RE` to allow CJK (Han + kana + hangul) alongside alphanumerics; path-traversal/separator/null-byte checks are separate and unchanged. 2080 tests pass; deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)