### PR TITLE
Decode percent-encoded slug params (CJK page URLs 404'd)

### DIFF
--- a/src/app/api/raw/[slug]/route.ts
+++ b/src/app/api/raw/[slug]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { decodeSlug } from "@/lib/slugify";
 import { readRawSource } from "@/lib/wiki";
 import { getErrorMessage } from "@/lib/errors";
 
@@ -15,7 +16,8 @@ export async function GET(
   { params }: { params: Promise<{ slug: string }> },
 ) {
   try {
-    const { slug } = await params;
+    const { slug: encodedSlug } = await params;
+    const slug = decodeSlug(encodedSlug);
     const source = await readRawSource(slug);
     return new NextResponse(source.content, {
       status: 200,

--- a/src/app/api/wiki/[slug]/discuss/[threadIndex]/comments/route.ts
+++ b/src/app/api/wiki/[slug]/discuss/[threadIndex]/comments/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { decodeSlug } from "@/lib/slugify";
 import { addComment } from "@/lib/talk";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
@@ -14,7 +15,8 @@ type RouteParams = { params: Promise<{ slug: string; threadIndex: string }> };
  */
 export async function POST(req: Request, { params }: RouteParams) {
   try {
-    const { slug, threadIndex } = await params;
+    const { slug: encodedSlug, threadIndex } = await params;
+    const slug = decodeSlug(encodedSlug);
     const idx = parseInt(threadIndex, 10);
     if (!Number.isFinite(idx) || idx < 0) {
       return NextResponse.json(

--- a/src/app/api/wiki/[slug]/discuss/[threadIndex]/route.ts
+++ b/src/app/api/wiki/[slug]/discuss/[threadIndex]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { decodeSlug } from "@/lib/slugify";
 import { getThread, resolveThread } from "@/lib/talk";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
@@ -13,7 +14,8 @@ type RouteParams = { params: Promise<{ slug: string; threadIndex: string }> };
  */
 export async function GET(_req: Request, { params }: RouteParams) {
   try {
-    const { slug, threadIndex } = await params;
+    const { slug: encodedSlug, threadIndex } = await params;
+    const slug = decodeSlug(encodedSlug);
     const idx = parseInt(threadIndex, 10);
     if (!Number.isFinite(idx) || idx < 0) {
       return NextResponse.json(
@@ -49,7 +51,8 @@ export async function GET(_req: Request, { params }: RouteParams) {
  */
 export async function PATCH(req: Request, { params }: RouteParams) {
   try {
-    const { slug, threadIndex } = await params;
+    const { slug: encodedSlug, threadIndex } = await params;
+    const slug = decodeSlug(encodedSlug);
     const idx = parseInt(threadIndex, 10);
     if (!Number.isFinite(idx) || idx < 0) {
       return NextResponse.json(

--- a/src/app/api/wiki/[slug]/discuss/route.ts
+++ b/src/app/api/wiki/[slug]/discuss/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { decodeSlug } from "@/lib/slugify";
 import { listThreads, createThread } from "@/lib/talk";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
@@ -13,7 +14,8 @@ type RouteParams = { params: Promise<{ slug: string }> };
  */
 export async function GET(_req: Request, { params }: RouteParams) {
   try {
-    const { slug } = await params;
+    const { slug: encodedSlug } = await params;
+    const slug = decodeSlug(encodedSlug);
     const threads = await listThreads(slug);
     return NextResponse.json({ threads });
   } catch (err) {
@@ -34,8 +36,8 @@ export async function GET(_req: Request, { params }: RouteParams) {
  */
 export async function POST(req: Request, { params }: RouteParams) {
   try {
-    const { slug } = await params;
-
+    const { slug: encodedSlug } = await params;
+    const slug = decodeSlug(encodedSlug);
     let body: unknown;
     try {
       body = await req.json();

--- a/src/app/api/wiki/[slug]/route.ts
+++ b/src/app/api/wiki/[slug]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { decodeSlug } from "@/lib/slugify";
 import {
   deleteWikiPage,
   readWikiPageWithFrontmatter,
@@ -15,7 +16,8 @@ export async function DELETE(
   { params }: { params: Promise<{ slug: string }> },
 ) {
   try {
-    const { slug } = await params;
+    const { slug: encodedSlug } = await params;
+    const slug = decodeSlug(encodedSlug);
     const result = await deleteWikiPage(slug);
     return NextResponse.json(result);
   } catch (err) {
@@ -50,8 +52,8 @@ export async function PUT(
   { params }: { params: Promise<{ slug: string }> },
 ) {
   try {
-    const { slug } = await params;
-
+    const { slug: encodedSlug } = await params;
+    const slug = decodeSlug(encodedSlug);
     let body: unknown;
     try {
       body = await req.json();
@@ -168,8 +170,8 @@ export async function PATCH(
   { params }: { params: Promise<{ slug: string }> },
 ) {
   try {
-    const { slug } = await params;
-
+    const { slug: encodedSlug } = await params;
+    const slug = decodeSlug(encodedSlug);
     let body: unknown;
     try {
       body = await req.json();

--- a/src/app/raw/[slug]/page.tsx
+++ b/src/app/raw/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { decodeSlug } from "@/lib/slugify";
 import { notFound } from "next/navigation";
 import { readRawSource } from "@/lib/wiki";
 
@@ -20,8 +21,8 @@ function formatSize(bytes: number): string {
 }
 
 export default async function RawSourcePage({ params }: RawSourcePageProps) {
-  const { slug } = await params;
-
+  const { slug: encodedSlug } = await params;
+  const slug = decodeSlug(encodedSlug);
   let source;
   try {
     source = await readRawSource(slug);

--- a/src/app/wiki/[slug]/edit/page.tsx
+++ b/src/app/wiki/[slug]/edit/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { decodeSlug } from "@/lib/slugify";
 import { readWikiPageWithFrontmatter } from "@/lib/wiki";
 import { WikiEditor } from "@/components/WikiEditor";
 
@@ -7,7 +8,8 @@ interface EditPageProps {
 }
 
 export default async function EditWikiPage({ params }: EditPageProps) {
-  const { slug } = await params;
+  const { slug: encodedSlug } = await params;
+  const slug = decodeSlug(encodedSlug);
   const page = await readWikiPageWithFrontmatter(slug);
 
   if (!page) {

--- a/src/app/wiki/[slug]/page.tsx
+++ b/src/app/wiki/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { decodeSlug } from "@/lib/slugify";
 import { readWikiPageWithFrontmatter, findBacklinks, type Frontmatter } from "@/lib/wiki";
 import { parseSources } from "@/lib/sources";
 import type { SourceEntry } from "@/lib/types";
@@ -424,7 +425,8 @@ function PageMetadata({ frontmatter, discussionStats }: { frontmatter: Frontmatt
 }
 
 export default async function WikiPageView({ params }: WikiPageProps) {
-  const { slug } = await params;
+  const { slug: encodedSlug } = await params;
+  const slug = decodeSlug(encodedSlug);
   const page = await readWikiPageWithFrontmatter(slug);
 
   if (!page) {

--- a/src/lib/__tests__/slugify.test.ts
+++ b/src/lib/__tests__/slugify.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { slugify } from "../slugify";
+import { slugify, decodeSlug } from "../slugify";
 
 describe("slugify", () => {
   it("converts a basic title to a slug", () => {
@@ -56,5 +56,20 @@ describe("slugify", () => {
   it("keeps CJK while hyphenating around Latin/punctuation", () => {
     expect(slugify("RAG 检索增强生成")).toBe("rag-检索增强生成");
     expect(slugify("你好 World")).toBe("你好-world");
+  });
+});
+
+describe("decodeSlug", () => {
+  it("decodes a percent-encoded CJK slug from a URL path", () => {
+    expect(decodeSlug("%E7%9F%A5%E8%AF%86%E5%BA%93")).toBe("知识库");
+  });
+
+  it("is a no-op for already-decoded slugs", () => {
+    expect(decodeSlug("知识库")).toBe("知识库");
+    expect(decodeSlug("llm-wiki")).toBe("llm-wiki");
+  });
+
+  it("falls back to the raw value on malformed encoding", () => {
+    expect(decodeSlug("%E0%A4%A")).toBe("%E0%A4%A");
   });
 });

--- a/src/lib/slugify.ts
+++ b/src/lib/slugify.ts
@@ -31,3 +31,21 @@ export function slugify(title: string): string {
     .replace(SLUG_SEPARATOR_RE, "-")
     .replace(/^-+|-+$/g, "");
 }
+
+/**
+ * Decode a slug taken from a URL path parameter.
+ *
+ * Browsers percent-encode non-ASCII (CJK) slugs in the address bar, and some
+ * runtimes (notably OpenNext on Cloudflare Workers) deliver the route param
+ * still percent-encoded — so `/wiki/检索增强生成` arrives as
+ * `%E6%A3%80%E7%B4%A2...` and a raw lookup 404s. Decoding is safe because a
+ * valid slug never contains a literal `%` (see `validateSlug`); on malformed
+ * input we fall back to the raw value rather than throw.
+ */
+export function decodeSlug(slug: string): string {
+  try {
+    return decodeURIComponent(slug);
+  } catch {
+    return slug;
+  }
+}


### PR DESCRIPTION
Browsers percent-encode CJK slugs in the address bar and OpenNext/Workers delivers the param still encoded, so `/wiki/检索增强生成` arrived as `%E6%A3%80...` and 404'd despite the page existing.

Adds `decodeSlug()` (safe `decodeURIComponent` + raw fallback) applied at every `[slug]` route boundary (wiki/raw page views, edit page, wiki/raw/discuss API routes). No-op for ASCII slugs. Verified: GET `/wiki/<encoded-CJK>` → 200 and renders. 2083 tests pass; deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)