### PR TITLE
Add Mine | All personal lens + /u/[handle]

### DIFF
--- a/src/app/u/[handle]/page.tsx
+++ b/src/app/u/[handle]/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { listWikiPages } from "@/lib/wiki";
+import { slugsForOwner } from "@/lib/search";
+import { getDiscussionStatsForSlugs } from "@/lib/talk";
+import { decodeSlug } from "@/lib/slugify";
+import { WikiIndexClient } from "@/components/WikiIndexClient";
+
+// Public profile: pages a given handle owns or has contributed to. Visible to
+// anyone (guests included) — yopedia is a public observer surface.
+export default async function UserPage({
+  params,
+}: {
+  params: Promise<{ handle: string }>;
+}) {
+  const { handle: encoded } = await params;
+  const handle = decodeSlug(encoded);
+
+  const mine = new Set(await slugsForOwner(handle));
+  const pages = (await listWikiPages()).filter((p) => mine.has(p.slug));
+
+  const statsMap = await getDiscussionStatsForSlugs(pages.map((p) => p.slug));
+  const discussionStats: Record<string, { total: number; open: number }> = {};
+  for (const [slug, stats] of statsMap) discussionStats[slug] = stats;
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <div className="mb-6">
+        <Link href="/wiki?scope=all" className="text-sm text-foreground/50 hover:text-foreground">
+          ← All content
+        </Link>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight">@{handle}</h1>
+        <p className="mt-1 text-foreground/60">
+          Public pages owned or contributed by {handle}.
+        </p>
+      </div>
+
+      {pages.length === 0 ? (
+        <p className="text-foreground/60">No pages yet.</p>
+      ) : (
+        <WikiIndexClient pages={pages} discussionStats={discussionStats} />
+      )}
+    </main>
+  );
+}

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -1,20 +1,50 @@
 import Link from "next/link";
 import { listWikiPages } from "@/lib/wiki";
+import { slugsForOwner } from "@/lib/search";
 import { getDiscussionStatsForSlugs } from "@/lib/talk";
+import { getPrincipal } from "@/lib/auth";
 import { WikiIndexClient } from "@/components/WikiIndexClient";
 
