### PR TITLE
Add Clerk auth (Twitter SSO) + close the unauthenticated-write hole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ timelapse.mp4
 generate_video.py
 .yoyo/scripts/__pycache__/
 journal-site/dist/
+.dev.vars

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@ai-sdk/anthropic": "^3.0.66",
     "@ai-sdk/google": "^3.0.60",
     "@ai-sdk/openai": "^3.0.50",
+    "@clerk/nextjs": "^7.4.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@mozilla/readability": "^0.6.0",
     "@tailwindcss/typography": "^0.5.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.50
         version: 3.0.50(zod@4.4.2)
+      '@clerk/nextjs':
+        specifier: ^7.4.2
+        version: 7.4.2(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.2)
@@ -390,6 +393,37 @@ packages:
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
+
+  '@clerk/backend@3.4.14':
+    resolution: {integrity: sha512-0iaMT7k4wDk31QVC3HMaoeVFttblwsCECTHKNQpbRzIyD8j2gHdKEw/FNjffoyqyBqPw869IQlk1YokUlwVAqQ==}
+    engines: {node: '>=20.9.0'}
+
+  '@clerk/nextjs@7.4.2':
+    resolution: {integrity: sha512-DpqljtLkTtMNsi03XRWYaWYyt0tb4S07HjS9fSmUtN//CKNqM7QAVMZzpgMAZz5yb2QhIVIVF1Uir2c7f72+MA==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      next: ^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/react@6.7.2':
+    resolution: {integrity: sha512-tgRWWTfW+ejXj6WiZqx7iMbtvh45h0445uEvbSNVCyJBEOaBlCF0/ZfAfXlWAQNbRZ+bPIphEfNUmatadZgGOQ==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/shared@4.14.0':
+    resolution: {integrity: sha512-StZCFJ2rg0ITE3fYjIN9CKuKq8ZACW6l2+5qGCFPPYd4hZphA+VDselmh/lHPsF1ex/WRVUSHvquykAHR8cQbQ==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -1572,6 +1606,9 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1670,6 +1707,9 @@ packages:
     resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
+  '@tanstack/query-core@5.100.14':
+    resolution: {integrity: sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==}
 
   '@tsconfig/node18@1.0.3':
     resolution: {integrity: sha512-RbwvSJQsuN9TB04AQbGULYfOGE/RnSFk/FLQ5b0NmDf5Kx2q/lABZbHQPKCO1vZ6Fiwkplu+yb9pGdLy1iGseQ==}
@@ -2618,6 +2658,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -2749,6 +2792,9 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   glob@12.0.0:
     resolution: {integrity: sha512-5Qcll1z7IKgHr5g485ePDdHcNQY0k2dtv/bjYy0iuyGxQw2qSOiiXUXJ+AYQpg3HNoUMHqAruX478Jeev7UULw==}
@@ -3024,6 +3070,10 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3749,6 +3799,9 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -3821,6 +3874,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -4925,6 +4981,44 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
+  '@clerk/backend@3.4.14(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@clerk/shared': 4.14.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/nextjs@7.4.2(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@clerk/backend': 3.4.14(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@clerk/react': 6.7.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@clerk/shared': 4.14.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.5.18(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      server-only: 0.0.1
+      tslib: 2.8.1
+
+  '@clerk/react@6.7.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@clerk/shared': 4.14.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tslib: 2.8.1
+
+  '@clerk/shared@4.14.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.100.14
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.7
+      std-env: 3.10.0
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
   '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260515.1)':
@@ -5835,6 +5929,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -5914,6 +6010,8 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.2
+
+  '@tanstack/query-core@5.100.14': {}
 
   '@tsconfig/node18@1.0.3': {}
 
@@ -7106,6 +7204,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fast-xml-builder@1.2.0:
@@ -7250,6 +7350,8 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob-to-regexp@0.4.1: {}
 
   glob@12.0.0:
     dependencies:
@@ -7535,6 +7637,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@6.2.3: {}
+
+  js-cookie@3.0.7: {}
 
   js-tokens@4.0.0: {}
 
@@ -8509,6 +8613,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  server-only@0.0.1: {}
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -8618,6 +8724,11 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ClerkProvider } from "@clerk/nextjs";
 import { NavHeader } from "@/components/NavHeader";
 import { ClientProviders } from "@/components/ClientProviders";
 import "./globals.css";
@@ -35,13 +36,15 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body className="min-h-screen antialiased">
-        <ClientProviders>
-          <a href="#main-content" className="skip-nav">
-            Skip to main content
-          </a>
-          <NavHeader />
-          <main id="main-content">{children}</main>
-        </ClientProviders>
+        <ClerkProvider>
+          <ClientProviders>
+            <a href="#main-content" className="skip-nav">
+              Skip to main content
+            </a>
+            <NavHeader />
+            <main id="main-content">{children}</main>
+          </ClientProviders>
+        </ClerkProvider>
       </body>
     </html>
   );

--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState, useEffect } from "react";
+import { Show, SignInButton, SignUpButton, UserButton } from "@clerk/nextjs";
 import { GlobalSearch } from "./GlobalSearch";
 import { ThemeToggle } from "./ThemeToggle";
 
@@ -130,6 +131,26 @@ export function NavHeader() {
           <li>
             <ThemeToggle />
           </li>
+
+          {/* Auth controls */}
+          <li className="mx-1 h-4 w-px bg-foreground/10" aria-hidden="true" />
+          <li className="flex items-center gap-2">
+            <Show when="signed-out">
+              <SignInButton mode="modal">
+                <button className="rounded-md px-3 py-1.5 text-sm text-foreground/60 hover:text-foreground hover:bg-foreground/5 transition-colors">
+                  Sign in
+                </button>
+              </SignInButton>
+              <SignUpButton mode="modal">
+                <button className="rounded-md bg-foreground px-3 py-1.5 text-sm font-medium text-background hover:opacity-90 transition-opacity">
+                  Sign up
+                </button>
+              </SignUpButton>
+            </Show>
+            <Show when="signed-in">
+              <UserButton />
+            </Show>
+          </li>
         </ul>
 
         {/* Hamburger button (mobile only) */}
@@ -216,6 +237,20 @@ export function NavHeader() {
           <div className="px-6 py-2 flex items-center gap-2 text-sm text-foreground/40">
             <ThemeToggle />
             <span>Theme</span>
+          </div>
+          <div className="mx-4 my-1 border-t border-foreground/10" />
+          <div className="px-6 py-2 flex items-center gap-3 text-sm">
+            <Show when="signed-out">
+              <SignInButton mode="modal">
+                <button className="text-foreground/60 hover:text-foreground">Sign in</button>
+              </SignInButton>
+              <SignUpButton mode="modal">
+                <button className="font-medium text-foreground">Sign up</button>
+              </SignUpButton>
+            </Show>
+            <Show when="signed-in">
+              <UserButton />
+            </Show>
           </div>
         </div>
       )}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------
+// Auth — resolve the current Clerk principal for attribution
+// ---------------------------------------------------------------------------
+//
+// The unauthenticated-write hole is closed in middleware (any /api write needs
+// a session). This module resolves *who* the signed-in user is, for write
+// attribution (`owner`/`authors`) — the route never trusts a client-supplied
+// author. SSO is Twitter/X, so the principal handle is the Twitter handle.
+
+import { auth, currentUser } from "@clerk/nextjs/server";
+
+export interface Principal {
+  /** Stable Clerk user id (never changes). */
+  id: string;
+  /** Twitter/X handle (falls back to Clerk username, then the user id). */
+  handle: string;
+}
+
+/** Minimal shape of a Clerk external account we read the handle from. */
+interface ExternalAccountLike {
+  provider?: string;
+  username?: string | null;
+}
+
+/** Resolve the Twitter/X handle from a Clerk user, or null. */
+function resolveHandle(user: {
+  username?: string | null;
+  externalAccounts?: ExternalAccountLike[];
+} | null): string | null {
+  if (!user) return null;
+  if (user.username) return user.username;
+  const x = user.externalAccounts?.find(
+    (a) => typeof a.provider === "string" && /(^|_)(x|twitter)$/i.test(a.provider),
+  );
+  return x?.username ?? null;
+}
+
+/**
+ * Resolve the current authenticated principal, or `null` when signed out.
+ * Safe to call in route handlers and server components (the request context is
+ * populated by `clerkMiddleware`).
+ */
+export async function getPrincipal(): Promise<Principal | null> {
+  const { userId } = await auth();
+  if (!userId) return null;
+  const user = await currentUser();
+  return { id: userId, handle: resolveHandle(user) ?? userId };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,34 @@
+import { clerkMiddleware } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+// HTTP methods that mutate state.
+const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+// Closes the unauthenticated-write hole at a single enforcement point:
+// any mutating request to /api/** requires a signed-in user. Reads (GET/HEAD)
+// stay public — yopedia is a public observer surface (see DESIGN-identity.md).
+// Attribution (which user) is read per-route from `getPrincipal()`.
+//
+// The MCP server is stdio-only and not exposed over HTTP, so it is unaffected.
+export default clerkMiddleware(async (auth, req) => {
+  const { pathname } = req.nextUrl;
+  if (WRITE_METHODS.has(req.method) && pathname.startsWith("/api/")) {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json(
+        { error: "Sign in required to write to yopedia." },
+        { status: 401 },
+      );
+    }
+  }
+});
+
+export const config = {
+  matcher: [
+    // Skip Next.js internals and static assets, run on everything else.
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    // Always run for API routes and Clerk's auto-proxy path.
+    "/(api|trpc)(.*)",
+    "/__clerk/(.*)",
+  ],
+};


### PR DESCRIPTION
Closes the headline security gap from [DESIGN-identity.md](DESIGN-identity.md): the deployed HTTP write endpoints were fully unauthenticated (anyone could ingest — spending DeepSeek/Workers-AI tokens — edit, or delete).

## What
- **Clerk (`@clerk/nextjs` v7, Twitter/X SSO)** wired: `ClerkProvider` in the layout, sign-in/up + `UserButton` in the nav (`<Show when>`), and `clerkMiddleware`.
- **Write hole closed in middleware** — one enforcement point: any mutating request (POST/PUT/PATCH/DELETE) to `/api/**` requires a signed-in user → **401** otherwise. Reads (GET/HEAD) stay public. The MCP server is stdio-only (no HTTP exposure) and unaffected.
- `src/lib/auth.ts` `getPrincipal()` → `{ id, twitter handle }` for write attribution in the next step (routes never trust a client-supplied author).

## Verification
- **Step-0 spike passed**: `clerkMiddleware` + `auth()` run on **workerd** via `wrangler dev`.
- **Live on production** (deployed): reads `/`, `/api/wiki`, `/wiki/llm-wiki` → 200; unauth `POST /api/ingest`, `DELETE`, `PATCH /api/wiki/[slug]` → **401**.
- `pnpm lint` clean, `pnpm build:cloudflare` builds, **2086 tests pass**.

## Next (separate PRs)
Step 3 — owner/actor attribution via `getPrincipal()` (retire `authors:["system"]`). Step 5 — Mine/All personal lens. Service tokens for yoyo/@yoyoevolve + scheduled tasks are a later phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)