### PR TITLE
feat(agents): Phase C1 — "Share with yoyo" (feed-as-grant)

### DIFF
--- a/src/app/api/agents/[id]/context/route.ts
+++ b/src/app/api/agents/[id]/context/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getAgent, resolveAgentPages } from "@/lib/agents";
+import { getAgent, resolveAgentPages, sharedPagesFor } from "@/lib/agents";
 import { readWikiPageWithFrontmatter } from "@/lib/wiki";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
@@ -74,19 +74,26 @@ export async function GET(_req: Request, { params }: RouteParams) {
     }
 
     // Resolve effective pages (own + inherited from the template chain), so a
-    // forked per-user yoyo returns the base content it inherits.
+    // forked per-user yoyo returns the base content it inherits. Plus the pages
+    // the owner shared into this agent's context (grant references).
     const pages = await resolveAgentPages(agent);
+    const sharedSlugs = await sharedPagesFor(agent.id);
 
-    // Load all three context sections in parallel
-    const [identity, learnings, social] = await Promise.all([
+    // Load all context sections in parallel
+    const [identity, learnings, social, shared] = await Promise.all([
       loadPages(pages.identityPages),
       loadPages(pages.learningPages),
       loadPages(pages.socialPages),
+      loadPages(sharedSlugs),
     ]);
 
     const totalChars =
-      identity.content.length + learnings.content.length + social.content.length;
-    const pageCount = identity.count + learnings.count + social.count;
+      identity.content.length +
+      learnings.content.length +
+      social.content.length +
+      shared.content.length;
+    const pageCount =
+      identity.count + learnings.count + social.count + shared.count;
 
     return NextResponse.json({
       agent,
@@ -94,6 +101,7 @@ export async function GET(_req: Request, { params }: RouteParams) {
         identity: identity.content,
         learnings: learnings.content,
         socialWisdom: social.content,
+        shared: shared.content,
       },
       meta: {
         totalChars,

--- a/src/app/api/agents/share/route.ts
+++ b/src/app/api/agents/share/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import {
+  setPageShared,
+  agentIdFor,
+  DEFAULT_AGENT_NAME,
+} from "@/lib/agents";
+import { getPrincipal } from "@/lib/auth";
+import { readWikiPageWithFrontmatter } from "@/lib/wiki";
+import { getErrorMessage } from "@/lib/errors";
+
+/**
+ * Share / unshare one of YOUR pages into YOUR yoyo's context.
+ *
+ *   POST   /api/agents/share   { slug, agentName? }  → share
+ *   DELETE /api/agents/share   { slug, agentName? }  → unshare
+ *
+ * "Share" is a grant, not a copy: it tags the page's `sharedWith` frontmatter
+ * with the agent id. The target agent is derived from the session (you can only
+ * share into your OWN yoyo), and you can only share pages you own/contributed.
+ */
+async function handle(req: Request, shared: boolean) {
+  try {
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    let body: { slug?: unknown; agentName?: unknown };
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const slug = body?.slug;
+    if (!slug || typeof slug !== "string") {
+      return NextResponse.json(
+        { error: "Missing or invalid 'slug'" },
+        { status: 400 },
+      );
+    }
+
+    const page = await readWikiPageWithFrontmatter(slug).catch(() => null);
+    if (!page) {
+      return NextResponse.json(
+        { error: `Page "${slug}" not found` },
+        { status: 404 },
+      );
+    }
+
+    // You can only share pages you own or have contributed to.
+    const owner =
+      typeof page.frontmatter.owner === "string" ? page.frontmatter.owner : "";
+    const contributors = Array.isArray(page.frontmatter.contributors)
+      ? (page.frontmatter.contributors as string[])
+      : [];
+    if (owner !== principal.handle && !contributors.includes(principal.handle)) {
+      return NextResponse.json(
+        { error: "You can only share pages you own." },
+        { status: 403 },
+      );
+    }
+
+    // Target = the caller's own yoyo (derived from the session, not the body).
+    const name =
+      typeof body.agentName === "string" ? body.agentName : DEFAULT_AGENT_NAME;
+    const agentId = agentIdFor(principal.handle, name);
+
+    await setPageShared(slug, agentId, shared);
+    return NextResponse.json({ shared, slug, agentId });
+  } catch (err) {
+    return NextResponse.json({ error: getErrorMessage(err) }, { status: 500 });
+  }
+}
+
+export const POST = (req: Request) => handle(req, true);
+export const DELETE = (req: Request) => handle(req, false);

--- a/src/app/api/agents/share/route.ts
+++ b/src/app/api/agents/share/route.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/agents";
 import { getPrincipal } from "@/lib/auth";
 import { readWikiPageWithFrontmatter } from "@/lib/wiki";
-import { getErrorMessage } from "@/lib/errors";
+import { logger } from "@/lib/logger";
 
 /**
  * Share / unshare one of YOUR pages into YOUR yoyo's context.
@@ -40,7 +40,10 @@ async function handle(req: Request, shared: boolean) {
       );
     }
 
-    const page = await readWikiPageWithFrontmatter(slug).catch(() => null);
+    // No .catch: readWikiPage returns null for a genuinely missing page (→ 404);
+    // a malformed-frontmatter throw should fall through to the 500 (and be
+    // logged) rather than masquerade as "not found".
+    const page = await readWikiPageWithFrontmatter(slug);
     if (!page) {
       return NextResponse.json(
         { error: `Page "${slug}" not found` },
@@ -56,7 +59,7 @@ async function handle(req: Request, shared: boolean) {
       : [];
     if (owner !== principal.handle && !contributors.includes(principal.handle)) {
       return NextResponse.json(
-        { error: "You can only share pages you own." },
+        { error: "You can only share pages you own or contributed to." },
         { status: 403 },
       );
     }
@@ -69,7 +72,12 @@ async function handle(req: Request, shared: boolean) {
     await setPageShared(slug, agentId, shared);
     return NextResponse.json({ shared, slug, agentId });
   } catch (err) {
-    return NextResponse.json({ error: getErrorMessage(err) }, { status: 500 });
+    // This is the only place a real write/parse failure is observable — log it.
+    logger.error("agents", "share toggle failed:", err);
+    return NextResponse.json(
+      { error: "Failed to update sharing." },
+      { status: 500 },
+    );
   }
 }
 

--- a/src/app/u/[handle]/a/[agent]/page.tsx
+++ b/src/app/u/[handle]/a/[agent]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getAgentByOwnerName, resolveAgentPages } from "@/lib/agents";
+import { getAgentByOwnerName, resolveAgentPages, sharedPagesFor } from "@/lib/agents";
 import { listWikiPages } from "@/lib/wiki";
 import { decodeSlug } from "@/lib/slugify";
 import { getErrorMessage } from "@/lib/errors";
@@ -33,8 +33,10 @@ export default async function AgentProfilePage({
   }
   if (!agent) notFound();
 
-  // Effective pages = own + inherited from the template chain (the base yoyo).
+  // Effective pages = own + inherited from the template chain (the base yoyo),
+  // plus pages the owner shared into this agent's context.
   const resolved = await resolveAgentPages(agent);
+  const sharedSlugs = await sharedPagesFor(agent.id);
 
   // Resolve slug -> title from the index for nicer links (fall back to slug).
   const index = await listWikiPages();
@@ -44,6 +46,7 @@ export default async function AgentProfilePage({
     { label: "Identity", slugs: resolved.identityPages },
     { label: "Learnings", slugs: resolved.learningPages },
     { label: "Social wisdom", slugs: resolved.socialPages },
+    { label: "Shared by owner", slugs: sharedSlugs },
   ];
   const totalPages = sections.reduce((n, s) => n + s.slugs.length, 0);
 

--- a/src/app/wiki/[slug]/page.tsx
+++ b/src/app/wiki/[slug]/page.tsx
@@ -6,6 +6,9 @@ import type { SourceEntry } from "@/lib/types";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { DeletePageButton } from "@/components/DeletePageButton";
 import { ReingestButton } from "@/components/ReingestButton";
+import { ShareWithYoyoButton } from "@/components/ShareWithYoyoButton";
+import { getPrincipal } from "@/lib/auth";
+import { agentIdFor, DEFAULT_AGENT_NAME } from "@/lib/agents";
 import { RevisionHistory } from "@/components/RevisionHistory";
 import { DiscussionPanel } from "@/components/DiscussionPanel";
 import { AuthorBadges } from "@/components/AuthorBadges";
@@ -458,6 +461,26 @@ export default async function WikiPageView({ params }: WikiPageProps) {
     typeof page.frontmatter.source_url === "string" &&
     page.frontmatter.source_url.trim().length > 0;
 
+  // "Share with yoyo" is shown only to the page's owner/contributor, and we
+  // pre-compute whether it's already shared into their yoyo.
+  const principal = await getPrincipal();
+  const pageOwner =
+    typeof page.frontmatter.owner === "string" ? page.frontmatter.owner : "";
+  const pageContributors = Array.isArray(page.frontmatter.contributors)
+    ? (page.frontmatter.contributors as string[])
+    : [];
+  const canShare =
+    !!principal &&
+    (pageOwner === principal.handle ||
+      pageContributors.includes(principal.handle));
+  const myYoyoId = principal
+    ? agentIdFor(principal.handle, DEFAULT_AGENT_NAME)
+    : "";
+  const alreadyShared =
+    !!myYoyoId &&
+    Array.isArray(page.frontmatter.sharedWith) &&
+    (page.frontmatter.sharedWith as string[]).includes(myYoyoId);
+
   return (
     <main className="mx-auto max-w-3xl px-6 py-12">
       <Link
@@ -500,6 +523,9 @@ export default async function WikiPageView({ params }: WikiPageProps) {
           Edit page
         </Link>
         {hasSourceUrl && <ReingestButton slug={slug} />}
+        {canShare && (
+          <ShareWithYoyoButton slug={slug} initiallyShared={alreadyShared} />
+        )}
         <DeletePageButton slug={slug} />
       </div>
     </main>

--- a/src/components/ShareWithYoyoButton.tsx
+++ b/src/components/ShareWithYoyoButton.tsx
@@ -13,7 +13,8 @@ interface ShareWithYoyoButtonProps {
  * Toggles whether one of your own pages is shared into your yoyo's context.
  * "Share" is a grant (read-access reference), not a copy — the page stays
  * yours and unchanged; your yoyo just also sees it. Rendered only for the
- * page's owner (the server gates this and re-checks ownership on the request).
+ * page's owner or a contributor (the server gates this and re-checks the same
+ * owner/contributor condition on the request).
  */
 export function ShareWithYoyoButton({
   slug,

--- a/src/components/ShareWithYoyoButton.tsx
+++ b/src/components/ShareWithYoyoButton.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface ShareWithYoyoButtonProps {
+  slug: string;
+  /** Whether this page is already shared into the viewer's yoyo. */
+  initiallyShared: boolean;
+}
+
+/**
+ * Toggles whether one of your own pages is shared into your yoyo's context.
+ * "Share" is a grant (read-access reference), not a copy — the page stays
+ * yours and unchanged; your yoyo just also sees it. Rendered only for the
+ * page's owner (the server gates this and re-checks ownership on the request).
+ */
+export function ShareWithYoyoButton({
+  slug,
+  initiallyShared,
+}: ShareWithYoyoButtonProps) {
+  const router = useRouter();
+  const [shared, setShared] = useState(initiallyShared);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function toggle() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/agents/share", {
+        method: shared ? "DELETE" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `request failed (${res.status})`);
+      }
+      setShared(!shared);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={busy}
+        className="rounded-md border border-foreground/20 px-4 py-2 text-sm font-medium text-foreground hover:bg-foreground/5 transition-colors disabled:opacity-50"
+        title={
+          shared
+            ? "Stop sharing this page with your yoyo"
+            : "Share this page into your yoyo's context"
+        }
+      >
+        {shared ? "✓ Shared with yoyo" : "Share with yoyo"}
+      </button>
+      {error && <span className="text-xs text-red-600 dark:text-red-400">{error}</span>}
+    </span>
+  );
+}

--- a/src/lib/__tests__/agents.test.ts
+++ b/src/lib/__tests__/agents.test.ts
@@ -1296,4 +1296,36 @@ describe("sharing (feed-as-grant via sharedWith)", () => {
   it("throws for a missing page", async () => {
     await expect(setPageShared("nope", "alice--yoyo", true)).rejects.toThrow();
   });
+
+  it("preserves body and other frontmatter through the share/unshare round-trip", async () => {
+    await writeUserPage("alice-note", "alice");
+
+    await setPageShared("alice-note", "alice--yoyo", true);
+    let page = await readWikiPageWithFrontmatter("alice-note");
+    expect(page!.body).toContain("Some content."); // body intact
+    expect(page!.frontmatter.owner).toBe("alice"); // other keys intact
+    expect(page!.frontmatter.contributors).toEqual(["alice"]);
+    expect(page!.frontmatter.sharedWith).toEqual(["alice--yoyo"]);
+
+    await setPageShared("alice-note", "alice--yoyo", false);
+    page = await readWikiPageWithFrontmatter("alice-note");
+    expect(page!.body).toContain("Some content.");
+    expect(page!.frontmatter.owner).toBe("alice");
+    // The key is fully removed once empty (not left as []).
+    expect(page!.frontmatter.sharedWith).toBeUndefined();
+  });
+
+  it("appends/removes one agent without clobbering other grants", async () => {
+    await writeUserPage("alice-note", "alice");
+    await setPageShared("alice-note", "bob--yoyo", true);
+    await setPageShared("alice-note", "alice--yoyo", true);
+
+    let page = await readWikiPageWithFrontmatter("alice-note");
+    expect(page!.frontmatter.sharedWith).toEqual(["bob--yoyo", "alice--yoyo"]);
+
+    // Removing one leaves the other.
+    await setPageShared("alice-note", "alice--yoyo", false);
+    page = await readWikiPageWithFrontmatter("alice-note");
+    expect(page!.frontmatter.sharedWith).toEqual(["bob--yoyo"]);
+  });
 })

--- a/src/lib/__tests__/agents.test.ts
+++ b/src/lib/__tests__/agents.test.ts
@@ -19,9 +19,13 @@ import {
   agentShortName,
   forkAgent,
   resolveAgentPages,
+  sharedPagesFor,
+  setPageShared,
 } from "../agents";
 import type { UpdateAgentPage } from "../agents";
 import { readWikiPage, readWikiPageWithFrontmatter } from "../wiki";
+import { writeWikiPageWithSideEffects } from "../lifecycle";
+import { serializeFrontmatter } from "../frontmatter";
 import type { AgentProfile } from "../types";
 import { _resetStorage, getStorage } from "../storage";
 
@@ -1249,3 +1253,47 @@ describe("agent page interlinking", () => {
     expect(p!.content).not.toContain("## Related");
   });
 });
+
+describe("sharing (feed-as-grant via sharedWith)", () => {
+  async function writeUserPage(slug: string, owner: string) {
+    const content = serializeFrontmatter(
+      { owner, authors: [owner], contributors: [owner] },
+      `# ${slug}\n\nSome content.`,
+    );
+    await writeWikiPageWithSideEffects({
+      slug,
+      title: slug,
+      content,
+      summary: "s",
+      logOp: "other",
+      crossRefSource: null,
+      author: owner,
+    });
+  }
+
+  it("shares and unshares a page into an agent's context", async () => {
+    await writeUserPage("alice-note", "alice");
+    expect(await sharedPagesFor("alice--yoyo")).toEqual([]);
+
+    await setPageShared("alice-note", "alice--yoyo", true);
+    expect(await sharedPagesFor("alice--yoyo")).toEqual(["alice-note"]);
+
+    // Idempotent — sharing again is a no-op.
+    await setPageShared("alice-note", "alice--yoyo", true);
+    expect(await sharedPagesFor("alice--yoyo")).toEqual(["alice-note"]);
+
+    await setPageShared("alice-note", "alice--yoyo", false);
+    expect(await sharedPagesFor("alice--yoyo")).toEqual([]);
+  });
+
+  it("grants are scoped to one agent (no cross-leak)", async () => {
+    await writeUserPage("alice-note", "alice");
+    await setPageShared("alice-note", "alice--yoyo", true);
+    expect(await sharedPagesFor("alice--yoyo")).toEqual(["alice-note"]);
+    expect(await sharedPagesFor("bob--yoyo")).toEqual([]);
+  });
+
+  it("throws for a missing page", async () => {
+    await expect(setPageShared("nope", "alice--yoyo", true)).rejects.toThrow();
+  });
+})

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../search";
 import type { SearchScope } from "../search";
 import { registerAgent, ensureAgentsDir } from "../agents";
+import { serializeFrontmatter } from "../frontmatter";
 import type { AgentProfile } from "../types";
 import { _resetStorage } from "../storage";
 
@@ -684,6 +685,38 @@ describe("resolveScope", () => {
     await ensureAgentsDir();
     const result = await resolveScope("agent:nonexistent");
     expect(result).toBeNull();
+  });
+
+  it("includes pages the owner shared into the agent (sharedWith)", async () => {
+    await ensureAgentsDir();
+    await registerAgent(
+      makeProfile({
+        id: "alice--yoyo",
+        owner: "alice",
+        identityPages: ["yoyo-identity"],
+        learningPages: [],
+        socialPages: [],
+      }),
+    );
+    // A separate page the owner shared into their yoyo via the frontmatter
+    // label. It must be in the index for the sharedWith scan to see it.
+    await writeWikiPage(
+      "alice-note",
+      serializeFrontmatter(
+        { owner: "alice", sharedWith: ["alice--yoyo"] },
+        "# Note\n\nShared knowledge.",
+      ),
+    );
+    await writeWikiPage(
+      "index",
+      "# Index\n\n- [Note](alice-note.md) — Shared knowledge.",
+    );
+
+    const result = await resolveScope("agent:alice--yoyo");
+    expect(result).not.toBeNull();
+    expect(result!.slugs).toEqual(
+      expect.arrayContaining(["yoyo-identity", "alice-note"]),
+    );
   });
 
   it("resolves a fork to its INHERITED (template) pages", async () => {

--- a/src/lib/__tests__/share-route.test.ts
+++ b/src/lib/__tests__/share-route.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/agents", () => ({
+  setPageShared: vi.fn(),
+  agentIdFor: (owner: string, name = "yoyo") => `${owner}--${name}`,
+  DEFAULT_AGENT_NAME: "yoyo",
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getPrincipal: vi.fn(async () => ({ id: "alice", handle: "alice" })),
+}));
+
+vi.mock("@/lib/wiki", () => ({
+  readWikiPageWithFrontmatter: vi.fn(),
+}));
+
+import { setPageShared } from "@/lib/agents";
+import { getPrincipal } from "@/lib/auth";
+import { readWikiPageWithFrontmatter } from "@/lib/wiki";
+import { POST, DELETE } from "@/app/api/agents/share/route";
+
+const mockedShare = vi.mocked(setPageShared);
+const mockedGetPrincipal = vi.mocked(getPrincipal);
+const mockedReadPage = vi.mocked(readWikiPageWithFrontmatter);
+
+function req(body: unknown): Request {
+  return new Request("http://localhost/api/agents/share", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/** A page owned by `owner` (with optional contributors). */
+function pageOwnedBy(owner: string, contributors: string[] = []) {
+  return {
+    slug: "alice-note",
+    frontmatter: { owner, contributors },
+    body: "# alice-note\n\nx",
+  } as unknown as Awaited<ReturnType<typeof readWikiPageWithFrontmatter>>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetPrincipal.mockResolvedValue({ id: "alice", handle: "alice" });
+  mockedReadPage.mockResolvedValue(pageOwnedBy("alice"));
+  mockedShare.mockResolvedValue();
+});
+
+describe("POST/DELETE /api/agents/share", () => {
+  it("shares your own page into your yoyo (owner-derived agent id)", async () => {
+    const res = await POST(req({ slug: "alice-note" }));
+    expect(res.status).toBe(200);
+    expect(mockedShare).toHaveBeenCalledWith("alice-note", "alice--yoyo", true);
+  });
+
+  it("DELETE unshares", async () => {
+    const res = await DELETE(req({ slug: "alice-note" }));
+    expect(res.status).toBe(200);
+    expect(mockedShare).toHaveBeenCalledWith("alice-note", "alice--yoyo", false);
+  });
+
+  it("allows a contributor to share", async () => {
+    mockedReadPage.mockResolvedValue(pageOwnedBy("bob", ["alice"]));
+    const res = await POST(req({ slug: "alice-note" }));
+    expect(res.status).toBe(200);
+    expect(mockedShare).toHaveBeenCalled();
+  });
+
+  it("returns 401 when signed out", async () => {
+    mockedGetPrincipal.mockResolvedValue(null);
+    const res = await POST(req({ slug: "alice-note" }));
+    expect(res.status).toBe(401);
+    expect(mockedShare).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when you don't own the page", async () => {
+    mockedReadPage.mockResolvedValue(pageOwnedBy("bob"));
+    const res = await POST(req({ slug: "alice-note" }));
+    expect(res.status).toBe(403);
+    expect(mockedShare).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the page doesn't exist", async () => {
+    mockedReadPage.mockResolvedValue(null);
+    const res = await POST(req({ slug: "ghost" }));
+    expect(res.status).toBe(404);
+    expect(mockedShare).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when slug is missing", async () => {
+    const res = await POST(req({}));
+    expect(res.status).toBe(400);
+    expect(mockedShare).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -15,7 +15,7 @@ import { isEnoent } from "./errors";
 import { serializeFrontmatter } from "./frontmatter";
 import { slugify } from "./slugify";
 import { writeWikiPageWithSideEffects } from "./lifecycle";
-import { readWikiPageWithFrontmatter } from "./wiki";
+import { readWikiPageWithFrontmatter, listWikiPages, writeWikiPage } from "./wiki";
 import type { AgentProfile } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -139,6 +139,74 @@ function relatedSectionLinks(
   if (targets.length === 0) return "";
   const items = targets.map((s) => `- [${s.title}](${s.slug}.md)`).join("\n");
   return `\n\n## Related\n\n${items}`;
+}
+
+// ---------------------------------------------------------------------------
+// Sharing — "Share with yoyo" (feed-as-grant, recorded on the page)
+// ---------------------------------------------------------------------------
+//
+// A user shares one of their own pages INTO their agent's context by tagging
+// the page's frontmatter with `sharedWith: [<agentId>]`. This is a grant
+// (read-access reference), not a copy: the page stays the owner's and unchanged
+// in the wiki; the agent just also sees it. The relationship lives on the page
+// (like `owner`/`contributors`), so it self-cleans on delete and is found by a
+// frontmatter scan — and it does NOT inherit down the template chain (your
+// grants are yours, not the base's).
+
+/**
+ * Slugs the owner has shared into an agent's context (frontmatter `sharedWith`
+ * scan). Mirrors the personal-lens scan in {@link slugsForOwner}.
+ */
+export async function sharedPagesFor(agentId: string): Promise<string[]> {
+  const pages = await listWikiPages();
+  const out: string[] = [];
+  for (const entry of pages) {
+    if (entry.slug === "index" || entry.slug === "log") continue;
+    const page = await readWikiPageWithFrontmatter(entry.slug).catch(() => null);
+    if (!page) continue;
+    const shared = Array.isArray(page.frontmatter.sharedWith)
+      ? (page.frontmatter.sharedWith as string[])
+      : [];
+    if (shared.includes(agentId)) out.push(entry.slug);
+  }
+  return out;
+}
+
+/**
+ * Add or remove an agent id from a page's `sharedWith` frontmatter. A no-op if
+ * the page is already in the requested state. Frontmatter-only write (the body
+ * is untouched), so no re-synthesis or re-embedding — just a cheap revision.
+ *
+ * Ownership/authorization is enforced by the caller (the route checks both that
+ * the actor owns the page and owns the target agent).
+ */
+export async function setPageShared(
+  slug: string,
+  agentId: string,
+  shared: boolean,
+): Promise<void> {
+  const page = await readWikiPageWithFrontmatter(slug);
+  if (!page) throw new Error(`Page "${slug}" not found`);
+
+  const current = Array.isArray(page.frontmatter.sharedWith)
+    ? (page.frontmatter.sharedWith as string[])
+    : [];
+  if (current.includes(agentId) === shared) return; // already in desired state
+
+  const next = shared
+    ? [...current, agentId]
+    : current.filter((a) => a !== agentId);
+
+  const frontmatter = { ...page.frontmatter };
+  if (next.length > 0) frontmatter.sharedWith = next;
+  else delete frontmatter.sharedWith;
+
+  await writeWikiPage(
+    slug,
+    serializeFrontmatter(frontmatter, page.body),
+    agentId,
+    shared ? "shared with agent" : "unshared from agent",
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -162,7 +162,11 @@ export async function sharedPagesFor(agentId: string): Promise<string[]> {
   const out: string[] = [];
   for (const entry of pages) {
     if (entry.slug === "index" || entry.slug === "log") continue;
-    const page = await readWikiPageWithFrontmatter(entry.slug).catch(() => null);
+    // No .catch here — readWikiPage already returns null for missing/ENOENT,
+    // so the only thing a catch would swallow is a malformed-frontmatter throw.
+    // Let that propagate (same as slugsForOwner) rather than silently dropping
+    // a shared page from the agent's context.
+    const page = await readWikiPageWithFrontmatter(entry.slug);
     if (!page) continue;
     const shared = Array.isArray(page.frontmatter.sharedWith)
       ? (page.frontmatter.sharedWith as string[])
@@ -177,8 +181,9 @@ export async function sharedPagesFor(agentId: string): Promise<string[]> {
  * the page is already in the requested state. Frontmatter-only write (the body
  * is untouched), so no re-synthesis or re-embedding — just a cheap revision.
  *
- * Ownership/authorization is enforced by the caller (the route checks both that
- * the actor owns the page and owns the target agent).
+ * Ownership/authorization is enforced by the caller: the route checks the actor
+ * owns/contributed to the page, and derives the target agent from the session so
+ * it is necessarily the actor's own yoyo.
  */
 export async function setPageShared(
   slug: string,

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -13,7 +13,7 @@ import {
   wikiRelPath,
 } from "./wiki";
 import { isEnoent } from "./errors";
-import { getAgent, resolveAgentPages } from "./agents";
+import { getAgent, resolveAgentPages, sharedPagesFor } from "./agents";
 import { getStorage } from "./storage";
 
 // ---------------------------------------------------------------------------
@@ -557,12 +557,17 @@ export async function resolveScope(
     if (!agent) return null;
 
     // Effective pages = own + inherited from the template chain, so an
-    // `agent:<fork>` scope also searches the base content the fork inherits.
+    // `agent:<fork>` scope also searches the base content the fork inherits,
+    // plus any pages the owner shared into this agent's context.
     const pages = await resolveAgentPages(agent);
+    const sharedSlugs = await sharedPagesFor(agent.id);
     const slugs = [
-      ...pages.identityPages,
-      ...pages.learningPages,
-      ...pages.socialPages,
+      ...new Set([
+        ...pages.identityPages,
+        ...pages.learningPages,
+        ...pages.socialPages,
+        ...sharedSlugs,
+      ]),
     ];
 
     return { agentId: agent.id, slugs };


### PR DESCRIPTION
## What
"I send content to yoyo" from the design chat. Lets a user **share one of their own pages into their yoyo's context** — a **grant** (read-access reference), not a copy. The page stays yours and unchanged in the wiki; your yoyo just also sees it.

Implements the **label** approach we agreed on:
- The relationship is a **`sharedWith: [<agentId>]` frontmatter label** on the page (like `owner`/`contributors`) — so it **self-cleans on delete**, is found by a frontmatter scan (mirroring the personal-lens `slugsForOwner`), and **doesn't inherit** down the template chain (your grants are yours, not the base's).
- Owned pages stay as **lists** on the `AgentProfile` (needed for `template` inheritance); grants are the **label**. Clean split.

## How
- **`agents.ts`**: `sharedPagesFor(agentId)` (scan) + `setPageShared(slug, agentId, bool)` (frontmatter-only write — **no re-synthesis/embedding**, just a cheap revision).
- **`POST`/`DELETE /api/agents/share { slug }`** — target agent is **derived from the session** (you can only share into *your own* yoyo); you can only share pages **you own/contributed**. → 401 signed-out, 403 not-your-page, 404 missing.
- **"Share with yoyo"** button on `/wiki/<slug>`, shown only to the page's owner, reflecting + toggling shared state.
- Shared pages surface in the **agent profile** ("Shared by owner"), the **context endpoint**, and the **`agent:` search scope**.

## Decisions locked (from the design chat)
- **Verb:** "Share" (grant semantics; avoids the "All feed" clash). 
- **D2:** only your own pages — "shared knowledge between me and my agent."
- **D3:** agent content public + scoped (unchanged here — that's C2's ingest).
- **Label over list** for grants.

## Tests
Lib: share/unshare/idempotent, per-agent scoping (no cross-leak), missing-page throw. Route: 200/401/403/404/400 + contributor-allowed + owner-derived agent id. Full suite **2213 passing**; build + lint clean.

## Next
**C2 — agent self-ingest** ("yoyo ingests content"): owner-triggered ingest scoped to the agent (public-but-scoped, into its `learningPages`). Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)