### PR TITLE
feat(agents): interlink seeded agent pages into a connected graph cluster

### DIFF
--- a/src/lib/__tests__/agents.test.ts
+++ b/src/lib/__tests__/agents.test.ts
@@ -1211,3 +1211,41 @@ describe("resolveAgentPages", () => {
     expect(resolved.learningPages).toEqual(["alice-own-learning", "yoyo-learnings"]);
   });
 });
+
+describe("agent page interlinking", () => {
+  it("links sibling pages into a connected cluster (star, hub = first section)", async () => {
+    await seedAgent({
+      id: "yoyo",
+      name: "Yoyo",
+      description: "Base",
+      owner: "yopedia",
+      sections: [
+        { type: "identity", slug: "yoyo-identity", title: "yoyo — Identity", content: "id" },
+        { type: "learnings", slug: "yoyo-learnings", title: "yoyo — Learnings", content: "l" },
+        { type: "social", slug: "yoyo-social", title: "yoyo — Social", content: "s" },
+      ],
+    });
+
+    // Graph edges come from [text](slug.md) links. The hub links to each sibling…
+    const hub = await readWikiPage("yoyo-identity");
+    expect(hub!.content).toContain("](yoyo-learnings.md)");
+    expect(hub!.content).toContain("](yoyo-social.md)");
+
+    // …and each spoke links back to the hub (only).
+    const spoke = await readWikiPage("yoyo-learnings");
+    expect(spoke!.content).toContain("](yoyo-identity.md)");
+    expect(spoke!.content).not.toContain("](yoyo-social.md)");
+  });
+
+  it("adds no Related block for a single-section agent", async () => {
+    await seedAgent({
+      id: "solo",
+      name: "Solo",
+      description: "d",
+      owner: "yopedia",
+      sections: [{ type: "identity", slug: "solo-id", title: "Solo", content: "x" }],
+    });
+    const p = await readWikiPage("solo-id");
+    expect(p!.content).not.toContain("## Related");
+  });
+});

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -120,6 +120,27 @@ export function agentShortName(agent: AgentProfile): string {
   return agent.id.startsWith(prefix) ? agent.id.slice(prefix.length) : agent.id;
 }
 
+/**
+ * Build a "## Related" markdown block that links an agent section page to its
+ * siblings, so the agent's pages form a connected cluster in the wiki graph
+ * (graph edges come from `[text](slug.md)` links). Star topology: the hub (the
+ * first section) links to every other page, and every other page links back to
+ * the hub. Returns "" when there are no siblings to link.
+ */
+function relatedSectionLinks(
+  currentSlug: string,
+  hubSlug: string,
+  sections: SeedAgentSection[],
+): string {
+  const isHub = currentSlug === hubSlug;
+  const targets = sections.filter((s) =>
+    isHub ? s.slug !== hubSlug : s.slug === hubSlug && s.slug !== currentSlug,
+  );
+  if (targets.length === 0) return "";
+  const items = targets.map((s) => `- [${s.title}](${s.slug}.md)`).join("\n");
+  return `\n\n## Related\n\n${items}`;
+}
+
 // ---------------------------------------------------------------------------
 // Ownership
 // ---------------------------------------------------------------------------
@@ -532,6 +553,9 @@ export async function seedAgent(options: SeedAgentOptions): Promise<AgentProfile
   const learningPages: string[] = [];
   const socialPages: string[] = [];
 
+  // Hub for interlinking the agent's pages into one connected graph cluster.
+  const hubSlug = options.sections[0]?.slug ?? "";
+
   for (const section of options.sections) {
     // Build frontmatter for this page
     const frontmatter: Record<string, string | string[] | number | boolean> = {
@@ -562,8 +586,11 @@ export async function seedAgent(options: SeedAgentOptions): Promise<AgentProfile
       frontmatter.contributors = [options.id];
     }
 
-    // Assemble the full markdown: frontmatter + H1 title + content body
-    const bodyWithTitle = `# ${section.title}\n\n${section.content}`;
+    // Assemble the full markdown: frontmatter + H1 title + content body, plus a
+    // "Related" block linking sibling pages so the agent forms a connected
+    // cluster in the graph.
+    const related = relatedSectionLinks(section.slug, hubSlug, options.sections);
+    const bodyWithTitle = `# ${section.title}\n\n${section.content}${related}`;
     const fullContent = serializeFrontmatter(frontmatter, bodyWithTitle);
 
     // Extract a summary (first non-empty line of content, trimmed)


### PR DESCRIPTION
## What
Fixes the "lonely dots" in the graph: seeded yoyo identity pages were disconnected because `seedAgent` disables cross-ref (`crossRefSource: null`) and the yoyo-evolve source markdown has no wiki links — so they had zero graph edges.

Graph edges come from `[text](slug.md)` links, so `seedAgent` now appends a **"## Related"** block interlinking the agent's sections in a **star** topology: the first section (Identity) is the hub; every other section links to the hub, and the hub links to each. Result: the agent's pages form one connected cluster.

- Single-section agents get no Related block.
- Forks inherit the base's pages by reference, so the cluster shows for every user's yoyo.

This is option **A** from the graph discussion (cheap, deterministic, no LLM, keeps agent content as its own cluster rather than wiring into the general concept graph).

## Tests
Hub links to each sibling; spokes link only the hub; single-section agent has no Related block. Full suite **2203 passing**; build + lint clean.

## Note
After merge+deploy, the next weekly seed (or a manual `gh workflow run seed-yoyo.yml`) re-applies the links to the live `yopedia/yoyo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)