### PR TITLE
feat(agents): agent ownership + nested /u/<handle>/a/<agent> profiles

### DIFF
--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from "next/server";
-import { getAgent, deleteAgent, updateAgent } from "@/lib/agents";
+import {
+  getAgent,
+  deleteAgent,
+  updateAgent,
+  assertCanMutateAgent,
+  AgentOwnershipError,
+} from "@/lib/agents";
 import type { UpdateAgentOptions } from "@/lib/agents";
+import { getPrincipal } from "@/lib/auth";
 import { getErrorMessage } from "@/lib/errors";
 
 interface RouteParams {
@@ -44,7 +51,8 @@ export async function GET(_req: Request, { params }: RouteParams) {
 /**
  * DELETE /api/agents/[id]
  *
- * Remove an agent profile. Returns 200 on success, 404 if not found.
+ * Remove an agent profile. Only the owner may delete it. Returns 200 on
+ * success, 403 if not the owner, 404 if not found.
  */
 export async function DELETE(_req: Request, { params }: RouteParams) {
   try {
@@ -57,16 +65,28 @@ export async function DELETE(_req: Request, { params }: RouteParams) {
       );
     }
 
-    const deleted = await deleteAgent(id);
-    if (!deleted) {
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json(
+        { error: "Sign in required to delete an agent." },
+        { status: 401 },
+      );
+    }
+    // Owns-or-403; also resolves whether the agent exists at all.
+    const existing = await assertCanMutateAgent(id, principal.handle);
+    if (!existing) {
       return NextResponse.json(
         { error: `Agent "${id}" not found` },
         { status: 404 },
       );
     }
 
+    await deleteAgent(id);
     return NextResponse.json({ deleted: true });
   } catch (err) {
+    if (err instanceof AgentOwnershipError) {
+      return NextResponse.json({ error: err.message }, { status: 403 });
+    }
     const message = getErrorMessage(err);
     if (message.includes("Invalid agent ID")) {
       return NextResponse.json({ error: message }, { status: 400 });
@@ -84,7 +104,8 @@ export async function DELETE(_req: Request, { params }: RouteParams) {
  *   - `addPages?` — array of `{ slug, title, type, content }` to create and link
  *   - `removePages?` — array of slugs to unlink (does NOT delete wiki pages)
  *
- * Returns the updated profile. 404 if agent doesn't exist, 400 for validation.
+ * Only the owner may update (feed) the agent. Returns the updated profile.
+ * 403 if not the owner, 404 if agent doesn't exist, 400 for validation.
  */
 export async function PUT(req: Request, { params }: RouteParams) {
   try {
@@ -94,6 +115,14 @@ export async function PUT(req: Request, { params }: RouteParams) {
       return NextResponse.json(
         { error: "Agent ID must be a non-empty string" },
         { status: 400 },
+      );
+    }
+
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json(
+        { error: "Sign in required to update an agent." },
+        { status: 401 },
       );
     }
 
@@ -114,6 +143,15 @@ export async function PUT(req: Request, { params }: RouteParams) {
       );
     }
 
+    // Owns-or-403; also resolves whether the agent exists (404 below).
+    const existing = await assertCanMutateAgent(id, principal.handle);
+    if (!existing) {
+      return NextResponse.json(
+        { error: `Agent "${id}" not found` },
+        { status: 404 },
+      );
+    }
+
     const updated = await updateAgent(id, body);
     if (!updated) {
       return NextResponse.json(
@@ -124,6 +162,9 @@ export async function PUT(req: Request, { params }: RouteParams) {
 
     return NextResponse.json({ agent: updated });
   } catch (err) {
+    if (err instanceof AgentOwnershipError) {
+      return NextResponse.json({ error: err.message }, { status: 403 });
+    }
     const message = getErrorMessage(err);
     if (
       message.includes("Invalid agent ID") ||

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { listAgents, registerAgent, getAgent } from "@/lib/agents";
+import { getPrincipal } from "@/lib/auth";
 import { getErrorMessage } from "@/lib/errors";
 import type { AgentProfile } from "@/lib/types";
 
@@ -21,12 +22,22 @@ export async function GET() {
 /**
  * POST /api/agents
  *
- * Register a new agent. Body must include: id, name, description.
+ * Register a new agent. Body must include: id, name, description. The creating
+ * principal becomes the `owner`; only they may later update/delete it.
  * Returns 201 on success, 400 for invalid input, 409 if the agent already
- * exists (use PUT on /api/agents/[id] to update — not yet implemented).
+ * exists (use PUT on /api/agents/[id] to update).
  */
 export async function POST(req: Request) {
   try {
+    // Writes are gated by middleware; resolve the principal to claim ownership.
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json(
+        { error: "Sign in required to register an agent." },
+        { status: 401 },
+      );
+    }
+
     const body = await req.json();
 
     // Basic presence checks before calling into the lib layer
@@ -64,6 +75,7 @@ export async function POST(req: Request) {
       id,
       name,
       description,
+      owner: principal.handle,
       identityPages: Array.isArray(body.identityPages) ? body.identityPages : [],
       learningPages: Array.isArray(body.learningPages) ? body.learningPages : [],
       socialPages: Array.isArray(body.socialPages) ? body.socialPages : [],

--- a/src/app/api/agents/seed/route.ts
+++ b/src/app/api/agents/seed/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { seedAgent } from "@/lib/agents";
+import { seedAgent, assertCanMutateAgent, AgentOwnershipError } from "@/lib/agents";
+import { getPrincipal } from "@/lib/auth";
 import { getErrorMessage } from "@/lib/errors";
 
 const VALID_SECTION_TYPES = new Set(["identity", "learnings", "social"]);
@@ -9,13 +10,25 @@ const VALID_SECTION_TYPES = new Set(["identity", "learnings", "social"]);
  *
  * Seed an agent by creating wiki pages for each content section and registering
  * the agent profile. Idempotent — re-seeding an existing agent updates its
- * pages (seedAgent preserves original registration date).
+ * pages (seedAgent preserves original registration date and owner).
+ *
+ * The first seed claims ownership (`owner` = the session principal); only that
+ * owner may re-seed. Anyone signed in can seed a brand-new agent id.
  *
  * Body: { id, name, description, sections: [{ slug, title, type, content }] }
  * Returns 201 with { agent: AgentProfile } on success.
  */
 export async function POST(req: Request) {
   try {
+    // Writes are gated by middleware, but resolve the principal for ownership.
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json(
+        { error: "Sign in required to seed an agent." },
+        { status: 401 },
+      );
+    }
+
     const body = await req.json();
 
     // --- Validate top-level fields ---
@@ -83,11 +96,23 @@ export async function POST(req: Request) {
       }
     }
 
-    // --- Call seedAgent ---
-    const profile = await seedAgent({ id, name, description, sections });
+    // --- Ownership: only the owner may re-seed an existing agent ---
+    await assertCanMutateAgent(id, principal.handle);
+
+    // --- Call seedAgent (owner from session, never from the body) ---
+    const profile = await seedAgent({
+      id,
+      name,
+      description,
+      owner: principal.handle,
+      sections,
+    });
 
     return NextResponse.json({ agent: profile }, { status: 201 });
   } catch (err) {
+    if (err instanceof AgentOwnershipError) {
+      return NextResponse.json({ error: err.message }, { status: 403 });
+    }
     const message = getErrorMessage(err);
     // Surface validation errors from the lib layer as 400s
     if (

--- a/src/app/u/[handle]/a/[agent]/page.tsx
+++ b/src/app/u/[handle]/a/[agent]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { getAgent } from "@/lib/agents";
 import { listWikiPages } from "@/lib/wiki";
 import { decodeSlug } from "@/lib/slugify";
+import { getErrorMessage } from "@/lib/errors";
 import type { AgentProfile } from "@/lib/types";
 
 // Public agent profile, scoped under its owner's handle:
@@ -18,7 +19,17 @@ export default async function AgentProfilePage({
   const handle = decodeSlug(encodedHandle);
   const agentId = decodeSlug(encodedAgent);
 
-  const agent = await getAgent(agentId).catch(() => null);
+  // getAgent returns null for a genuinely missing agent (ENOENT) and throws on
+  // real errors (storage down, corrupt JSON). Don't flatten the latter into a
+  // 404 — only a missing or malformed-id agent is "not found"; let real errors
+  // propagate to the error boundary (500 + logging).
+  let agent: AgentProfile | null;
+  try {
+    agent = await getAgent(agentId);
+  } catch (err) {
+    if (getErrorMessage(err).includes("Invalid agent ID")) notFound();
+    throw err;
+  }
   if (!agent) notFound();
 
   // Resolve slug -> title from the index for nicer links (fall back to slug).

--- a/src/app/u/[handle]/a/[agent]/page.tsx
+++ b/src/app/u/[handle]/a/[agent]/page.tsx
@@ -1,0 +1,93 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getAgent } from "@/lib/agents";
+import { listWikiPages } from "@/lib/wiki";
+import { decodeSlug } from "@/lib/slugify";
+import type { AgentProfile } from "@/lib/types";
+
+// Public agent profile, scoped under its owner's handle:
+//   /u/<handle>/a/<agent>
+// Shows the agent's identity / learnings / social pages and cross-links back to
+// the owning user. Reads are public — yopedia is a public observer surface.
+export default async function AgentProfilePage({
+  params,
+}: {
+  params: Promise<{ handle: string; agent: string }>;
+}) {
+  const { handle: encodedHandle, agent: encodedAgent } = await params;
+  const handle = decodeSlug(encodedHandle);
+  const agentId = decodeSlug(encodedAgent);
+
+  const agent = await getAgent(agentId).catch(() => null);
+  if (!agent) notFound();
+
+  // Resolve slug -> title from the index for nicer links (fall back to slug).
+  const index = await listWikiPages();
+  const titleFor = new Map(index.map((p) => [p.slug, p.title]));
+
+  const sections: { label: string; slugs: string[] }[] = [
+    { label: "Identity", slugs: agent.identityPages ?? [] },
+    { label: "Learnings", slugs: agent.learningPages ?? [] },
+    { label: "Social wisdom", slugs: agent.socialPages ?? [] },
+  ];
+  const totalPages = sections.reduce((n, s) => n + s.slugs.length, 0);
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <div className="mb-6">
+        <Link
+          href={`/u/${handle}`}
+          className="text-sm text-foreground/50 hover:text-foreground"
+        >
+          ← @{handle}
+        </Link>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight">{agent.name}</h1>
+        <p className="mt-1 text-foreground/60">{agent.description}</p>
+        <AgentMeta agent={agent} />
+      </div>
+
+      {totalPages === 0 ? (
+        <p className="text-foreground/60">
+          This agent has no knowledge pages yet.
+        </p>
+      ) : (
+        <div className="space-y-8">
+          {sections.map((section) =>
+            section.slugs.length === 0 ? null : (
+              <section key={section.label}>
+                <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-foreground/50">
+                  {section.label}
+                </h2>
+                <ul className="space-y-1">
+                  {section.slugs.map((slug) => (
+                    <li key={slug}>
+                      <Link
+                        href={`/wiki/${slug}`}
+                        className="text-foreground hover:underline"
+                      >
+                        {titleFor.get(slug) ?? slug}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ),
+          )}
+        </div>
+      )}
+    </main>
+  );
+}
+
+/** Owner cross-link under the agent header. */
+function AgentMeta({ agent }: { agent: AgentProfile }) {
+  if (!agent.owner) return null;
+  return (
+    <p className="mt-3 text-sm text-foreground/50">
+      owned by{" "}
+      <Link href={`/u/${agent.owner}`} className="hover:text-foreground">
+        @{agent.owner}
+      </Link>
+    </p>
+  );
+}

--- a/src/app/u/[handle]/page.tsx
+++ b/src/app/u/[handle]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { listWikiPages } from "@/lib/wiki";
 import { slugsForOwner } from "@/lib/search";
+import { listAgentsForOwner } from "@/lib/agents";
 import { getDiscussionStatsForSlugs } from "@/lib/talk";
 import { decodeSlug } from "@/lib/slugify";
 import { WikiIndexClient } from "@/components/WikiIndexClient";
@@ -17,6 +18,7 @@ export default async function UserPage({
 
   const mine = new Set(await slugsForOwner(handle));
   const pages = (await listWikiPages()).filter((p) => mine.has(p.slug));
+  const agents = await listAgentsForOwner(handle);
 
   const statsMap = await getDiscussionStatsForSlugs(pages.map((p) => p.slug));
   const discussionStats: Record<string, { total: number; open: number }> = {};
@@ -33,6 +35,31 @@ export default async function UserPage({
           Public pages owned or contributed by {handle}.
         </p>
       </div>
+
+      {agents.length > 0 && (
+        <section className="mb-8">
+          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-foreground/50">
+            Agents
+          </h2>
+          <ul className="space-y-2">
+            {agents.map((agent) => (
+              <li key={agent.id}>
+                <Link
+                  href={`/u/${handle}/a/${agent.id}`}
+                  className="group block rounded-lg border border-foreground/10 p-3 hover:border-foreground/30"
+                >
+                  <span className="font-medium group-hover:underline">
+                    {agent.name}
+                  </span>
+                  <span className="mt-0.5 block text-sm text-foreground/60">
+                    {agent.description}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       {pages.length === 0 ? (
         <p className="text-foreground/60">No pages yet.</p>

--- a/src/lib/__tests__/agents-id-route.test.ts
+++ b/src/lib/__tests__/agents-id-route.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mock the agents library. AgentOwnershipError is a real class so the route's
+// `instanceof` check maps it to 403.
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/agents", () => {
+  class AgentOwnershipError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "AgentOwnershipError";
+    }
+  }
+  return {
+    getAgent: vi.fn(),
+    deleteAgent: vi.fn(),
+    updateAgent: vi.fn(),
+    assertCanMutateAgent: vi.fn(),
+    AgentOwnershipError,
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  getPrincipal: vi.fn(async () => ({ id: "alice", handle: "alice" })),
+}));
+
+import {
+  deleteAgent,
+  updateAgent,
+  assertCanMutateAgent,
+  AgentOwnershipError,
+} from "@/lib/agents";
+import { getPrincipal } from "@/lib/auth";
+import { PUT, DELETE } from "@/app/api/agents/[id]/route";
+import type { AgentProfile } from "@/lib/types";
+
+const mockedDelete = vi.mocked(deleteAgent);
+const mockedUpdate = vi.mocked(updateAgent);
+const mockedAssert = vi.mocked(assertCanMutateAgent);
+const mockedGetPrincipal = vi.mocked(getPrincipal);
+
+const ownedAgent: AgentProfile = {
+  id: "yoyo",
+  name: "Yoyo",
+  description: "An agent",
+  owner: "alice",
+  identityPages: [],
+  learningPages: [],
+  socialPages: [],
+  registered: "2026-05-03T00:00:00.000Z",
+  lastUpdated: "2026-05-03T00:00:00.000Z",
+};
+
+const params = Promise.resolve({ id: "yoyo" });
+
+function putReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/agents/yoyo", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetPrincipal.mockResolvedValue({ id: "alice", handle: "alice" });
+  mockedAssert.mockResolvedValue(ownedAgent);
+  mockedUpdate.mockResolvedValue({ ...ownedAgent, name: "Yoyo v2" });
+  mockedDelete.mockResolvedValue(true);
+});
+
+describe("PUT /api/agents/[id] — ownership", () => {
+  it("updates when the caller owns the agent", async () => {
+    const res = await PUT(putReq({ name: "Yoyo v2" }), { params });
+    expect(res.status).toBe(200);
+    expect(mockedUpdate).toHaveBeenCalledWith("yoyo", { name: "Yoyo v2" });
+  });
+
+  it("returns 401 when signed out", async () => {
+    mockedGetPrincipal.mockResolvedValue(null);
+    const res = await PUT(putReq({ name: "x" }), { params });
+    expect(res.status).toBe(401);
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the caller is not the owner", async () => {
+    mockedAssert.mockRejectedValue(
+      new AgentOwnershipError('Agent "yoyo" is owned by @bob; @alice cannot modify it.'),
+    );
+    const res = await PUT(putReq({ name: "x" }), { params });
+    expect(res.status).toBe(403);
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the agent does not exist", async () => {
+    mockedAssert.mockResolvedValue(null);
+    const res = await PUT(putReq({ name: "x" }), { params });
+    expect(res.status).toBe(404);
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/agents/[id] — ownership", () => {
+  it("deletes when the caller owns the agent", async () => {
+    const res = await DELETE(new Request("http://localhost/api/agents/yoyo"), {
+      params,
+    });
+    expect(res.status).toBe(200);
+    expect(mockedDelete).toHaveBeenCalledWith("yoyo");
+  });
+
+  it("returns 401 when signed out", async () => {
+    mockedGetPrincipal.mockResolvedValue(null);
+    const res = await DELETE(new Request("http://localhost/api/agents/yoyo"), {
+      params,
+    });
+    expect(res.status).toBe(401);
+    expect(mockedDelete).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the caller is not the owner", async () => {
+    mockedAssert.mockRejectedValue(
+      new AgentOwnershipError('Agent "yoyo" is owned by @bob; @alice cannot modify it.'),
+    );
+    const res = await DELETE(new Request("http://localhost/api/agents/yoyo"), {
+      params,
+    });
+    expect(res.status).toBe(403);
+    expect(mockedDelete).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the agent does not exist", async () => {
+    mockedAssert.mockResolvedValue(null);
+    const res = await DELETE(new Request("http://localhost/api/agents/yoyo"), {
+      params,
+    });
+    expect(res.status).toBe(404);
+    expect(mockedDelete).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/agents-route.test.ts
+++ b/src/lib/__tests__/agents-route.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mock the agents data layer — the route only validates input and claims
+// ownership; the lib layer is exercised by agents.test.ts.
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/agents", () => ({
+  listAgents: vi.fn(),
+  registerAgent: vi.fn(),
+  getAgent: vi.fn(),
+}));
+
+// The route claims ownership from the session principal.
+vi.mock("@/lib/auth", () => ({
+  getPrincipal: vi.fn(async () => ({ id: "alice", handle: "alice" })),
+}));
+
+import { registerAgent, getAgent } from "@/lib/agents";
+import { getPrincipal } from "@/lib/auth";
+import { POST } from "@/app/api/agents/route";
+
+const mockedRegister = vi.mocked(registerAgent);
+const mockedGetAgent = vi.mocked(getAgent);
+const mockedGetPrincipal = vi.mocked(getPrincipal);
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/agents", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function validBody() {
+  return { id: "yoyo", name: "Yoyo", description: "An agent" };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetPrincipal.mockResolvedValue({ id: "alice", handle: "alice" });
+  mockedGetAgent.mockResolvedValue(null); // no conflict by default
+  mockedRegister.mockResolvedValue(undefined);
+});
+
+describe("POST /api/agents — ownership", () => {
+  it("claims ownership from the session principal", async () => {
+    const res = await POST(makeRequest(validBody()));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.agent.owner).toBe("alice");
+    expect(mockedRegister).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "yoyo", owner: "alice" }),
+    );
+  });
+
+  it("ignores a client-supplied owner (set from session, never the body)", async () => {
+    const res = await POST(makeRequest({ ...validBody(), owner: "attacker" }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.agent.owner).toBe("alice");
+    expect(mockedRegister).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "alice" }),
+    );
+  });
+
+  it("returns 401 when signed out, without registering", async () => {
+    mockedGetPrincipal.mockResolvedValue(null);
+    const res = await POST(makeRequest(validBody()));
+    expect(res.status).toBe(401);
+    expect(mockedRegister).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when the agent already exists", async () => {
+    mockedGetAgent.mockResolvedValue({
+      id: "yoyo",
+      name: "Yoyo",
+      description: "An agent",
+      owner: "bob",
+      identityPages: [],
+      learningPages: [],
+      socialPages: [],
+      registered: "2026-05-03T00:00:00.000Z",
+      lastUpdated: "2026-05-03T00:00:00.000Z",
+    });
+    const res = await POST(makeRequest(validBody()));
+    expect(res.status).toBe(409);
+    expect(mockedRegister).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for missing required fields", async () => {
+    const res = await POST(makeRequest({ name: "Yoyo" }));
+    expect(res.status).toBe(400);
+    expect(mockedRegister).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/agents.test.ts
+++ b/src/lib/__tests__/agents.test.ts
@@ -6,11 +6,14 @@ import {
   getAgentsDir,
   ensureAgentsDir,
   listAgents,
+  listAgentsForOwner,
   getAgent,
   registerAgent,
   deleteAgent,
   seedAgent,
   updateAgent,
+  assertCanMutateAgent,
+  AgentOwnershipError,
 } from "../agents";
 import type { UpdateAgentPage } from "../agents";
 import { readWikiPage, readWikiPageWithFrontmatter } from "../wiki";
@@ -895,5 +898,113 @@ describe("updateAgent", () => {
     expect(new Date(result!.lastUpdated).getTime()).toBeGreaterThan(
       new Date("2020-01-01T00:00:00.000Z").getTime(),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ownership — owner field, assertCanMutateAgent, listAgentsForOwner
+// ---------------------------------------------------------------------------
+
+describe("agent ownership", () => {
+  const sections = [
+    {
+      type: "identity" as const,
+      slug: "yoyo-identity",
+      title: "Yoyo Identity",
+      content: "I am yoyo.",
+    },
+  ];
+
+  it("seedAgent persists the owner", async () => {
+    const profile = await seedAgent({
+      id: "yoyo",
+      name: "Yoyo",
+      description: "An agent",
+      owner: "alice",
+      sections,
+    });
+    expect(profile.owner).toBe("alice");
+    expect((await getAgent("yoyo"))!.owner).toBe("alice");
+  });
+
+  it("re-seed preserves the original owner (ownership never transfers)", async () => {
+    await seedAgent({
+      id: "yoyo",
+      name: "Yoyo",
+      description: "An agent",
+      owner: "alice",
+      sections,
+    });
+    // A second seed claiming a different owner must NOT take over.
+    const reseeded = await seedAgent({
+      id: "yoyo",
+      name: "Yoyo v2",
+      description: "An agent, updated",
+      owner: "bob",
+      sections,
+    });
+    expect(reseeded.owner).toBe("alice");
+    expect((await getAgent("yoyo"))!.owner).toBe("alice");
+  });
+
+  describe("assertCanMutateAgent", () => {
+    it("allows creation when the agent does not exist yet", async () => {
+      await expect(assertCanMutateAgent("yoyo", "alice")).resolves.toBeNull();
+    });
+
+    it("allows the owner to mutate their agent", async () => {
+      await seedAgent({
+        id: "yoyo",
+        name: "Yoyo",
+        description: "An agent",
+        owner: "alice",
+        sections,
+      });
+      const existing = await assertCanMutateAgent("yoyo", "alice");
+      expect(existing!.owner).toBe("alice");
+    });
+
+    it("rejects a non-owner with AgentOwnershipError", async () => {
+      await seedAgent({
+        id: "yoyo",
+        name: "Yoyo",
+        description: "An agent",
+        owner: "alice",
+        sections,
+      });
+      await expect(assertCanMutateAgent("yoyo", "bob")).rejects.toBeInstanceOf(
+        AgentOwnershipError,
+      );
+    });
+
+    it("allows mutation of a legacy agent with no owner", async () => {
+      // Pre-ownership record written directly (no owner field).
+      await registerAgent(makeProfile({ id: "legacy" }));
+      await expect(
+        assertCanMutateAgent("legacy", "anyone"),
+      ).resolves.not.toBeNull();
+    });
+  });
+
+  describe("listAgentsForOwner", () => {
+    it("returns only the agents owned by the handle", async () => {
+      await seedAgent({
+        id: "yoyo",
+        name: "Yoyo",
+        description: "Alice's agent",
+        owner: "alice",
+        sections,
+      });
+      await seedAgent({
+        id: "bobbot",
+        name: "BobBot",
+        description: "Bob's agent",
+        owner: "bob",
+        sections: [{ ...sections[0], slug: "bobbot-identity" }],
+      });
+      const aliceAgents = await listAgentsForOwner("alice");
+      expect(aliceAgents.map((a) => a.id)).toEqual(["yoyo"]);
+      expect(await listAgentsForOwner("carol")).toEqual([]);
+    });
   });
 });

--- a/src/lib/__tests__/seed-route.test.ts
+++ b/src/lib/__tests__/seed-route.test.ts
@@ -2,17 +2,36 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // ---------------------------------------------------------------------------
-// Mock the agents library — we only test the route's validation and wiring
+// Mock the agents library — we only test the route's validation and wiring.
+// AgentOwnershipError is a real class so the route's `instanceof` check works.
 // ---------------------------------------------------------------------------
-vi.mock("@/lib/agents", () => ({
-  seedAgent: vi.fn(),
+vi.mock("@/lib/agents", () => {
+  class AgentOwnershipError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "AgentOwnershipError";
+    }
+  }
+  return {
+    seedAgent: vi.fn(),
+    assertCanMutateAgent: vi.fn(async () => null),
+    AgentOwnershipError,
+  };
+});
+
+// The route resolves the owner from the session principal.
+vi.mock("@/lib/auth", () => ({
+  getPrincipal: vi.fn(async () => ({ id: "test-user", handle: "test-user" })),
 }));
 
-import { seedAgent } from "@/lib/agents";
+import { seedAgent, assertCanMutateAgent, AgentOwnershipError } from "@/lib/agents";
+import { getPrincipal } from "@/lib/auth";
 import { POST } from "@/app/api/agents/seed/route";
 import type { AgentProfile } from "@/lib/types";
 
 const mockedSeedAgent = vi.mocked(seedAgent);
+const mockedAssertCanMutate = vi.mocked(assertCanMutateAgent);
+const mockedGetPrincipal = vi.mocked(getPrincipal);
 
 function makeRequest(body: unknown): NextRequest {
   return new NextRequest("http://localhost:3000/api/agents/seed", {
@@ -64,6 +83,10 @@ const fakeProfile: AgentProfile = {
 beforeEach(() => {
   mockedSeedAgent.mockReset();
   mockedSeedAgent.mockResolvedValue(fakeProfile);
+  mockedAssertCanMutate.mockReset();
+  mockedAssertCanMutate.mockResolvedValue(null);
+  mockedGetPrincipal.mockReset();
+  mockedGetPrincipal.mockResolvedValue({ id: "test-user", handle: "test-user" });
 });
 
 // ---------------------------------------------------------------------------
@@ -81,8 +104,41 @@ describe("POST /api/agents/seed", () => {
         id: "yoyo",
         name: "yoyo",
         description: "A self-evolving coding agent growing up in public",
+        owner: "test-user",
         sections: validBody().sections,
       });
+    });
+
+    it("derives owner from the session, ignoring any client-supplied owner", async () => {
+      const body = { ...validBody(), owner: "attacker" };
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(201);
+      // Owner comes from the principal, never the body.
+      expect(mockedSeedAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ owner: "test-user" }),
+      );
+    });
+  });
+
+  describe("auth & ownership", () => {
+    it("returns 401 when there is no signed-in principal", async () => {
+      mockedGetPrincipal.mockResolvedValue(null);
+      const res = await POST(makeRequest(validBody()));
+      expect(res.status).toBe(401);
+      expect(mockedSeedAgent).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 when a non-owner tries to re-seed", async () => {
+      mockedAssertCanMutate.mockRejectedValue(
+        new AgentOwnershipError(
+          'Agent "yoyo" is owned by @alice; @test-user cannot modify it.',
+        ),
+      );
+      const res = await POST(makeRequest(validBody()));
+      expect(res.status).toBe(403);
+      const data = await res.json();
+      expect(data.error).toMatch(/owned by @alice/);
+      expect(mockedSeedAgent).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -98,6 +98,9 @@ export class AgentOwnershipError extends Error {
  * Otherwise throws {@link AgentOwnershipError}. This is what makes "seed once,
  * then only the owner can re-seed/feed/edit/delete" hold: the first seed claims
  * ownership, and everyone else is read-only against that agent.
+ *
+ * Also throws a validation error first if `id` is malformed (routes map that to
+ * 400, distinct from the 403 ownership rejection).
  */
 export async function assertCanMutateAgent(
   id: string,
@@ -515,7 +518,8 @@ export async function seedAgent(options: SeedAgentOptions): Promise<AgentProfile
   };
 
   // If the agent already exists, preserve its original registration date and
-  // owner — ownership is claimed by the first seed and never transfers here.
+  // owner — an owned agent never changes hands here. An existing *unowned*
+  // (legacy) agent is claimed by this seeder via the `?? options.owner` fallback.
   const existingAgent = await getAgent(options.id);
   if (existingAgent) {
     profile.registered = existingAgent.registered;

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -72,6 +72,48 @@ function validateProfile(profile: AgentProfile): void {
 }
 
 // ---------------------------------------------------------------------------
+// Ownership
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when an actor tries to mutate an agent they don't own. Routes map
+ * this to HTTP 403 (distinct from a 404 for a missing agent).
+ */
+export class AgentOwnershipError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentOwnershipError";
+  }
+}
+
+/**
+ * Assert that `actor` (a session principal handle) may mutate agent `id`, and
+ * return the existing profile (or null if it doesn't exist yet).
+ *
+ * A mutation is allowed when:
+ *   - the agent doesn't exist yet (this is a creation), OR
+ *   - the agent has no recorded owner (legacy/pre-ownership record), OR
+ *   - the agent's owner equals `actor`.
+ *
+ * Otherwise throws {@link AgentOwnershipError}. This is what makes "seed once,
+ * then only the owner can re-seed/feed/edit/delete" hold: the first seed claims
+ * ownership, and everyone else is read-only against that agent.
+ */
+export async function assertCanMutateAgent(
+  id: string,
+  actor: string,
+): Promise<AgentProfile | null> {
+  validateAgentId(id);
+  const existing = await getAgent(id);
+  if (existing?.owner && existing.owner !== actor) {
+    throw new AgentOwnershipError(
+      `Agent "${id}" is owned by @${existing.owner}; @${actor} cannot modify it.`,
+    );
+  }
+  return existing;
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -104,6 +146,17 @@ export async function listAgents(): Promise<AgentProfile[]> {
   // Sort alphabetically by ID for stable ordering.
   profiles.sort((a, b) => a.id.localeCompare(b.id));
   return profiles;
+}
+
+/**
+ * List the agents owned by a given principal handle, sorted by ID.
+ * Returns an empty array if the handle owns none (or the registry is empty).
+ */
+export async function listAgentsForOwner(
+  handle: string,
+): Promise<AgentProfile[]> {
+  const agents = await listAgents();
+  return agents.filter((a) => a.owner === handle);
 }
 
 /**
@@ -337,6 +390,10 @@ export interface SeedAgentOptions {
   id: string;
   name: string;
   description: string;
+  /** Accountable principal handle claiming ownership. Set from the session by
+   *  the route, never from client input. Ignored on re-seed if the agent
+   *  already has an owner (ownership never transfers via seed). */
+  owner?: string;
   /** Content sections to create as wiki pages. */
   sections: SeedAgentSection[];
 }
@@ -449,6 +506,7 @@ export async function seedAgent(options: SeedAgentOptions): Promise<AgentProfile
     id: options.id,
     name: options.name,
     description: options.description,
+    owner: options.owner,
     identityPages,
     learningPages,
     socialPages,
@@ -456,10 +514,12 @@ export async function seedAgent(options: SeedAgentOptions): Promise<AgentProfile
     lastUpdated: now.toISOString(),
   };
 
-  // If the agent already exists, preserve its original registration date
+  // If the agent already exists, preserve its original registration date and
+  // owner — ownership is claimed by the first seed and never transfers here.
   const existingAgent = await getAgent(options.id);
   if (existingAgent) {
     profile.registered = existingAgent.registered;
+    profile.owner = existingAgent.owner ?? options.owner;
   }
 
   await registerAgent(profile);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -177,6 +177,11 @@ export interface AgentProfile {
   name: string;
   /** Short description of who this agent is */
   description: string;
+  /** Accountable principal handle (the user who seeded/owns this agent).
+   *  Set from the authenticated session, never from client input. Only the
+   *  owner may re-seed, feed, update, or delete the agent. Optional for
+   *  back-compat with any pre-ownership agent records (treated as unowned). */
+  owner?: string;
   /** Wiki page slugs that form this agent's identity context */
   identityPages: string[];
   /** Wiki page slugs containing this agent's learnings */


### PR DESCRIPTION
## What

Builds the two pieces of the **agent layer** that need no new write credential — the "C first" slice of [`yopedia-concept.md`](yopedia-concept.md)'s agent-layer design.

### 1. Agent ownership — *you can only edit your own agent*
- `AgentProfile` gains an **`owner`** (accountable principal handle), set from the authenticated session — **never from client input**.
- `assertCanMutateAgent(id, actor)` + `AgentOwnershipError` enforce **creation-or-owner-only** across all four mutation routes:
  - `POST /api/agents`, `POST /api/agents/seed`, `PUT /api/agents/[id]`, `DELETE /api/agents/[id]`
  - → **401** signed-out · **403** non-owner · **404** missing
- `seedAgent` claims ownership on first seed and **preserves it on re-seed** (ownership never transfers). This makes **"seed yoyo once, reuse for all users"** safe: the first seed owns it; everyone else is read-only against it.

### 2. Nested agent profiles
- New **`/u/<handle>/a/<agent>`** route — an agent's identity / learnings / social pages, with an owner cross-link back to `/u/<handle>`.
- `/u/<handle>` now lists the agents that handle **owns** (`listAgentsForOwner`), cross-linking **user → agent → pages**.

## Tests
- `agents.test.ts`: owner persist/preserve on re-seed; `assertCanMutateAgent` (create / owner / non-owner / legacy-unowned); `listAgentsForOwner`.
- `seed-route.test.ts`: owner derived from session (ignores client-supplied `owner`); **401** no principal; **403** non-owner re-seed.
- `agents-id-route.test.ts` (new): `PUT`/`DELETE` ownership → 200 / 401 / 403 / 404.

Full suite **2138 passing**; `next build` + `eslint` clean.

## Not in this pass (deferred, per scope)
- Scoped agent-content visibility (keep agent pages out of the public "All" feed)
- Feed-as-grant (agent context = own pages + granted owner pages)
- Service / scheduled tokens → autonomous seeding + `@yoyoevolve` loop
- The one-time live yoyo seed itself (needs the external yoyo-evolve identity content)

Follow-up: once #286 (concept consolidation) merges, flip "agent `owner`" and the nested profile from *pending* → *built* in the concept's Agent-layer section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)