### PR TITLE
Show owner badge on page cards

### DIFF
--- a/src/components/WikiPageCard.tsx
+++ b/src/components/WikiPageCard.tsx
@@ -11,11 +11,14 @@ export function WikiPageCard({ page, discussionCount }: WikiPageCardProps) {
   const relLabel = page.updated ? formatRelativeTime(page.updated) : null;
   const pageTags = page.tags ?? [];
   const hasOpenDiscussions = (discussionCount?.open ?? 0) > 0;
+  // Show real owners; hide the legacy/system placeholder.
+  const owner = page.owner && page.owner !== "system" ? page.owner : null;
   const hasMeta =
     pageTags.length > 0 ||
     relLabel !== null ||
     (page.sourceCount ?? 0) > 0 ||
-    hasOpenDiscussions;
+    hasOpenDiscussions ||
+    owner !== null;
 
   return (
     <li>
@@ -39,6 +42,11 @@ export function WikiPageCard({ page, discussionCount }: WikiPageCardProps) {
                 {tag}
               </span>
             ))}
+            {owner && (
+              <span className="inline-flex items-center rounded-full bg-foreground/5 px-2 py-0.5 text-xs text-foreground/60">
+                by @{owner}
+              </span>
+            )}
             {relLabel && <span>updated {relLabel}</span>}
             {(page.sourceCount ?? 0) > 0 && (
               <span>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,8 @@ export interface IndexEntry {
   sourceUrl?: string;
   /** Confidence score 0–1 from frontmatter. */
   confidence?: number;
+  /** Owner (principal handle) from frontmatter, if any. */
+  owner?: string;
 }
 
 /** Result returned after ingesting a source document. */

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -343,6 +343,11 @@ export async function listWikiPages(): Promise<IndexEntry[]> {
             ? fm.source_url
             : undefined;
 
+        const owner =
+          typeof fm.owner === "string" && fm.owner.length > 0
+            ? fm.owner
+            : undefined;
+
         // Parse confidence (0–1 number from frontmatter)
         const confidenceRaw = fm.confidence;
         const confidenceNum =
@@ -363,6 +368,7 @@ export async function listWikiPages(): Promise<IndexEntry[]> {
           ...(sourceCount !== undefined ? { sourceCount } : {}),
           ...(sourceUrl ? { sourceUrl } : {}),
           ...(confidence !== undefined ? { confidence } : {}),
+          ...(owner ? { owner } : {}),
         };
       } catch (err) {
         logger.warn(


### PR DESCRIPTION
Polish: surface attribution while browsing. `listWikiPages` enriches `IndexEntry` with `owner`; `WikiPageCard` shows a 'by @handle' badge (legacy `system` owners hidden). 2090 tests pass; deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)