### PR TITLE
Identity design doc + ingest dedup (shared canonical page)

### DIFF
--- a/DESIGN-identity.md
+++ b/DESIGN-identity.md
@@ -1,0 +1,181 @@
+# yopedia Identity, Auth & Contribution — Design
+
+Status: **proposed** (2026-06-02). Supersedes the "contribute via git" model in
+[yopedia-concept.md](yopedia-concept.md) for how writes actually happen.
+
+## Why this redesign
+
+The concept assumed contributions flow through **git** (attributed commits,
+review-before-merge, repo permissions as the auth layer). That doesn't fit the
+product:
+
+- Writing via git means committing **raw markdown**, which **bypasses the
+  ingest synthesis** (fetch → LLM synthesize → embed) — the core value of
+  yopedia.
+- The deployed app stores pages in **R2** and writes via the **HTTP API**;
+  `wiki/` is gitignored. There is no git write path.
+
+So contribution stays **API-based, through the ingest pipeline**. Git gave us
+**authentication, attribution, and review** for free; dropping it means we
+build those explicitly. This doc defines that.
+
+It also fixes two live problems: every page is currently authored by the
+hardcoded `system`, and the HTTP write endpoints are **unauthenticated**
+(anyone can ingest/edit/delete — see the write-token stopgap).
+
+## The three identities
+
+The central clarification: **yoyo is a shared service, not a per-user install.**
+
+| # | Identity | What it is | When |
+|---|----------|------------|------|
+| 1 | **User (principal)** | A human, authenticated via SSO. Owns the content they bring in; accountable party. | Now |
+| 2 | **yoyo — service agent** | One shared ingestion/knowledge engine + one base identity. Acts **on behalf of** users. Triggered in-app, by long-running tasks, or via `@yoyoevolve` on X. | Now (seeded once) |
+| 3 | **Per-user yoyo identity** | A *personalized* yoyo that knows a specific user (persona + memory). Loaded/provisioned via API when a user starts their yoyo chatbot. | Future |
+
+## Authentication
+
+- **Humans → Clerk (SSO/OIDC).** Login yields a *principal*. Clerk is chosen
+  because it also provides **billing/subscriptions**, which gates the paid
+  "private content" feature (below) without a second vendor. Verify Clerk's
+  middleware works under OpenNext/Workers early in the build.
+- **yoyo (service) → system credential.** Authenticates to the API as itself and
+  always stamps *on whose behalf* it is acting.
+- **Third-party agents (future) → scoped API keys / service tokens**, each owned
+  by a principal.
+- **Principals are individuals only** this version — no orgs/teams (maybe later).
+
+## Authorization & access
+
+- **Reads:** all **public** content is readable by anyone (the observer surface),
+  plus the requester's own **private** pages. The read/query/search path filters
+  out private pages not owned by the requester. Reuses the existing `?scope=…`
+  mechanism for owner-scoped views.
+- **Writes:** require an authenticated principal — either the user directly
+  (manual ingest) or **yoyo on behalf of an authenticated principal** (mediated).
+  There is no anonymous write path. This closes the open-write hole.
+
+## Visibility & monetization
+
+- **Default visibility is `public`.** Ingested content joins the shared commons
+  (attributed by `owner`), readable by everyone. This is the free tier.
+- **`private` is a paid feature.** A page may be `visibility: private` only if
+  its `owner` has an active paid plan (entitlement checked via Clerk billing).
+  Private pages are visible only to their owner.
+- **No data partitioning needed.** Public and private content share one store
+  (R2 + Vectorize); a `visibility` field plus an `owner` check on reads is the
+  only gate. Search/vector results must honor `visibility` + `owner`.
+- Frontmatter gains: `visibility: public | private` (default `public`).
+
+## Content ownership & attribution
+
+Two separate fields, decided model: **actors-only contributors + `owner`.**
+
+- **`owner`** — the principal the content belongs to / who's accountable.
+  **Always the user**, in every case.
+- **`authors` / `contributors[]`** — the **acting identities only** (who actually
+  did the work). The **user** when manual, **yoyo** when mediated. Grows as
+  actors edit over time. The user is **not** double-listed here when yoyo acts —
+  the `owner` field carries that link.
+- **`sources[].triggered_by`** — always traces back to the user (even when yoyo
+  authored).
+
+This replaces the hardcoded `authors: ["system"]`.
+
+| Case | `owner` | `authors`/actor | `triggered_by` |
+|------|---------|-----------------|----------------|
+| User ingests manually (logged in, pastes URL/text) | `alice` | `alice` | `alice` |
+| yoyo ingests for user (X mention, long task, "research X") | `alice` | `yoyo` | `alice` (or X handle) |
+
+Example frontmatter (yoyo-mediated):
+
+```yaml
+owner: alice
+visibility: public        # default; `private` requires owner on a paid plan
+authors: [yoyo]
+contributors: [yoyo]      # actors only; alice is the owner, not re-listed here
+sources:
+  - type: x-mention
+    url: https://x.com/<user>/status/<id>
+    triggered_by: alice
+```
+
+## Ingestion triggers (all yoyo-mediated except manual)
+
+1. **Manual (in-app)** — a logged-in user pastes a URL/text → ingested → page
+   `owner: user`, `authors: [user]`.
+2. **Long-running task** — queued ingest job run by yoyo → `owner: user`,
+   `authors: [yoyo]`.
+3. **X / Twitter** — user tweets `@yoyoevolve <url>` → yoyo ingests →
+   `triggered_by: <x-handle>`. The handle is mapped to a principal if the user
+   linked their X account during onboarding; otherwise a provisional identity.
+
+## Knowledge sharing / query
+
+"yoyo shares knowledge based on your content" = the query/answer surface
+**scoped to the user** (their content + shared/public pages). The shared yoyo
+answers from the user's scope. **No per-user yoyo identity is required for
+this** — it is pure scoping.
+
+## Seed agent
+
+Manual seeding goes away.
+
+- **Base yoyo identity** (personality + learnings as yopedia pages): seeded
+  **once at system bootstrap** (automatable in a deploy step). Not per-user, not
+  per-session.
+- **Per-user yoyo identities** (future): **auto-provisioned / loaded via API**
+  the first time a user starts their yoyo chatbot — via
+  `GET /api/agents/:id/context`, inheriting the base yoyo plus what it has
+  learned about that user. `seed_agent` becomes an **internal API primitive**,
+  not a human command.
+
+## Trust (future)
+
+Trust accrues to the **actor** (whoever did the work — user or yoyo), based on
+revert/contradiction rates and external citation, used to weight conflicting
+contributions. Because attribution is actor-based, a bad yoyo ingest dings
+yoyo's score while still resolving to the owner who triggered it.
+
+## Phasing
+
+**Phase 1 (now)**
+- Clerk SSO login → principals (individuals)
+- Content ownership + `visibility` field (default `public`) + scoped/visibility-
+  aware reads
+- All writes authenticated (manual by user, or yoyo on behalf of a principal) —
+  closes the unauthenticated-write hole
+- Real attribution: `owner` + actor `authors` (retire `system`)
+- X-handle linking for the `@yoyoevolve` loop
+- Base yoyo seeded once at bootstrap
+
+**Phase 1.5 — paid private content**
+- Clerk billing/subscription; `visibility: private` gated on an active plan;
+  read/search enforcement of private ownership
+
+**Phase 2 (later)**
+- Per-user yoyo identities, auto-provisioned via the agent-context API
+- Personalized yoyo chatbot (persona + per-user memory)
+- Trust scores across contributors
+- Orgs/teams as principals
+
+## Reuse (not greenfield)
+
+- **Agent registry** (`AgentProfile`, `agents/<id>.json`, seed/list/get) →
+  the identity store; add `owner` + credentials.
+- **Scoped search** (`?scope=agent:yoyo`) → per-identity views.
+- **`triggeredBy`** on ingest → set to the principal instead of going unused.
+- **`isReadOnly()`** → evolve into the write-auth guard.
+
+## Decisions
+
+- **SSO provider:** ✅ **Clerk** (also provides billing for paid private content).
+- **Default visibility:** ✅ **public by default**; `private` is a paid feature.
+  → No per-owner data partitioning; one store + `visibility`/`owner` filtering.
+- **Org/team principals:** ✅ **individuals only** this version (orgs later).
+
+### Still to confirm during build
+- Clerk middleware compatibility under OpenNext/Workers (smoke-test early).
+- Entitlement check shape for `private` (Clerk billing plan → allow-private).
+- Read enforcement in **Vectorize/search** so private pages never leak into
+  another user's results.

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -23,7 +23,9 @@ import {
 import { findRelatedPages, updateRelatedPages } from "../search";
 import { parseSources } from "../sources";
 import { MAX_LLM_INPUT_CHARS } from "../constants";
-import { listWikiPages, readWikiPage, writeWikiPage } from "../wiki";
+import { listWikiPages, readWikiPage, writeWikiPage, readWikiPageWithFrontmatter } from "../wiki";
+import { resetSourceIndex } from "../source-index";
+import { resetAliasIndex } from "../alias-index";
 import type { IndexEntry } from "../types";
 
 // Mock the LLM module so ingest never calls the real API
@@ -2260,5 +2262,62 @@ describe("ingest ledger", () => {
 
     const entries = await readLedger();
     expect(entries).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ingest dedup (shared canonical page) — token saving
+// ---------------------------------------------------------------------------
+
+describe("ingest dedup", () => {
+  beforeEach(() => {
+    // In-memory indexes are module singletons — reset so each test starts clean
+    // (they rebuild from the fresh temp-dir frontmatter on demand).
+    resetSourceIndex();
+    resetAliasIndex();
+    mockedHasLLMKey.mockReturnValue(true);
+    mockedCallLLM.mockResolvedValue("# Page\n\n## Summary\n\nMocked synthesis.");
+  });
+
+  it("dedups identical content across different titles — no second LLM call", async () => {
+    await ingest("Doc A", "Identical body content for dedup test.");
+    expect(mockedCallLLM).toHaveBeenCalledTimes(1);
+
+    mockedCallLLM.mockClear();
+    // Same content, different title → should attach to the existing canonical
+    // page (by content hash) instead of synthesizing a new one.
+    const result = await ingest("Doc B", "Identical body content for dedup test.");
+
+    expect(result.deduped).toBe(true);
+    expect(result.primarySlug).toBe("doc-a");
+    expect(mockedCallLLM).not.toHaveBeenCalled();
+    expect(await listWikiPages()).toHaveLength(1); // one canonical page, not two
+  });
+
+  it("does NOT dedup different content — both pages created, LLM called twice", async () => {
+    await ingest("Page One", "First distinct content here.");
+    mockedCallLLM.mockClear();
+    const result = await ingest("Page Two", "Completely different content here.");
+
+    expect(result.deduped).toBeFalsy();
+    // Synthesis ran (not deduped). Exact count varies because a cross-ref LLM
+    // call also fires once another page exists — so just assert it was called.
+    expect(mockedCallLLM).toHaveBeenCalled();
+    expect(await listWikiPages()).toHaveLength(2);
+  });
+
+  it("attaches the new triggerer as a contributor on a dedup hit", async () => {
+    await ingest("Trigger Doc", "Body for trigger attribution.", {
+      triggeredBy: "alice",
+    });
+    const result = await ingest("Trigger Doc", "Body for trigger attribution.", {
+      triggeredBy: "bob",
+    });
+
+    expect(result.deduped).toBe(true);
+    const page = await readWikiPageWithFrontmatter("trigger-doc");
+    expect(page).not.toBeNull();
+    // The second triggerer is recorded as a contributor (basis for "Mine").
+    expect(page!.frontmatter.contributors).toContain("bob");
   });
 });

--- a/src/lib/__tests__/integration.test.ts
+++ b/src/lib/__tests__/integration.test.ts
@@ -11,11 +11,15 @@ vi.mock("../llm", () => ({
   callLLM: vi.fn(async () => "mocked"),
 }));
 
-vi.mock("../embeddings", () => ({
-  searchByVector: vi.fn(async () => []),
-  upsertEmbedding: vi.fn(async () => {}),
-  removeEmbedding: vi.fn(async () => {}),
-}));
+vi.mock("../embeddings", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../embeddings")>();
+  return {
+    ...actual, // keep the real contentHash (used by ingest dedup)
+    searchByVector: vi.fn(async () => []),
+    upsertEmbedding: vi.fn(async () => {}),
+    removeEmbedding: vi.fn(async () => {}),
+  };
+});
 
 import { hasLLMKey, callLLM } from "../llm";
 import { ingest } from "../ingest";

--- a/src/lib/__tests__/x-mention-integration.test.ts
+++ b/src/lib/__tests__/x-mention-integration.test.ts
@@ -11,11 +11,15 @@ vi.mock("../llm", () => ({
   callLLM: vi.fn(async () => "mocked"),
 }));
 
-vi.mock("../embeddings", () => ({
-  searchByVector: vi.fn(async () => []),
-  upsertEmbedding: vi.fn(async () => {}),
-  removeEmbedding: vi.fn(async () => {}),
-}));
+vi.mock("../embeddings", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../embeddings")>();
+  return {
+    ...actual, // keep the real contentHash (used by ingest dedup)
+    searchByVector: vi.fn(async () => []),
+    upsertEmbedding: vi.fn(async () => {}),
+    removeEmbedding: vi.fn(async () => {}),
+  };
+});
 
 import { hasLLMKey, callLLM } from "../llm";
 import { ingestXMention } from "../ingest";

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -23,6 +23,12 @@ import { slugify } from "./slugify";
 import { loadPageConventions } from "./schema";
 import { getRawDir } from "./config";
 import { resolveAlias } from "./alias-index";
+import {
+  resolveSourceUrl,
+  resolveContentHash,
+  updateSourceIndexForPage,
+} from "./source-index";
+import { contentHash } from "./embeddings";
 import { getStorage } from "./storage";
 import { logger } from "./logger";
 
@@ -114,6 +120,21 @@ export async function ingestUrl(
   url: string,
   options?: IngestOptions,
 ): Promise<IngestResult> {
+  // Dedup: if this URL is already a canonical page, attach the triggerer and
+  // skip the fetch + LLM + embedding entirely. Not for preview / commit-from-
+  // preview (those are explicit content workflows).
+  if (!options?.preview && !options?.generatedContent) {
+    const dupSlug = await resolveSourceUrl(url);
+    if (dupSlug) {
+      const result = await attachIngestTrigger(dupSlug, {
+        url,
+        type: options?.sourceType ?? "url",
+        triggeredBy: options?.triggeredBy,
+      });
+      if (result) return result;
+    }
+  }
+
   const { title, content: rawContent } = await fetchUrlContent(url);
   // Download images referenced in the fetched content to local storage
   const slug = slugify(title);
@@ -424,6 +445,96 @@ export interface IngestOptions {
 }
 
 /**
+ * Attach a new ingest trigger to an existing canonical page **without
+ * re-synthesizing** — the token-saving dedup path. Used when a source (same URL
+ * or identical content) was already ingested: append a provenance entry + the
+ * triggerer, bump `updated`, increment `source_count`, but skip the LLM and (the
+ * body is unchanged) any new embedding. Returns `null` if the page is missing
+ * (stale index) so the caller can fall through to a normal ingest.
+ */
+async function attachIngestTrigger(
+  slug: string,
+  source: {
+    url: string;
+    type: "url" | "text" | "x-mention" | "wiki-ref";
+    triggeredBy?: string;
+  },
+): Promise<IngestResult | null> {
+  const existing = await readWikiPageWithFrontmatter(slug);
+  if (!existing) return null; // index drifted — let the caller ingest normally
+
+  const frontmatter: Frontmatter = { ...existing.frontmatter };
+  frontmatter.updated = new Date().toISOString().slice(0, 10);
+
+  // Merge the new provenance entry into sources[] (update fetched/triggered_by
+  // if the same source already has an entry, else append).
+  const entry = buildSourceEntry(source.url, source.type, source.triggeredBy);
+  const existingSourcesRaw = existing.frontmatter.sources;
+  const sources = parseSources(
+    typeof existingSourcesRaw === "string"
+      ? existingSourcesRaw
+      : Array.isArray(existingSourcesRaw)
+        ? existingSourcesRaw
+        : undefined,
+  );
+  const matchIdx = sources.findIndex(
+    (s) => s.url === entry.url && s.type === entry.type,
+  );
+  if (matchIdx >= 0) {
+    sources[matchIdx] = {
+      ...sources[matchIdx],
+      fetched: entry.fetched,
+      triggered_by: entry.triggered_by,
+    };
+  } else {
+    sources.push(entry);
+  }
+  frontmatter.sources = serializeSources(sources);
+  frontmatter.source_count = String(sources.length);
+
+  // Record the triggerer as a contributor (deduped) — drives the "Mine" lens.
+  const triggeredBy = source.triggeredBy?.trim();
+  if (triggeredBy) {
+    const contribs = Array.isArray(existing.frontmatter.contributors)
+      ? (existing.frontmatter.contributors as string[])
+      : [];
+    if (!contribs.includes(triggeredBy)) {
+      frontmatter.contributors = [...contribs, triggeredBy];
+    }
+  }
+
+  const mergedContent = serializeFrontmatter(frontmatter, existing.body);
+  await writeWikiPageWithSideEffects({
+    slug,
+    title: existing.title,
+    content: mergedContent,
+    summary: extractSummary(existing.body.replace(/^#\s+.+$/m, "").trim()),
+    logOp: "ingest",
+    crossRefSource: null, // skip the cross-ref LLM — pure dedup attach
+    author: triggeredBy,
+    logDetails: () => `dedup: attached trigger to existing page "${slug}"`,
+  });
+
+  const url =
+    typeof frontmatter.source_url === "string" ? frontmatter.source_url : undefined;
+  const hash =
+    typeof frontmatter.content_hash === "string"
+      ? frontmatter.content_hash
+      : undefined;
+  updateSourceIndexForPage(slug, url, hash);
+
+  return {
+    rawPath: "",
+    primarySlug: slug,
+    relatedUpdated: [],
+    wikiPages: [slug],
+    indexUpdated: true,
+    deduped: true,
+    ...(url ? { sourceUrl: url } : {}),
+  };
+}
+
+/**
  * Ingest a source document into the wiki.
  *
  * Supports a two-phase preview workflow:
@@ -461,6 +572,22 @@ export async function ingest(
 
   const isPreview = options?.preview === true;
   const preGeneratedContent = options?.generatedContent;
+
+  // Dedup by content: if identical content was already ingested (any slug),
+  // attach the triggerer and skip the LLM + embedding. Not for preview /
+  // commit-from-preview.
+  const hash = contentHash(content);
+  if (!isPreview && !preGeneratedContent) {
+    const dupSlug = await resolveContentHash(hash);
+    if (dupSlug) {
+      const result = await attachIngestTrigger(dupSlug, {
+        url: options?.sourceUrl ?? "text-paste",
+        type: options?.sourceType ?? (options?.sourceUrl ? "url" : "text"),
+        triggeredBy: options?.triggeredBy,
+      });
+      if (result) return result;
+    }
+  }
 
   // 1. Generate wiki page content (or use pre-generated from preview)
   let wikiContent: string;
@@ -544,6 +671,7 @@ export async function ingest(
     disputed: false,
     supersedes: "",
     aliases: [],
+    content_hash: hash,
   };
 
   // Persist the original source URL when provided (URL-based ingest).
@@ -673,7 +801,13 @@ export async function ingest(
 
   // 6. Alias index is updated automatically by the lifecycle pipeline
   //    (writeWikiPageWithSideEffects → runPageLifecycleOp) — no caller-side
-  //    call needed.
+  //    call needed. The source index (URL/content-hash → slug) is caller-owned,
+  //    so refresh it here for future dedup hits.
+  updateSourceIndexForPage(
+    slug,
+    typeof frontmatter.source_url === "string" ? frontmatter.source_url : undefined,
+    hash,
+  );
 
   const result: IngestResult = {
     rawPath,

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -18,6 +18,7 @@ import { withFileLock } from "./lock";
 import { escapeRegex } from "./links";
 import { getErrorMessage } from "./errors";
 import { removeAliasForPage, updateAliasIndexForPage } from "./alias-index";
+import { removeSourceForPage } from "./source-index";
 import { parseFrontmatter } from "./frontmatter";
 import type { LogOperation } from "./wiki";
 import { logger } from "./logger";
@@ -235,6 +236,8 @@ async function runPageLifecycleOp(
     // 2e. Invalidate alias index entries for the deleted page so that
     //     resolveAlias(deletedTitle) no longer ghost-resolves to this slug.
     removeAliasForPage(slug);
+    // Also drop source-index (URL/content-hash) entries for the deleted page.
+    removeSourceForPage(slug);
   } else {
     // 2e. Update alias index for written page so resolveAlias() finds it
     //     immediately — no server restart needed. Parse the frontmatter to

--- a/src/lib/source-index.ts
+++ b/src/lib/source-index.ts
@@ -1,0 +1,131 @@
+// ---------------------------------------------------------------------------
+// Source Index — maps a source (URL or content hash) to its canonical slug
+// ---------------------------------------------------------------------------
+//
+// Deduplication at ingest time. Before fetching + synthesizing a source, the
+// ingest pipeline checks whether the same source has already been ingested:
+//   - `source_url` frontmatter → canonical slug (URL ingests)
+//   - `content_hash` frontmatter → canonical slug (text/identical-content ingests)
+//
+// On a hit, the ingest pipeline attaches the new triggerer to the existing
+// canonical page instead of re-running the LLM + embedding — saving tokens and
+// keeping the commons to one page per source. Mirrors the in-memory, rebuilt-
+// from-frontmatter approach of `alias-index.ts`.
+
+import { listWikiPages, readWikiPageWithFrontmatter } from "./wiki";
+
+// ---------------------------------------------------------------------------
+// Types + singleton
+// ---------------------------------------------------------------------------
+
+export interface SourceIndex {
+  /** Maps `source_url` → canonical slug */
+  byUrl: Map<string, string>;
+  /** Maps `content_hash` → canonical slug */
+  byHash: Map<string, string>;
+}
+
+let cachedIndex: SourceIndex | null = null;
+
+/** Reset the cached source index (for testing or after bulk writes). */
+export function resetSourceIndex(): void {
+  cachedIndex = null;
+}
+
+/** Normalize a URL for stable matching (trim; drop a single trailing slash). */
+function normalizeUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+// ---------------------------------------------------------------------------
+// Build / rebuild
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the source index by scanning all wiki pages' frontmatter for
+ * `source_url` and `content_hash`. Cheap (one listing + frontmatter parse per
+ * page) and small, like the alias index.
+ */
+export async function buildSourceIndex(): Promise<SourceIndex> {
+  const index: SourceIndex = { byUrl: new Map(), byHash: new Map() };
+  const pages = await listWikiPages();
+
+  for (const entry of pages) {
+    if (entry.slug === "index" || entry.slug === "log") continue;
+    const page = await readWikiPageWithFrontmatter(entry.slug);
+    if (!page) continue;
+
+    const url = page.frontmatter.source_url;
+    if (typeof url === "string" && url.trim() !== "" && url !== "text-paste") {
+      index.byUrl.set(normalizeUrl(url), entry.slug);
+    }
+    const hash = page.frontmatter.content_hash;
+    if (typeof hash === "string" && hash.trim() !== "") {
+      index.byHash.set(hash, entry.slug);
+    }
+  }
+
+  cachedIndex = index;
+  return index;
+}
+
+/** Get the source index, building it if not cached. */
+export async function getSourceIndex(): Promise<SourceIndex> {
+  if (cachedIndex) return cachedIndex;
+  return buildSourceIndex();
+}
+
+// ---------------------------------------------------------------------------
+// Lookup
+// ---------------------------------------------------------------------------
+
+/** Resolve a source URL to an existing canonical slug, or null. */
+export async function resolveSourceUrl(url: string): Promise<string | null> {
+  if (!url || url.trim() === "" || url === "text-paste") return null;
+  const index = await getSourceIndex();
+  return index.byUrl.get(normalizeUrl(url)) ?? null;
+}
+
+/** Resolve a content hash to an existing canonical slug, or null. */
+export async function resolveContentHash(hash: string): Promise<string | null> {
+  if (!hash || hash.trim() === "") return null;
+  const index = await getSourceIndex();
+  return index.byHash.get(hash) ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Incremental update / removal
+// ---------------------------------------------------------------------------
+
+/**
+ * Update the cached index after a page write. No-op if the index isn't cached
+ * yet (it'll be picked up on the next build).
+ */
+export function updateSourceIndexForPage(
+  slug: string,
+  sourceUrl: string | undefined,
+  contentHash: string | undefined,
+): void {
+  if (!cachedIndex) return;
+  if (
+    typeof sourceUrl === "string" &&
+    sourceUrl.trim() !== "" &&
+    sourceUrl !== "text-paste"
+  ) {
+    cachedIndex.byUrl.set(normalizeUrl(sourceUrl), slug);
+  }
+  if (typeof contentHash === "string" && contentHash.trim() !== "") {
+    cachedIndex.byHash.set(contentHash, slug);
+  }
+}
+
+/** Remove all source-index entries pointing to a slug (called on delete). */
+export function removeSourceForPage(slug: string): void {
+  if (!cachedIndex) return;
+  for (const [key, value] of cachedIndex.byUrl) {
+    if (value === slug) cachedIndex.byUrl.delete(key);
+  }
+  for (const [key, value] of cachedIndex.byHash) {
+    if (value === slug) cachedIndex.byHash.delete(key);
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,6 +44,13 @@ export interface IngestResult {
   previewContent?: string;
   /** The original source URL, if the ingest was URL-based. */
   sourceUrl?: string;
+  /**
+   * True when this ingest matched an existing canonical page (same source URL
+   * or identical content) and was attached to it instead of re-synthesizing —
+   * no LLM/embedding tokens spent. The UI can say "added to your collection"
+   * rather than "created".
+   */
+  deduped?: boolean;
 }
 
 /** Result from a query against the wiki. */


### PR DESCRIPTION
First landed slice of the identity/auth work ([DESIGN-identity.md](DESIGN-identity.md)).

## 1. Design doc
`DESIGN-identity.md` — the approved reference: three identities (user / shared-yoyo / per-user-yoyo), Clerk Twitter-SSO, public-by-default with a personal **Mine/All** lens, shared-canonical ingest dedup, owner/actor attribution, phasing.

## 2. Ingest dedup (shared canonical page) — token saving
When a source (same URL, or identical content) was already ingested, attach the new triggerer to the existing canonical page instead of re-synthesizing — **skipping the LLM and the embedding**. Saves tokens *and* storage; keeps the commons to one page per source.

- New `src/lib/source-index.ts`: in-memory `source_url→slug` + `content_hash→slug` index, rebuilt from frontmatter (mirrors `alias-index`).
- `ingest.ts`: `content_hash` added to frontmatter; dedup short-circuit in `ingestUrl` (before fetch) and `ingest` (before synthesis) via `attachIngestTrigger()` — a no-LLM frontmatter update (`crossRefSource: null`) that appends a `sources[]` entry and records the triggerer as a **contributor** (the reliable basis for the upcoming "Mine" lens; `sources[].triggered_by` collapses for text-paste).
- `IngestResult.deduped` flag so the UI can say "added to your collection".
- `lifecycle.ts`: drop source-index entries on delete.

## Verification
`pnpm lint` clean, `pnpm build:cloudflare` builds, **2086 tests pass** (3 new dedup tests). **Live-verified**: 1st ingest of a fresh URL synthesized (22.6s); 2nd ingest of the same URL → `deduped: true`, same slug, 7.7s, **no DeepSeek synthesis**.

## Not in this PR (next, blocked on Clerk keys)
Clerk Twitter SSO + `requireUser` write guard (closes the unauth-write hole) + owner/visibility attribution + the Mine/All lens. Those follow once Clerk credentials are provisioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)