### PR TITLE
feat(agents): service token + weekly GitHub Action to seed/sync yoyo

### DIFF
--- a/.github/workflows/seed-yoyo.yml
+++ b/.github/workflows/seed-yoyo.yml
@@ -1,0 +1,107 @@
+name: Seed yoyo
+
+# Keeps the yopedia "yoyo" agent in sync with the canonical identity in
+# yologdev/yoyo-evolve. Assembles yoyo's identity / learnings / social pages
+# from that repo and POSTs them to /api/agents/seed.
+#
+# Auth: a service token (NOT a human Clerk session) — see src/lib/auth.ts
+# getServicePrincipal(). seedAgent is idempotent and preserves ownership, so a
+# weekly re-seed refreshes the content without changing the owner.
+#
+# Required config:
+#   - secret YOPEDIA_SERVICE_TOKEN  — must equal the Worker secret of the same name
+#   - (Worker secrets, set via wrangler) YOPEDIA_SERVICE_TOKEN + YOPEDIA_SERVICE_PRINCIPAL
+#   - optional repo variable YOPEDIA_URL (defaults to the production Worker URL)
+
+on:
+  schedule:
+    - cron: "17 6 * * 1" # Mondays 06:17 UTC
+  workflow_dispatch: {} # manual run — needed for the very first seed
+
+permissions:
+  contents: read
+
+concurrency:
+  group: seed-yoyo
+  cancel-in-progress: false
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out yoyo-evolve identity (public repo)
+        uses: actions/checkout@v4
+        with:
+          repository: yologdev/yoyo-evolve
+          path: yoyo-evolve
+
+      - name: Build seed payload
+        run: |
+          cat > build-seed.mjs <<'EOF'
+          import { readFileSync, existsSync, writeFileSync } from "node:fs";
+
+          const ROOT = "yoyo-evolve";
+          const read = (rel) => {
+            const path = `${ROOT}/${rel}`;
+            return existsSync(path) ? readFileSync(path, "utf8").trim() : "";
+          };
+
+          // Maps yoyo-evolve's identity files onto seedAgent sections.
+          const defs = [
+            { type: "identity",  slug: "yoyo-identity",      title: "yoyo — Identity",             file: "IDENTITY.md" },
+            { type: "identity",  slug: "yoyo-personality",   title: "yoyo — Voice & Personality",  file: "PERSONALITY.md" },
+            { type: "identity",  slug: "yoyo-economics",     title: "yoyo — Economics",            file: "ECONOMICS.md" },
+            { type: "learnings", slug: "yoyo-learnings",     title: "yoyo — Learnings",            file: "memory/active_learnings.md" },
+            { type: "social",    slug: "yoyo-social-wisdom", title: "yoyo — Social Wisdom",        file: "memory/active_social_learnings.md" },
+          ];
+
+          // Skip any file that is missing or empty — seedAgent rejects empty content.
+          const sections = defs
+            .map((d) => ({ type: d.type, slug: d.slug, title: d.title, content: read(d.file) }))
+            .filter((s) => s.content.length > 0);
+
+          if (sections.length === 0) {
+            console.error("No identity content found in yoyo-evolve — aborting.");
+            process.exit(1);
+          }
+
+          const payload = {
+            id: "yoyo",
+            name: "yoyo",
+            description:
+              "A self-evolving coding agent growing up in public. Identity synced from yologdev/yoyo-evolve.",
+            sections,
+          };
+
+          writeFileSync("payload.json", JSON.stringify(payload));
+          console.log(
+            `Built payload: ${sections.length} sections (${sections.map((s) => s.slug).join(", ")}), ` +
+              `${JSON.stringify(payload).length} bytes`,
+          );
+          EOF
+          node build-seed.mjs
+
+      - name: Seed yopedia
+        env:
+          YOPEDIA_SERVICE_TOKEN: ${{ secrets.YOPEDIA_SERVICE_TOKEN }}
+          YOPEDIA_URL: ${{ vars.YOPEDIA_URL || 'https://yopedia.yuanhao-li.workers.dev' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${YOPEDIA_SERVICE_TOKEN:-}" ]; then
+            echo "::error::YOPEDIA_SERVICE_TOKEN secret is not set"
+            exit 1
+          fi
+          code=$(curl -sS -o resp.json -w '%{http_code}' \
+            -X POST "$YOPEDIA_URL/api/agents/seed" \
+            -H "Authorization: Bearer $YOPEDIA_SERVICE_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data @payload.json)
+          echo "HTTP $code"
+          cat resp.json || true
+          echo
+          if [ "$code" != "201" ]; then
+            echo "::error::Seed failed with HTTP $code"
+            exit 1
+          fi
+          echo "yoyo seeded/updated successfully."

--- a/src/app/api/agents/seed/route.ts
+++ b/src/app/api/agents/seed/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { seedAgent, assertCanMutateAgent, AgentOwnershipError } from "@/lib/agents";
-import { getPrincipal } from "@/lib/auth";
+import { getPrincipal, getServicePrincipal } from "@/lib/auth";
 import { getErrorMessage } from "@/lib/errors";
 
 const VALID_SECTION_TYPES = new Set(["identity", "learnings", "social"]);
@@ -12,19 +12,23 @@ const VALID_SECTION_TYPES = new Set(["identity", "learnings", "social"]);
  * the agent profile. Idempotent — re-seeding an existing agent updates its
  * pages (seedAgent preserves original registration date and owner).
  *
- * The first seed claims ownership (`owner` = the session principal); only that
- * owner may re-seed. Anyone signed in can seed a brand-new agent id.
+ * The first seed claims ownership (`owner` = the principal); only that owner
+ * may re-seed. Anyone signed in can seed a brand-new agent id.
+ *
+ * This route is exempt from the middleware write-gate and authenticates here,
+ * accepting EITHER a Clerk session OR a service token (for the scheduled
+ * seed-yoyo job). Both resolve to a principal whose handle becomes the owner.
  *
  * Body: { id, name, description, sections: [{ slug, title, type, content }] }
  * Returns 201 with { agent: AgentProfile } on success.
  */
 export async function POST(req: Request) {
   try {
-    // Writes are gated by middleware, but resolve the principal for ownership.
-    const principal = await getPrincipal();
+    // Clerk session (human) OR service token (automation) — never the body.
+    const principal = (await getPrincipal()) ?? getServicePrincipal(req);
     if (!principal) {
       return NextResponse.json(
-        { error: "Sign in required to seed an agent." },
+        { error: "Sign in or a valid service token is required to seed an agent." },
         { status: 401 },
       );
     }

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// auth.ts imports Clerk at module scope; stub it (getServicePrincipal doesn't
+// use it, but the import must resolve).
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+  currentUser: vi.fn(),
+}));
+
+import { getServicePrincipal } from "../auth";
+
+const TOKEN = "s3cr3t-service-token-abcdef";
+const HANDLE = "yoyo-bot";
+
+function reqWith(authHeader?: string): Request {
+  const headers = new Headers();
+  if (authHeader !== undefined) headers.set("authorization", authHeader);
+  return new Request("https://yopedia.example/api/agents/seed", {
+    method: "POST",
+    headers,
+  });
+}
+
+let savedToken: string | undefined;
+let savedHandle: string | undefined;
+
+beforeEach(() => {
+  savedToken = process.env.YOPEDIA_SERVICE_TOKEN;
+  savedHandle = process.env.YOPEDIA_SERVICE_PRINCIPAL;
+  process.env.YOPEDIA_SERVICE_TOKEN = TOKEN;
+  process.env.YOPEDIA_SERVICE_PRINCIPAL = HANDLE;
+});
+
+afterEach(() => {
+  if (savedToken === undefined) delete process.env.YOPEDIA_SERVICE_TOKEN;
+  else process.env.YOPEDIA_SERVICE_TOKEN = savedToken;
+  if (savedHandle === undefined) delete process.env.YOPEDIA_SERVICE_PRINCIPAL;
+  else process.env.YOPEDIA_SERVICE_PRINCIPAL = savedHandle;
+});
+
+describe("getServicePrincipal", () => {
+  it("resolves a principal for the correct bearer token", () => {
+    const p = getServicePrincipal(reqWith(`Bearer ${TOKEN}`));
+    expect(p).toEqual({ id: `service:${HANDLE}`, handle: HANDLE });
+  });
+
+  it("accepts a case-insensitive scheme", () => {
+    expect(getServicePrincipal(reqWith(`bearer ${TOKEN}`))).not.toBeNull();
+  });
+
+  it("returns null for a wrong token", () => {
+    expect(getServicePrincipal(reqWith("Bearer wrong-token"))).toBeNull();
+  });
+
+  it("returns null for a token of different length (no partial match)", () => {
+    expect(getServicePrincipal(reqWith(`Bearer ${TOKEN}x`))).toBeNull();
+  });
+
+  it("returns null when there is no Authorization header", () => {
+    expect(getServicePrincipal(reqWith())).toBeNull();
+  });
+
+  it("returns null for a non-bearer header", () => {
+    expect(getServicePrincipal(reqWith(`Basic ${TOKEN}`))).toBeNull();
+  });
+
+  it("returns null when the token env var is unset (feature off)", () => {
+    delete process.env.YOPEDIA_SERVICE_TOKEN;
+    expect(getServicePrincipal(reqWith(`Bearer ${TOKEN}`))).toBeNull();
+  });
+
+  it("returns null when the principal handle env var is unset", () => {
+    delete process.env.YOPEDIA_SERVICE_PRINCIPAL;
+    expect(getServicePrincipal(reqWith(`Bearer ${TOKEN}`))).toBeNull();
+  });
+
+  it("does not accept an empty bearer token even if env token is empty", () => {
+    process.env.YOPEDIA_SERVICE_TOKEN = "";
+    expect(getServicePrincipal(reqWith("Bearer "))).toBeNull();
+  });
+});

--- a/src/lib/__tests__/seed-route.test.ts
+++ b/src/lib/__tests__/seed-route.test.ts
@@ -19,19 +19,22 @@ vi.mock("@/lib/agents", () => {
   };
 });
 
-// The route resolves the owner from the session principal.
+// The route resolves the owner from the session principal, falling back to a
+// service-token principal for automated (CI) seeding.
 vi.mock("@/lib/auth", () => ({
   getPrincipal: vi.fn(async () => ({ id: "test-user", handle: "test-user" })),
+  getServicePrincipal: vi.fn(() => null),
 }));
 
 import { seedAgent, assertCanMutateAgent, AgentOwnershipError } from "@/lib/agents";
-import { getPrincipal } from "@/lib/auth";
+import { getPrincipal, getServicePrincipal } from "@/lib/auth";
 import { POST } from "@/app/api/agents/seed/route";
 import type { AgentProfile } from "@/lib/types";
 
 const mockedSeedAgent = vi.mocked(seedAgent);
 const mockedAssertCanMutate = vi.mocked(assertCanMutateAgent);
 const mockedGetPrincipal = vi.mocked(getPrincipal);
+const mockedGetServicePrincipal = vi.mocked(getServicePrincipal);
 
 function makeRequest(body: unknown): NextRequest {
   return new NextRequest("http://localhost:3000/api/agents/seed", {
@@ -87,6 +90,8 @@ beforeEach(() => {
   mockedAssertCanMutate.mockResolvedValue(null);
   mockedGetPrincipal.mockReset();
   mockedGetPrincipal.mockResolvedValue({ id: "test-user", handle: "test-user" });
+  mockedGetServicePrincipal.mockReset();
+  mockedGetServicePrincipal.mockReturnValue(null);
 });
 
 // ---------------------------------------------------------------------------
@@ -121,11 +126,27 @@ describe("POST /api/agents/seed", () => {
   });
 
   describe("auth & ownership", () => {
-    it("returns 401 when there is no signed-in principal", async () => {
+    it("returns 401 when there is neither a session nor a service token", async () => {
       mockedGetPrincipal.mockResolvedValue(null);
+      mockedGetServicePrincipal.mockReturnValue(null);
       const res = await POST(makeRequest(validBody()));
       expect(res.status).toBe(401);
       expect(mockedSeedAgent).not.toHaveBeenCalled();
+    });
+
+    it("seeds via a service token when there is no session (CI path)", async () => {
+      mockedGetPrincipal.mockResolvedValue(null);
+      mockedGetServicePrincipal.mockReturnValue({
+        id: "service:yoyo-bot",
+        handle: "yoyo-bot",
+      });
+      const res = await POST(makeRequest(validBody()));
+      expect(res.status).toBe(201);
+      // The service principal's handle becomes the owner.
+      expect(mockedSeedAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ owner: "yoyo-bot" }),
+      );
+      expect(mockedAssertCanMutate).toHaveBeenCalledWith("yoyo", "yoyo-bot");
     });
 
     it("returns 403 when a non-owner tries to re-seed", async () => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -46,3 +46,57 @@ export async function getPrincipal(): Promise<Principal | null> {
   const user = await currentUser();
   return { id: userId, handle: resolveHandle(user) ?? userId };
 }
+
+// ---------------------------------------------------------------------------
+// Service principal — non-human write credential (scheduled jobs / CI)
+// ---------------------------------------------------------------------------
+//
+// A bearer token lets a trusted automated caller (e.g. the weekly
+// seed-yoyo GitHub Action) write WITHOUT a Clerk session. It is intentionally
+// narrow: only routes that opt in by calling getServicePrincipal() honor it,
+// and it resolves to ONE fixed principal handle (YOPEDIA_SERVICE_PRINCIPAL) so
+// everything it writes is attributed and owner-gated like any other user.
+//
+// Set both as Worker secrets:
+//   wrangler secret put YOPEDIA_SERVICE_TOKEN       (a long random string)
+//   wrangler secret put YOPEDIA_SERVICE_PRINCIPAL   (the handle it acts as)
+
+/** Extract the bearer token from an Authorization header, or null. */
+function bearerToken(header: string | null): string | null {
+  if (!header) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  return match ? match[1] : null;
+}
+
+/**
+ * Constant-time string comparison — avoids leaking the token via response
+ * timing. Length is allowed to short-circuit (the token is high-entropy, so a
+ * length difference is not a useful signal).
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/**
+ * Resolve a service principal from a request's bearer token, or `null`.
+ *
+ * Returns a principal ONLY when both `YOPEDIA_SERVICE_TOKEN` and
+ * `YOPEDIA_SERVICE_PRINCIPAL` are configured and the request presents the
+ * exact token. The principal's handle is the configured value, so writes are
+ * attributed/owned exactly like a human user with that handle.
+ */
+export function getServicePrincipal(req: Request): Principal | null {
+  const expected = process.env.YOPEDIA_SERVICE_TOKEN;
+  const handle = process.env.YOPEDIA_SERVICE_PRINCIPAL;
+  if (!expected || !handle) return null;
+
+  const provided = bearerToken(req.headers.get("authorization"));
+  if (!provided || !timingSafeEqual(provided, expected)) return null;
+
+  return { id: `service:${handle}`, handle };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,13 +6,24 @@ const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 // Closes the unauthenticated-write hole at a single enforcement point:
 // any mutating request to /api/** requires a signed-in user. Reads (GET/HEAD)
-// stay public — yopedia is a public observer surface (see DESIGN-identity.md).
+// stay public — yopedia is a public observer surface (see yopedia-concept.md).
 // Attribution (which user) is read per-route from `getPrincipal()`.
 //
+// Exception: /api/agents/seed authenticates IN-ROUTE because it accepts either
+// a Clerk session OR a service token (getServicePrincipal) for automated
+// re-seeding. It still rejects unauthenticated callers — the auth just lives in
+// the handler, not here — so this is not a hole.
+//
 // The MCP server is stdio-only and not exposed over HTTP, so it is unaffected.
+const IN_ROUTE_AUTH_PATHS = new Set(["/api/agents/seed"]);
+
 export default clerkMiddleware(async (auth, req) => {
   const { pathname } = req.nextUrl;
-  if (WRITE_METHODS.has(req.method) && pathname.startsWith("/api/")) {
+  if (
+    WRITE_METHODS.has(req.method) &&
+    pathname.startsWith("/api/") &&
+    !IN_ROUTE_AUTH_PATHS.has(pathname)
+  ) {
     const { userId } = await auth();
     if (!userId) {
       return NextResponse.json(


### PR DESCRIPTION
## What

Answers "can we use a GitHub Action to feed the yoyo seed, kept in sync as yoyo-evolve evolves?" — **yes**. Builds the missing primitive (a non-human write credential) and the weekly sync job.

### 1. Service token — the deferred "service/scheduled token"
- **`getServicePrincipal(req)`** (`src/lib/auth.ts`): resolves a bearer token via **constant-time compare** against the `YOPEDIA_SERVICE_TOKEN` Worker secret, attributing writes to the fixed `YOPEDIA_SERVICE_PRINCIPAL` handle. **Disabled unless both env vars are set.**
- **`/api/agents/seed` is exempted from the middleware write-gate** and authenticates *in-route*: **Clerk session OR service token**, else 401. Narrow blast radius — only the seed path honors the token; every other `/api` write still requires a Clerk session.
- Owner still comes from the resolved principal, **never the body**. `seedAgent` is idempotent and preserves ownership → re-seeds refresh content and keep the owner (the seed-once-reuse model from #287).

### 2. Weekly sync workflow (`.github/workflows/seed-yoyo.yml`)
- **Weekly cron + manual `workflow_dispatch`**.
- Checks out the **public** `yologdev/yoyo-evolve`, maps its canonical identity onto seed sections:
  - `IDENTITY.md` + `PERSONALITY.md` + `ECONOMICS.md` → **identity**
  - `memory/active_learnings.md` → **learnings**
  - `memory/active_social_learnings.md` → **social**
- Skips empty files, POSTs to `/api/agents/seed` with the token, fails on non-201.

## Tests
- `auth.test.ts` (new): `getServicePrincipal` — valid token, wrong token, length-mismatch (no partial match), missing/non-bearer header, feature-off when env unset.
- `seed-route.test.ts`: service-token path → 201 with `owner` = service handle; 401 when neither session nor token.

Full suite **2153 passing**; `next build` + `eslint` clean; workflow YAML + embedded script validated.

## Operator steps to activate (involve secrets — not done here)
1. **Worker secrets** (production):
   - `wrangler secret put YOPEDIA_SERVICE_TOKEN` — a long random string
   - `wrangler secret put YOPEDIA_SERVICE_PRINCIPAL` — the handle the yoyo will be owned by (e.g. your X handle)
2. **GitHub repo secret** `YOPEDIA_SERVICE_TOKEN` — the *same* value as the Worker secret.
3. **Deploy** the Worker (these middleware/route changes must be live before the token works).
4. **Run the workflow manually** once (`workflow_dispatch`) to perform the first seed; the weekly cron keeps it fresh after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)