-export default async function WikiIndex() {
-  const pages = await listWikiPages();
+export default async function WikiIndex({
+  searchParams,
+}: {
+  searchParams: Promise<{ scope?: string }>;
+}) {
+  const { scope: scopeParam } = await searchParams;
+  const principal = await getPrincipal();
+  const myHandle = principal?.handle ?? null;
 
-  // Fetch discussion stats for all pages in one batch.
+  // Effective scope: explicit ?scope wins; otherwise signed-in users default to
+  // their own content ("Mine"), guests to the full public commons ("All").
+  // This is a soft VIEW filter over public content — not access control.
+  const effectiveScope = scopeParam ?? (myHandle ? "mine" : "all");
+  const ownerHandle =
+    effectiveScope === "mine"
+      ? myHandle
+      : effectiveScope.startsWith("owner:")
+        ? effectiveScope.slice("owner:".length)
+        : null;
+  const showingMine = ownerHandle !== null;
+
+  let pages = await listWikiPages();
+  if (ownerHandle) {
+    const mine = new Set(await slugsForOwner(ownerHandle));
+    pages = pages.filter((p) => mine.has(p.slug));
+  }
+
   const slugs = pages.map((p) => p.slug);
   const statsMap = await getDiscussionStatsForSlugs(slugs);
-
-  // Convert Map → plain object so it can be serialized across the server/client boundary.
   const discussionStats: Record<string, { total: number; open: number }> = {};
   for (const [slug, stats] of statsMap) {
     discussionStats[slug] = stats;
   }
+
+  const tabClass = (active: boolean) =>
+    `rounded-md px-3 py-1.5 text-sm transition-colors ${
+      active
+        ? "bg-foreground/10 font-semibold text-foreground"
+        : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
+    }`;
 
   return (
     <main className="mx-auto max-w-3xl px-6 py-12">
@@ -36,7 +66,34 @@ export default async function WikiIndex() {
         </div>
       </div>
 
-      <WikiIndexClient pages={pages} discussionStats={discussionStats} />
+      {/* Mine | All lens — "Mine" shown only when signed in. A soft view filter
+          over public content (everyone can still view All). */}
+      <div className="mb-4 inline-flex items-center gap-1 rounded-lg border border-foreground/10 p-1">
+        {myHandle && (
+          <Link href="/wiki?scope=mine" className={tabClass(showingMine)}>
+            Mine
+          </Link>
+        )}
+        <Link href="/wiki?scope=all" className={tabClass(!showingMine)}>
+          All
+        </Link>
+      </div>
+
+      {pages.length === 0 && showingMine ? (
+        <p className="text-foreground/60">
+          You haven&rsquo;t added any pages yet.{" "}
+          <Link href="/wiki?scope=all" className="underline hover:text-foreground">
+            Browse all content
+          </Link>{" "}
+          or{" "}
+          <Link href="/ingest" className="underline hover:text-foreground">
+            ingest a source
+          </Link>
+          .
+        </p>
+      ) : (
+        <WikiIndexClient pages={pages} discussionStats={discussionStats} />
+      )}
     </main>
   );
 }

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -701,6 +701,18 @@ describe("resolveScope", () => {
     expect(result).toBeNull();
   });
 
+  it("resolves 'owner:<handle>' to a Mine-lens scope", async () => {
+    await ensureDirectories();
+    const result = await resolveScope("owner:alice");
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe("alice");
+    expect(Array.isArray(result!.slugs)).toBe(true);
+  });
+
+  it("returns null for an empty owner handle", async () => {
+    expect(await resolveScope("owner:")).toBeNull();
+  });
+
   it("combines all three page arrays from agent profile", async () => {
     await ensureAgentsDir();
     await registerAgent(

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -6,6 +6,7 @@ import { parseFrontmatter } from "./frontmatter";
 import { logger } from "./logger";
 import {
   readWikiPage,
+  readWikiPageWithFrontmatter,
   writeWikiPage,
   listWikiPages,
   withPageCache,
@@ -508,10 +509,42 @@ export async function fuzzySearchWikiContent(
  * Returns `null` if the scope string format is invalid or the referenced
  * entity doesn't exist.
  */
+/**
+ * Slugs a handle "owns" for the Mine lens: pages where `owner === handle` OR
+ * the handle appears in `contributors`. Scans frontmatter (O(n), small scale).
+ */
+export async function slugsForOwner(handle: string): Promise<string[]> {
+  const pages = await listWikiPages();
+  const out: string[] = [];
+  for (const entry of pages) {
+    if (entry.slug === "index" || entry.slug === "log") continue;
+    const page = await readWikiPageWithFrontmatter(entry.slug);
+    if (!page) continue;
+    const owner =
+      typeof page.frontmatter.owner === "string" ? page.frontmatter.owner : "";
+    const contributors = Array.isArray(page.frontmatter.contributors)
+      ? (page.frontmatter.contributors as string[])
+      : [];
+    if (owner === handle || contributors.includes(handle)) {
+      out.push(entry.slug);
+    }
+  }
+  return out;
+}
+
 export async function resolveScope(
   scopeParam: string,
 ): Promise<SearchScope | null> {
   if (!scopeParam || typeof scopeParam !== "string") return null;
+
+  // owner:<handle> — the personal "Mine" lens (a public view filter, not access
+  // control). Resolves to pages the handle owns OR has contributed to.
+  const ownerMatch = scopeParam.match(/^owner:(.+)$/);
+  if (ownerMatch) {
+    const handle = ownerMatch[1]?.trim();
+    if (!handle) return null;
+    return { agentId: handle, slugs: await slugsForOwner(handle) };
+  }
 
   const match = scopeParam.match(/^agent:(.+)$/);
   if (!match) return null;


### PR DESCRIPTION
Step 5 of the identity work. A soft, public-safe personal lens over the commons (everyone can still view All) — not access control.

- `search.ts`: `resolveScope` now handles `owner:<handle>`; exported `slugsForOwner` (pages where `owner === handle` OR handle ∈ `contributors`). Scoped search/query already consume `scope.slugs`, so they gain owner scope for free.
- **Browse (`/wiki`)**: Mine | All segmented control. Signed-in → defaults to Mine (`?scope=mine`); guests → All. Empty-Mine state links to All / ingest.
- **`/u/[handle]`**: public profile of a user's owned/contributed pages.

Verified on prod: `/wiki?scope=all` and `/u/<handle>` → 200. Legacy pages without an `owner` correctly appear only in All; new authed ingests populate Mine. **2090 tests pass**, lint clean, deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)