### PR TITLE
feat(agents): Phase C2 — per-agent credentials + agent self-ingest

### DIFF
--- a/src/app/api/agents/[id]/context/route.ts
+++ b/src/app/api/agents/[id]/context/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getAgent, resolveAgentPages, sharedPagesFor } from "@/lib/agents";
+import { getAgent, resolveAgentPages, sharedPagesFor, publicAgent } from "@/lib/agents";
 import { readWikiPageWithFrontmatter } from "@/lib/wiki";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
@@ -96,7 +96,7 @@ export async function GET(_req: Request, { params }: RouteParams) {
       identity.count + learnings.count + social.count + shared.count;
 
     return NextResponse.json({
-      agent,
+      agent: publicAgent(agent),
       context: {
         identity: identity.content,
         learnings: learnings.content,

--- a/src/app/api/agents/[id]/ingest/route.ts
+++ b/src/app/api/agents/[id]/ingest/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { verifyAgentToken, addAgentLearningPage } from "@/lib/agents";
-import { ingestUrl, ingest } from "@/lib/ingest";
+import { ingestUrl, ingest, type IngestOptions } from "@/lib/ingest";
 import { logger } from "@/lib/logger";
 
 interface RouteParams {
@@ -67,7 +67,7 @@ export async function POST(req: Request, { params }: RouteParams) {
     }
 
     // Ingest as the agent: scoped type, attributed to the agent.
-    const opts = {
+    const opts: IngestOptions = {
       author: id,
       owner: id,
       triggeredBy: id,

--- a/src/app/api/agents/[id]/ingest/route.ts
+++ b/src/app/api/agents/[id]/ingest/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+import { verifyAgentToken, addAgentLearningPage } from "@/lib/agents";
+import { ingestUrl, ingest } from "@/lib/ingest";
+import { logger } from "@/lib/logger";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/** Page `type` that marks ingested content as the agent's scoped knowledge. */
+const AGENT_KNOWLEDGE_TYPE = "agent-knowledge";
+
+/**
+ * POST /api/agents/[id]/ingest — the agent ingests a source into its OWN
+ * knowledge.
+ *
+ * Authenticated by the **agent's token** (Authorization: Bearer ...), NOT a
+ * human session — so an external runtime (e.g. openclaw) can ingest as the
+ * agent. The token is self-scoping: it can only ingest into the agent whose id
+ * it carries (mismatch → 403). This route is exempt from the middleware
+ * write-gate because it uses a token instead of Clerk.
+ *
+ * Body: { url } or { text, title? }. The resulting page is scoped
+ * (`type: agent-knowledge`, authored/owned by the agent) and appended to the
+ * agent's learnings, so it surfaces under the agent profile and `agent:` scope
+ * but not in the public feed or general search.
+ */
+export async function POST(req: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+
+    const bearer = req.headers
+      .get("authorization")
+      ?.match(/^Bearer\s+(.+)$/i)?.[1];
+    if (!bearer) {
+      return NextResponse.json(
+        { error: "Agent token required (Authorization: Bearer <token>)." },
+        { status: 401 },
+      );
+    }
+    const tokenAgentId = await verifyAgentToken(bearer);
+    if (!tokenAgentId) {
+      return NextResponse.json({ error: "Invalid agent token." }, { status: 401 });
+    }
+    if (tokenAgentId !== id) {
+      return NextResponse.json(
+        { error: "This token does not authenticate that agent." },
+        { status: 403 },
+      );
+    }
+
+    let body: { url?: unknown; text?: unknown; title?: unknown };
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const url = typeof body.url === "string" ? body.url.trim() : "";
+    const text = typeof body.text === "string" ? body.text : "";
+    const title = typeof body.title === "string" ? body.title : "";
+    if (!url && !text) {
+      return NextResponse.json(
+        { error: "Provide a 'url' or 'text' to ingest." },
+        { status: 400 },
+      );
+    }
+
+    // Ingest as the agent: scoped type, attributed to the agent.
+    const opts = {
+      author: id,
+      owner: id,
+      triggeredBy: id,
+      pageType: AGENT_KNOWLEDGE_TYPE,
+    };
+    const result = url
+      ? await ingestUrl(url, opts)
+      : await ingest(title || "Untitled", text, opts);
+
+    // Attach the ingested page to the agent's own learnings.
+    await addAgentLearningPage(id, result.primarySlug);
+
+    return NextResponse.json({
+      slug: result.primarySlug,
+      deduped: result.deduped ?? false,
+    });
+  } catch (err) {
+    logger.error("agents", "agent ingest failed:", err);
+    return NextResponse.json({ error: "Ingest failed." }, { status: 500 });
+  }
+}

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -5,6 +5,7 @@ import {
   updateAgent,
   assertCanMutateAgent,
   AgentOwnershipError,
+  publicAgent,
 } from "@/lib/agents";
 import type { UpdateAgentOptions } from "@/lib/agents";
 import { getPrincipal } from "@/lib/auth";
@@ -38,7 +39,7 @@ export async function GET(_req: Request, { params }: RouteParams) {
       );
     }
 
-    return NextResponse.json({ agent });
+    return NextResponse.json({ agent: publicAgent(agent) });
   } catch (err) {
     const message = getErrorMessage(err);
     if (message.includes("Invalid agent ID")) {
@@ -160,7 +161,7 @@ export async function PUT(req: Request, { params }: RouteParams) {
       );
     }
 
-    return NextResponse.json({ agent: updated });
+    return NextResponse.json({ agent: publicAgent(updated) });
   } catch (err) {
     if (err instanceof AgentOwnershipError) {
       return NextResponse.json({ error: err.message }, { status: 403 });

--- a/src/app/api/agents/[id]/token/route.ts
+++ b/src/app/api/agents/[id]/token/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import {
+  generateAgentToken,
+  revokeAgentToken,
+  assertCanMutateAgent,
+  AgentOwnershipError,
+} from "@/lib/agents";
+import { getPrincipal } from "@/lib/auth";
+import { logger } from "@/lib/logger";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * POST /api/agents/[id]/token — generate (or rotate) the agent's credential.
+ *
+ * Owner-gated (Clerk session). Returns the raw token **once** — only its hash is
+ * stored, so it can't be retrieved later (rotate to get a new one). The owner
+ * pastes this into an external runtime (e.g. openclaw) to ingest as the agent.
+ */
+export async function POST(_req: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    const existing = await assertCanMutateAgent(id, principal.handle);
+    if (!existing) {
+      return NextResponse.json(
+        { error: `Agent "${id}" not found` },
+        { status: 404 },
+      );
+    }
+    const token = await generateAgentToken(id);
+    return NextResponse.json({ token });
+  } catch (err) {
+    if (err instanceof AgentOwnershipError) {
+      return NextResponse.json({ error: err.message }, { status: 403 });
+    }
+    logger.error("agents", "token generate failed:", err);
+    return NextResponse.json(
+      { error: "Failed to generate token." },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * DELETE /api/agents/[id]/token — revoke the agent's credential. Owner-gated.
+ */
+export async function DELETE(_req: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    const existing = await assertCanMutateAgent(id, principal.handle);
+    if (!existing) {
+      return NextResponse.json(
+        { error: `Agent "${id}" not found` },
+        { status: 404 },
+      );
+    }
+    await revokeAgentToken(id);
+    return NextResponse.json({ revoked: true });
+  } catch (err) {
+    if (err instanceof AgentOwnershipError) {
+      return NextResponse.json({ error: err.message }, { status: 403 });
+    }
+    logger.error("agents", "token revoke failed:", err);
+    return NextResponse.json(
+      { error: "Failed to revoke token." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/agents/ensure/route.ts
+++ b/src/app/api/agents/ensure/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { forkAgent, baseAgentId } from "@/lib/agents";
+import { forkAgent, baseAgentId, publicAgent } from "@/lib/agents";
 import { getPrincipal } from "@/lib/auth";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
@@ -33,7 +33,7 @@ export async function POST() {
       return NextResponse.json({ provisioned: false });
     }
 
-    return NextResponse.json({ agent, provisioned: true });
+    return NextResponse.json({ agent: publicAgent(agent), provisioned: true });
   } catch (err) {
     // The client's auto-ping ignores the body, so this is the only place a real
     // provisioning failure is observable — log it before returning 500.

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -84,7 +84,7 @@ export async function POST(req: Request) {
     };
 
     await registerAgent(profile);
-    return NextResponse.json({ agent: profile }, { status: 201 });
+    return NextResponse.json({ agent: publicAgent(profile) }, { status: 201 });
   } catch (err) {
     const message = getErrorMessage(err);
     // Surface validation errors from the lib layer as 400s

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { listAgents, registerAgent, getAgent } from "@/lib/agents";
+import { listAgents, registerAgent, getAgent, publicAgent } from "@/lib/agents";
 import { getPrincipal } from "@/lib/auth";
 import { getErrorMessage } from "@/lib/errors";
 import type { AgentProfile } from "@/lib/types";
@@ -12,7 +12,7 @@ import type { AgentProfile } from "@/lib/types";
 export async function GET() {
   try {
     const agents = await listAgents();
-    return NextResponse.json({ agents });
+    return NextResponse.json({ agents: agents.map(publicAgent) });
   } catch (err) {
     const message = getErrorMessage(err);
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/api/agents/seed/route.ts
+++ b/src/app/api/agents/seed/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { seedAgent, assertCanMutateAgent, AgentOwnershipError, agentIdFor } from "@/lib/agents";
+import { seedAgent, assertCanMutateAgent, AgentOwnershipError, agentIdFor, publicAgent } from "@/lib/agents";
 import { getPrincipal, getServicePrincipal } from "@/lib/auth";
 import { getErrorMessage } from "@/lib/errors";
 
@@ -114,7 +114,7 @@ export async function POST(req: Request) {
       sections,
     });
 
-    return NextResponse.json({ agent: profile }, { status: 201 });
+    return NextResponse.json({ agent: publicAgent(profile) }, { status: 201 });
   } catch (err) {
     if (err instanceof AgentOwnershipError) {
       return NextResponse.json({ error: err.message }, { status: 403 });

--- a/src/app/api/wiki/route.ts
+++ b/src/app/api/wiki/route.ts
@@ -5,6 +5,7 @@ import {
   listWikiPages,
   serializeFrontmatter,
   writeWikiPageWithSideEffects,
+  isAgentScopedType,
   type Frontmatter,
 } from "@/lib/wiki";
 import { extractSummary } from "@/lib/ingest";
@@ -17,9 +18,9 @@ import { getErrorMessage } from "@/lib/errors";
  * Lightweight list of all wiki pages (slug, title, summary).
  * Much cheaper than /api/wiki/graph which reads every page and builds a link graph.
  *
- * By default, pages with `type: agent-identity` are excluded from the response
- * so the main feed stays human-centric. Pass `?includeAgentPages=true` to
- * include them (used by agent profile pages and admin views).
+ * By default, agent-scoped pages (`type: agent-*` — identity, knowledge, …) are
+ * excluded from the response so the main feed stays human-centric. Pass
+ * `?includeAgentPages=true` to include them (used by agent profile pages).
  */
 export async function GET(req: Request) {
   try {
@@ -29,7 +30,7 @@ export async function GET(req: Request) {
 
     let entries = await listWikiPages();
     if (!includeAgentPages) {
-      entries = entries.filter((e) => e.type !== "agent-identity");
+      entries = entries.filter((e) => !isAgentScopedType(e.type));
     }
     return NextResponse.json({ pages: entries });
   } catch (err) {

--- a/src/app/u/[handle]/a/[agent]/page.tsx
+++ b/src/app/u/[handle]/a/[agent]/page.tsx
@@ -1,16 +1,24 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getAgentByOwnerName, resolveAgentPages, sharedPagesFor } from "@/lib/agents";
+import {
+  getAgentByOwnerName,
+  resolveAgentPages,
+  sharedPagesFor,
+} from "@/lib/agents";
 import { listWikiPages } from "@/lib/wiki";
+import { getDiscussionStatsForSlugs } from "@/lib/talk";
 import { decodeSlug } from "@/lib/slugify";
 import { getErrorMessage } from "@/lib/errors";
-import type { AgentProfile } from "@/lib/types";
+import { getPrincipal } from "@/lib/auth";
+import { WikiIndexClient } from "@/components/WikiIndexClient";
+import { AgentTokenPanel } from "@/components/AgentTokenPanel";
+import type { AgentProfile, IndexEntry } from "@/lib/types";
 
-// Public agent profile, scoped under its owner's handle:
-//   /u/<handle>/a/<name>     e.g. /u/alice/a/yoyo
-// Resolves the agent by (handle, name) and shows its EFFECTIVE identity /
-// learnings / social pages — including everything inherited from its template
-// (the base yoyo). Reads are public — yopedia is a public observer surface.
+// Public agent profile, scoped under its owner's handle: /u/<handle>/a/<name>.
+// Layout: a Knowledge list (the agent's own + inherited learnings, shown like a
+// user's page list), a separate Identity section (the base identity it's forked
+// from), and a labeled "Shared by owner" section (pages the owner granted in).
+// The owner additionally sees the credential panel. Reads are public.
 export default async function AgentProfilePage({
   params,
 }: {
@@ -20,10 +28,6 @@ export default async function AgentProfilePage({
   const handle = decodeSlug(encodedHandle);
   const name = decodeSlug(encodedAgent);
 
-  // getAgentByOwnerName returns null for a genuinely missing agent (ENOENT) and
-  // throws on real errors (storage down, corrupt JSON). Don't flatten the latter
-  // into a 404 — only a missing/malformed-id agent is "not found"; let real
-  // errors propagate to the error boundary (500 + logging).
   let agent: AgentProfile | null;
   try {
     agent = await getAgentByOwnerName(handle, name);
@@ -33,22 +37,30 @@ export default async function AgentProfilePage({
   }
   if (!agent) notFound();
 
-  // Effective pages = own + inherited from the template chain (the base yoyo),
-  // plus pages the owner shared into this agent's context.
   const resolved = await resolveAgentPages(agent);
   const sharedSlugs = await sharedPagesFor(agent.id);
 
-  // Resolve slug -> title from the index for nicer links (fall back to slug).
   const index = await listWikiPages();
-  const titleFor = new Map(index.map((p) => [p.slug, p.title]));
+  const bySlug = new Map(index.map((p) => [p.slug, p]));
+  const titleFor = (slug: string) => bySlug.get(slug)?.title ?? slug;
 
-  const sections: { label: string; slugs: string[] }[] = [
-    { label: "Identity", slugs: resolved.identityPages },
-    { label: "Learnings", slugs: resolved.learningPages },
-    { label: "Social wisdom", slugs: resolved.socialPages },
-    { label: "Shared by owner", slugs: sharedSlugs },
-  ];
-  const totalPages = sections.reduce((n, s) => n + s.slugs.length, 0);
+  // Knowledge = the agent's accumulated learnings + social wisdom, rendered as
+  // a card list (the same component the user profile uses).
+  const knowledgeEntries: IndexEntry[] = [
+    ...resolved.learningPages,
+    ...resolved.socialPages,
+  ]
+    .map((slug) => bySlug.get(slug))
+    .filter((e): e is IndexEntry => Boolean(e));
+
+  const statsMap = await getDiscussionStatsForSlugs(
+    knowledgeEntries.map((e) => e.slug),
+  );
+  const discussionStats: Record<string, { total: number; open: number }> = {};
+  for (const [slug, stats] of statsMap) discussionStats[slug] = stats;
+
+  const principal = await getPrincipal();
+  const canManage = !!principal && agent.owner === principal.handle;
 
   return (
     <main className="mx-auto max-w-3xl px-6 py-12">
@@ -61,51 +73,76 @@ export default async function AgentProfilePage({
         </Link>
         <h1 className="mt-2 text-3xl font-bold tracking-tight">{agent.name}</h1>
         <p className="mt-1 text-foreground/60">{agent.description}</p>
-        <AgentMeta agent={agent} />
+        {agent.owner && (
+          <p className="mt-3 text-sm text-foreground/50">
+            owned by{" "}
+            <Link href={`/u/${agent.owner}`} className="hover:text-foreground">
+              @{agent.owner}
+            </Link>
+          </p>
+        )}
       </div>
 
-      {totalPages === 0 ? (
-        <p className="text-foreground/60">
-          This agent has no knowledge pages yet.
-        </p>
-      ) : (
-        <div className="space-y-8">
-          {sections.map((section) =>
-            section.slugs.length === 0 ? null : (
-              <section key={section.label}>
-                <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-foreground/50">
-                  {section.label}
-                </h2>
-                <ul className="space-y-1">
-                  {section.slugs.map((slug) => (
-                    <li key={slug}>
-                      <Link
-                        href={`/wiki/${slug}`}
-                        className="text-foreground hover:underline"
-                      >
-                        {titleFor.get(slug) ?? slug}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            ),
-          )}
-        </div>
-      )}
+      {canManage && <AgentTokenPanel agentId={agent.id} />}
+
+      <section className="mb-8">
+        <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-foreground/50">
+          Knowledge
+        </h2>
+        {knowledgeEntries.length === 0 ? (
+          <p className="text-foreground/60">
+            No knowledge yet — this agent hasn&rsquo;t ingested anything.
+          </p>
+        ) : (
+          <WikiIndexClient
+            pages={knowledgeEntries}
+            discussionStats={discussionStats}
+          />
+        )}
+      </section>
+
+      <LinkSection
+        label="Identity"
+        slugs={resolved.identityPages}
+        titleFor={titleFor}
+      />
+      <LinkSection
+        label="Shared by owner"
+        slugs={sharedSlugs}
+        titleFor={titleFor}
+      />
     </main>
   );
 }
 
-/** Owner cross-link under the agent header. */
-function AgentMeta({ agent }: { agent: AgentProfile }) {
-  if (!agent.owner) return null;
+/** A simple labeled list of page links (used for Identity and Shared). */
+function LinkSection({
+  label,
+  slugs,
+  titleFor,
+}: {
+  label: string;
+  slugs: string[];
+  titleFor: (slug: string) => string;
+}) {
+  if (slugs.length === 0) return null;
   return (
-    <p className="mt-3 text-sm text-foreground/50">
-      owned by{" "}
-      <Link href={`/u/${agent.owner}`} className="hover:text-foreground">
-        @{agent.owner}
-      </Link>
-    </p>
+    <section className="mb-8">
+      <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-foreground/50">
+        {label}
+      </h2>
+      <ul className="space-y-1">
+        {slugs.map((slug) => (
+          <li key={slug}>
+            <Link
+              href={`/wiki/${slug}`}
+              className="text-foreground hover:underline"
+            >
+              {titleFor(slug)}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }

--- a/src/components/AgentTokenPanel.tsx
+++ b/src/components/AgentTokenPanel.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Owner-only panel to manage an agent's credential (per-agent token). The token
+ * is shown **once** when generated/rotated — only its hash is stored server-side
+ * — so the owner copies it then into an external runtime (e.g. openclaw) to
+ * ingest as the agent. Lost it? Rotate for a new one.
+ */
+export function AgentTokenPanel({ agentId }: { agentId: string }) {
+  const [token, setToken] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  async function call(method: "POST" | "DELETE") {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/agents/${agentId}/token`, { method });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `request failed (${res.status})`);
+      }
+      if (method === "POST") {
+        const data = (await res.json()) as { token: string };
+        setToken(data.token);
+        setCopied(false);
+      } else {
+        setToken(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copy() {
+    if (!token) return;
+    try {
+      await navigator.clipboard.writeText(token);
+      setCopied(true);
+    } catch {
+      // Clipboard blocked — the user can select the text manually.
+    }
+  }
+
+  return (
+    <section className="mb-8 rounded-lg border border-foreground/10 p-4">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-foreground/50">
+        Agent credential
+      </h2>
+      <p className="mt-1 text-sm text-foreground/60">
+        A token lets an external runtime (e.g. openclaw) ingest into this agent.
+        It&rsquo;s shown once — copy it now; rotate if you lose it.
+      </p>
+
+      {token && (
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <code className="break-all rounded bg-foreground/5 px-2 py-1 text-xs">
+            {token}
+          </code>
+          <button
+            type="button"
+            onClick={copy}
+            className="rounded-md border border-foreground/20 px-2 py-1 text-xs hover:bg-foreground/5"
+          >
+            {copied ? "Copied ✓" : "Copy"}
+          </button>
+        </div>
+      )}
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => call("POST")}
+          disabled={busy}
+          className="rounded-md border border-foreground/20 px-3 py-1.5 text-sm font-medium hover:bg-foreground/5 disabled:opacity-50"
+        >
+          {token ? "Rotate token" : "Generate token"}
+        </button>
+        <button
+          type="button"
+          onClick={() => call("DELETE")}
+          disabled={busy}
+          className="rounded-md border border-foreground/20 px-3 py-1.5 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:hover:bg-red-900/20"
+        >
+          Revoke
+        </button>
+        {error && (
+          <span className="text-xs text-red-600 dark:text-red-400">{error}</span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/__tests__/agent-ingest-route.test.ts
+++ b/src/lib/__tests__/agent-ingest-route.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/agents", () => ({
+  verifyAgentToken: vi.fn(),
+  addAgentLearningPage: vi.fn(),
+}));
+
+vi.mock("@/lib/ingest", () => ({
+  ingestUrl: vi.fn(),
+  ingest: vi.fn(),
+}));
+
+import { verifyAgentToken, addAgentLearningPage } from "@/lib/agents";
+import { ingestUrl, ingest } from "@/lib/ingest";
+import { POST } from "@/app/api/agents/[id]/ingest/route";
+
+const mockedVerify = vi.mocked(verifyAgentToken);
+const mockedAddLearning = vi.mocked(addAgentLearningPage);
+const mockedIngestUrl = vi.mocked(ingestUrl);
+const mockedIngest = vi.mocked(ingest);
+
+const params = Promise.resolve({ id: "alice--yoyo" });
+
+function req(body: unknown, token?: string): Request {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (token) headers.authorization = `Bearer ${token}`;
+  return new Request("http://localhost/api/agents/alice--yoyo/ingest", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedVerify.mockResolvedValue("alice--yoyo");
+  mockedAddLearning.mockResolvedValue();
+  mockedIngestUrl.mockResolvedValue({
+    primarySlug: "ingested-page",
+    relatedUpdated: [],
+    wikiPages: ["ingested-page"],
+    indexUpdated: true,
+    rawPath: "raw/x",
+  });
+  mockedIngest.mockResolvedValue({
+    primarySlug: "text-page",
+    relatedUpdated: [],
+    wikiPages: ["text-page"],
+    indexUpdated: true,
+    rawPath: "raw/y",
+  });
+});
+
+describe("POST /api/agents/[id]/ingest", () => {
+  it("ingests a URL as the agent (scoped) and attaches it to learnings", async () => {
+    const res = await POST(req({ url: "https://example.com" }, "alice--yoyo.s"), {
+      params,
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).slug).toBe("ingested-page");
+    expect(mockedIngestUrl).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.objectContaining({
+        author: "alice--yoyo",
+        owner: "alice--yoyo",
+        pageType: "agent-knowledge",
+      }),
+    );
+    expect(mockedAddLearning).toHaveBeenCalledWith("alice--yoyo", "ingested-page");
+  });
+
+  it("ingests text", async () => {
+    const res = await POST(
+      req({ text: "hello", title: "Note" }, "alice--yoyo.s"),
+      { params },
+    );
+    expect(res.status).toBe(200);
+    expect(mockedIngest).toHaveBeenCalledWith(
+      "Note",
+      "hello",
+      expect.objectContaining({ pageType: "agent-knowledge" }),
+    );
+  });
+
+  it("401 without a bearer token", async () => {
+    const res = await POST(req({ url: "https://example.com" }), { params });
+    expect(res.status).toBe(401);
+    expect(mockedIngestUrl).not.toHaveBeenCalled();
+  });
+
+  it("401 for an invalid token", async () => {
+    mockedVerify.mockResolvedValue(null);
+    const res = await POST(req({ url: "https://example.com" }, "bad"), { params });
+    expect(res.status).toBe(401);
+  });
+
+  it("403 when the token authenticates a different agent", async () => {
+    mockedVerify.mockResolvedValue("bob--yoyo");
+    const res = await POST(req({ url: "https://example.com" }, "bob--yoyo.s"), {
+      params,
+    });
+    expect(res.status).toBe(403);
+    expect(mockedIngestUrl).not.toHaveBeenCalled();
+  });
+
+  it("400 when neither url nor text is provided", async () => {
+    const res = await POST(req({}, "alice--yoyo.s"), { params });
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/lib/__tests__/agent-token-route.test.ts
+++ b/src/lib/__tests__/agent-token-route.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/agents", () => {
+  class AgentOwnershipError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "AgentOwnershipError";
+    }
+  }
+  return {
+    generateAgentToken: vi.fn(),
+    revokeAgentToken: vi.fn(),
+    assertCanMutateAgent: vi.fn(),
+    AgentOwnershipError,
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  getPrincipal: vi.fn(async () => ({ id: "alice", handle: "alice" })),
+}));
+
+import {
+  generateAgentToken,
+  revokeAgentToken,
+  assertCanMutateAgent,
+  AgentOwnershipError,
+} from "@/lib/agents";
+import { getPrincipal } from "@/lib/auth";
+import { POST, DELETE } from "@/app/api/agents/[id]/token/route";
+import type { AgentProfile } from "@/lib/types";
+
+const mockedGen = vi.mocked(generateAgentToken);
+const mockedRevoke = vi.mocked(revokeAgentToken);
+const mockedAssert = vi.mocked(assertCanMutateAgent);
+const mockedGetPrincipal = vi.mocked(getPrincipal);
+
+const params = Promise.resolve({ id: "alice--yoyo" });
+const ownedAgent = { id: "alice--yoyo", owner: "alice" } as AgentProfile;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetPrincipal.mockResolvedValue({ id: "alice", handle: "alice" });
+  mockedAssert.mockResolvedValue(ownedAgent);
+  mockedGen.mockResolvedValue("alice--yoyo.secret123");
+  mockedRevoke.mockResolvedValue();
+});
+
+describe("POST /api/agents/[id]/token", () => {
+  it("returns the freshly generated token to the owner", async () => {
+    const res = await POST(new Request("http://localhost"), { params });
+    expect(res.status).toBe(200);
+    expect((await res.json()).token).toBe("alice--yoyo.secret123");
+    expect(mockedGen).toHaveBeenCalledWith("alice--yoyo");
+  });
+
+  it("401 when signed out", async () => {
+    mockedGetPrincipal.mockResolvedValue(null);
+    const res = await POST(new Request("http://localhost"), { params });
+    expect(res.status).toBe(401);
+    expect(mockedGen).not.toHaveBeenCalled();
+  });
+
+  it("403 when not the owner", async () => {
+    mockedAssert.mockRejectedValue(new AgentOwnershipError("not owner"));
+    const res = await POST(new Request("http://localhost"), { params });
+    expect(res.status).toBe(403);
+    expect(mockedGen).not.toHaveBeenCalled();
+  });
+
+  it("404 when the agent doesn't exist", async () => {
+    mockedAssert.mockResolvedValue(null);
+    const res = await POST(new Request("http://localhost"), { params });
+    expect(res.status).toBe(404);
+    expect(mockedGen).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/agents/[id]/token", () => {
+  it("revokes for the owner", async () => {
+    const res = await DELETE(new Request("http://localhost"), { params });
+    expect(res.status).toBe(200);
+    expect(mockedRevoke).toHaveBeenCalledWith("alice--yoyo");
+  });
+
+  it("403 when not the owner", async () => {
+    mockedAssert.mockRejectedValue(new AgentOwnershipError("not owner"));
+    const res = await DELETE(new Request("http://localhost"), { params });
+    expect(res.status).toBe(403);
+    expect(mockedRevoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/agents-id-route.test.ts
+++ b/src/lib/__tests__/agents-id-route.test.ts
@@ -18,7 +18,12 @@ vi.mock("@/lib/agents", () => {
     updateAgent: vi.fn(),
     assertCanMutateAgent: vi.fn(),
     AgentOwnershipError,
-    publicAgent: (a: unknown) => a,
+    // Faithful strip so the test verifies the route routes responses through it.
+    publicAgent: (a: { tokenHash?: string }) => {
+      const { tokenHash: _omit, ...rest } = a;
+      void _omit;
+      return rest;
+    },
   };
 });
 
@@ -31,15 +36,17 @@ import {
   updateAgent,
   assertCanMutateAgent,
   AgentOwnershipError,
+  getAgent,
 } from "@/lib/agents";
 import { getPrincipal } from "@/lib/auth";
-import { PUT, DELETE } from "@/app/api/agents/[id]/route";
+import { GET, PUT, DELETE } from "@/app/api/agents/[id]/route";
 import type { AgentProfile } from "@/lib/types";
 
 const mockedDelete = vi.mocked(deleteAgent);
 const mockedUpdate = vi.mocked(updateAgent);
 const mockedAssert = vi.mocked(assertCanMutateAgent);
 const mockedGetPrincipal = vi.mocked(getPrincipal);
+const mockedGetAgent = vi.mocked(getAgent);
 
 const ownedAgent: AgentProfile = {
   id: "yoyo",
@@ -138,5 +145,18 @@ describe("DELETE /api/agents/[id] — ownership", () => {
     });
     expect(res.status).toBe(404);
     expect(mockedDelete).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/agents/[id] — secret stripping", () => {
+  it("never serializes tokenHash to the client", async () => {
+    mockedGetAgent.mockResolvedValue({ ...ownedAgent, tokenHash: "deadbeef" });
+    const res = await GET(new Request("http://localhost/api/agents/yoyo"), {
+      params,
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.agent.id).toBe("yoyo");
+    expect(data.agent.tokenHash).toBeUndefined();
   });
 });

--- a/src/lib/__tests__/agents-id-route.test.ts
+++ b/src/lib/__tests__/agents-id-route.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/agents", () => {
     updateAgent: vi.fn(),
     assertCanMutateAgent: vi.fn(),
     AgentOwnershipError,
+    publicAgent: (a: unknown) => a,
   };
 });
 

--- a/src/lib/__tests__/agents-route.test.ts
+++ b/src/lib/__tests__/agents-route.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/lib/agents", () => ({
   listAgents: vi.fn(),
   registerAgent: vi.fn(),
   getAgent: vi.fn(),
+  publicAgent: (a: unknown) => a,
 }));
 
 // The route claims ownership from the session principal.

--- a/src/lib/__tests__/agents.test.ts
+++ b/src/lib/__tests__/agents.test.ts
@@ -21,6 +21,11 @@ import {
   resolveAgentPages,
   sharedPagesFor,
   setPageShared,
+  generateAgentToken,
+  verifyAgentToken,
+  revokeAgentToken,
+  publicAgent,
+  addAgentLearningPage,
 } from "../agents";
 import type { UpdateAgentPage } from "../agents";
 import { readWikiPage, readWikiPageWithFrontmatter } from "../wiki";
@@ -1327,5 +1332,74 @@ describe("sharing (feed-as-grant via sharedWith)", () => {
     await setPageShared("alice-note", "alice--yoyo", false);
     page = await readWikiPageWithFrontmatter("alice-note");
     expect(page!.frontmatter.sharedWith).toEqual(["bob--yoyo"]);
+  });
+})
+
+describe("per-agent credentials", () => {
+  async function seedAgentRecord(id = "alice--yoyo", owner = "alice") {
+    await registerAgent(makeProfile({ id, owner }));
+  }
+
+  it("generateAgentToken returns <id>.<secret> and stores only the hash", async () => {
+    await seedAgentRecord();
+    const token = await generateAgentToken("alice--yoyo");
+    expect(token.startsWith("alice--yoyo.")).toBe(true);
+
+    const agent = await getAgent("alice--yoyo");
+    expect(agent!.tokenHash).toBeTruthy();
+    // The raw secret is never stored.
+    expect(agent!.tokenHash).not.toContain(token.split(".")[1]);
+  });
+
+  it("verifyAgentToken accepts the right token and rejects others", async () => {
+    await seedAgentRecord();
+    const token = await generateAgentToken("alice--yoyo");
+
+    expect(await verifyAgentToken(token)).toBe("alice--yoyo");
+    expect(await verifyAgentToken("alice--yoyo.wrongsecret")).toBeNull();
+    expect(await verifyAgentToken("garbage")).toBeNull();
+    expect(await verifyAgentToken("bob--yoyo.whatever")).toBeNull(); // no such agent
+  });
+
+  it("rotating invalidates the previous token", async () => {
+    await seedAgentRecord();
+    const first = await generateAgentToken("alice--yoyo");
+    const second = await generateAgentToken("alice--yoyo");
+    expect(first).not.toBe(second);
+    expect(await verifyAgentToken(first)).toBeNull();
+    expect(await verifyAgentToken(second)).toBe("alice--yoyo");
+  });
+
+  it("revokeAgentToken clears the credential", async () => {
+    await seedAgentRecord();
+    const token = await generateAgentToken("alice--yoyo");
+    await revokeAgentToken("alice--yoyo");
+    expect(await verifyAgentToken(token)).toBeNull();
+    expect((await getAgent("alice--yoyo"))!.tokenHash).toBeUndefined();
+  });
+
+  it("publicAgent strips the tokenHash", async () => {
+    await seedAgentRecord();
+    await generateAgentToken("alice--yoyo");
+    const agent = await getAgent("alice--yoyo");
+    expect(agent!.tokenHash).toBeTruthy();
+    expect(publicAgent(agent!).tokenHash).toBeUndefined();
+    // Other fields survive.
+    expect(publicAgent(agent!).id).toBe("alice--yoyo");
+  });
+});
+
+describe("addAgentLearningPage", () => {
+  it("appends a slug to learningPages (idempotent)", async () => {
+    await registerAgent(makeProfile({ id: "alice--yoyo", owner: "alice" }));
+    await addAgentLearningPage("alice--yoyo", "some-page");
+    await addAgentLearningPage("alice--yoyo", "some-page"); // no dup
+    expect((await getAgent("alice--yoyo"))!.learningPages).toEqual(["some-page"]);
+  });
+
+  it("is a no-op for a missing agent", async () => {
+    await expect(
+      addAgentLearningPage("ghost--yoyo", "x"),
+    ).resolves.toBeUndefined();
   });
 })

--- a/src/lib/__tests__/agents.test.ts
+++ b/src/lib/__tests__/agents.test.ts
@@ -1361,6 +1361,15 @@ describe("per-agent credentials", () => {
     expect(await verifyAgentToken("bob--yoyo.whatever")).toBeNull(); // no such agent
   });
 
+  it("rejects malformed/crafted tokens", async () => {
+    await seedAgentRecord();
+    await generateAgentToken("alice--yoyo");
+    expect(await verifyAgentToken("")).toBeNull(); // empty
+    expect(await verifyAgentToken(".secret")).toBeNull(); // empty agent id
+    expect(await verifyAgentToken("alice--yoyo.")).toBeNull(); // empty secret
+    expect(await verifyAgentToken("alice--yoyo")).toBeNull(); // no dot
+  });
+
   it("rotating invalidates the previous token", async () => {
     await seedAgentRecord();
     const first = await generateAgentToken("alice--yoyo");

--- a/src/lib/__tests__/ensure-route.test.ts
+++ b/src/lib/__tests__/ensure-route.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@/lib/agents", () => ({
   forkAgent: vi.fn(),
   baseAgentId: vi.fn(() => "yopedia-yoyo"),
+  publicAgent: (a: unknown) => a,
 }));
 
 vi.mock("@/lib/auth", () => ({

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -201,6 +201,25 @@ describe("ingest", () => {
     expect(entries[0].summary).toBe("This is the content.");
   });
 
+  it("writes the pageType to frontmatter.type on a new page (agent-scoping)", async () => {
+    const result = await ingest("Agent Note", "Knowledge the agent learned.", {
+      pageType: "agent-knowledge",
+    });
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect(page!.frontmatter.type).toBe("agent-knowledge");
+  });
+
+  it("does not change an existing page's scope on re-ingest", async () => {
+    // A plain public page (no type)…
+    await ingest("Shared Topic", "Public content here.");
+    // …re-ingested with an agent pageType must NOT be flipped to agent-scope.
+    const result = await ingest("Shared Topic", "Public content, expanded.", {
+      pageType: "agent-knowledge",
+    });
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect(page!.frontmatter.type).toBeUndefined();
+  });
+
   it("updates existing entry on re-ingest instead of duplicating", async () => {
     // First ingest
     await ingest("My Topic", "Original content about the topic. More details.");

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -101,6 +101,30 @@ describe("searchWikiContent", () => {
     expect(results[0].title).toBe("Neural Networks");
   });
 
+  it("excludes agent-scoped pages from general (unscoped) search", async () => {
+    await ensureDirectories();
+    await writeWikiPage(
+      "normal-note",
+      "# Normal\n\nAttention mechanisms explained here.",
+    );
+    await writeWikiPage(
+      "agent-note",
+      serializeFrontmatter(
+        { type: "agent-knowledge" },
+        "# Agent Note\n\nAttention mechanisms explained here.",
+      ),
+    );
+    // Both must be in the index so the type-based exclusion can see them.
+    await writeWikiPage(
+      "index",
+      "# Index\n\n- [Normal](normal-note.md) — n\n- [Agent Note](agent-note.md) — a",
+    );
+
+    const slugs = (await searchWikiContent("attention")).map((r) => r.slug);
+    expect(slugs).toContain("normal-note");
+    expect(slugs).not.toContain("agent-note");
+  });
+
   it("is case-insensitive", async () => {
     await ensureDirectories();
     await writeWikiPage("test-page", "# Test Page\n\nHello WORLD.");

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -28,6 +28,7 @@ import {
 import type { SearchScope } from "../search";
 import { registerAgent, ensureAgentsDir } from "../agents";
 import { serializeFrontmatter } from "../frontmatter";
+import { isAgentScopedType } from "../wiki";
 import type { AgentProfile } from "../types";
 import { _resetStorage } from "../storage";
 
@@ -70,6 +71,18 @@ afterEach(async () => {
 // ---------------------------------------------------------------------------
 // searchWikiContent
 // ---------------------------------------------------------------------------
+
+describe("isAgentScopedType", () => {
+  it("is true only for agent-* types", () => {
+    expect(isAgentScopedType("agent-knowledge")).toBe(true);
+    expect(isAgentScopedType("agent-identity")).toBe(true);
+    expect(isAgentScopedType(undefined)).toBe(false);
+    expect(isAgentScopedType("")).toBe(false);
+    expect(isAgentScopedType("prose")).toBe(false);
+    // "agent" must be a prefix, not just contained.
+    expect(isAgentScopedType("my-agent-notes")).toBe(false);
+  });
+});
 
 describe("searchWikiContent", () => {
   it("returns empty array for empty query", async () => {

--- a/src/lib/__tests__/seed-route.test.ts
+++ b/src/lib/__tests__/seed-route.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/lib/agents", () => {
     seedAgent: vi.fn(),
     assertCanMutateAgent: vi.fn(async () => null),
     AgentOwnershipError,
+    publicAgent: (a: unknown) => a,
     // Mirrors the real composite-id helper (separate parts joined with "--").
     agentIdFor: (owner: string, name = "yoyo") => `${owner}--${name}`,
   };

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -16,6 +16,7 @@ import { serializeFrontmatter } from "./frontmatter";
 import { slugify } from "./slugify";
 import { writeWikiPageWithSideEffects } from "./lifecycle";
 import { readWikiPageWithFrontmatter, listWikiPages, writeWikiPage } from "./wiki";
+import { logger } from "./logger";
 import type { AgentProfile } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -280,7 +281,15 @@ export async function addAgentLearningPage(
   slug: string,
 ): Promise<void> {
   const agent = await getAgent(id);
-  if (!agent) return;
+  if (!agent) {
+    // The agent was just authenticated for this ingest, so a missing record
+    // here is an anomaly — the page was written but is now unattached.
+    logger.error(
+      "agents",
+      `addAgentLearningPage: agent "${id}" not found; page "${slug}" left unattached`,
+    );
+    return;
+  }
   if (!agent.learningPages.includes(slug)) {
     agent.learningPages = [...agent.learningPages, slug];
     agent.lastUpdated = new Date().toISOString();
@@ -313,8 +322,15 @@ export async function verifyAgentToken(token: string): Promise<string | null> {
   let agent: AgentProfile | null;
   try {
     agent = await getAgent(id);
-  } catch {
-    return null; // malformed id, etc.
+  } catch (err) {
+    // A malformed id is a bad token (→ null → 401). A storage failure is OUR
+    // problem — surface it (route → 500) rather than masking an outage as an
+    // invalid credential, which would make a valid token look revoked.
+    if (err instanceof Error && err.message.includes("Invalid agent ID")) {
+      return null;
+    }
+    logger.error("agents", "verifyAgentToken: agent lookup failed:", err);
+    throw err;
   }
   if (!agent?.tokenHash) return null;
 
@@ -835,6 +851,9 @@ export async function seedAgent(options: SeedAgentOptions): Promise<AgentProfile
   if (existingAgent) {
     profile.registered = existingAgent.registered;
     profile.owner = existingAgent.owner ?? options.owner;
+    // Preserve a previously-issued credential — a re-seed must not silently
+    // revoke the agent's token.
+    if (existingAgent.tokenHash) profile.tokenHash = existingAgent.tokenHash;
   }
 
   await registerAgent(profile);

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -215,6 +215,114 @@ export async function setPageShared(
 }
 
 // ---------------------------------------------------------------------------
+// Per-agent credentials — a token an external runtime uses to ingest AS the
+// agent (e.g. openclaw). Only the SHA-256 hash is stored; the raw token is
+// shown to the owner once at generation (show-once + rotate). The token format
+// `<agentId>.<secret>` makes verification O(1) and self-scoping: a token can
+// only ever authenticate the agent whose id it carries.
+// ---------------------------------------------------------------------------
+
+function toHex(buf: ArrayBuffer): string {
+  return [...new Uint8Array(buf)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(input),
+  );
+  return toHex(digest);
+}
+
+/** Constant-time string compare (avoids leaking the secret via timing). */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+/** Strip secret fields (tokenHash) before serving an agent profile publicly. */
+export function publicAgent(agent: AgentProfile): AgentProfile {
+  const { tokenHash: _omit, ...rest } = agent;
+  void _omit;
+  return rest;
+}
+
+/**
+ * Generate (or rotate) an agent's credential. Stores only the SHA-256 hash on
+ * the profile and returns the raw token ONCE — format `<agentId>.<secret>`.
+ * The caller must enforce that the actor owns the agent.
+ */
+export async function generateAgentToken(id: string): Promise<string> {
+  const agent = await getAgent(id);
+  if (!agent) throw new Error(`Agent "${id}" not found`);
+
+  const secretBytes = new Uint8Array(32);
+  crypto.getRandomValues(secretBytes);
+  const secret = toHex(secretBytes.buffer);
+
+  agent.tokenHash = await sha256Hex(secret);
+  agent.lastUpdated = new Date().toISOString();
+  await registerAgent(agent);
+
+  return `${id}.${secret}`;
+}
+
+/**
+ * Append a page slug to an agent's own `learningPages` (idempotent). Used when
+ * the agent ingests content into its own knowledge. No-op if the agent is gone.
+ */
+export async function addAgentLearningPage(
+  id: string,
+  slug: string,
+): Promise<void> {
+  const agent = await getAgent(id);
+  if (!agent) return;
+  if (!agent.learningPages.includes(slug)) {
+    agent.learningPages = [...agent.learningPages, slug];
+    agent.lastUpdated = new Date().toISOString();
+    await registerAgent(agent);
+  }
+}
+
+/** Revoke an agent's credential (clears the stored hash). No-op if unset. */
+export async function revokeAgentToken(id: string): Promise<void> {
+  const agent = await getAgent(id);
+  if (!agent?.tokenHash) return;
+  delete agent.tokenHash;
+  agent.lastUpdated = new Date().toISOString();
+  await registerAgent(agent);
+}
+
+/**
+ * Verify an agent bearer token. Returns the agent id it authenticates, or null.
+ * Splits `<agentId>.<secret>`, looks up the agent, and constant-time-compares
+ * sha256(secret) to the stored `tokenHash`.
+ */
+export async function verifyAgentToken(token: string): Promise<string | null> {
+  if (!token) return null;
+  const dot = token.indexOf(".");
+  if (dot <= 0) return null;
+  const id = token.slice(0, dot);
+  const secret = token.slice(dot + 1);
+  if (!secret) return null;
+
+  let agent: AgentProfile | null;
+  try {
+    agent = await getAgent(id);
+  } catch {
+    return null; // malformed id, etc.
+  }
+  if (!agent?.tokenHash) return null;
+
+  const hash = await sha256Hex(secret);
+  return timingSafeEqual(hash, agent.tokenHash) ? id : null;
+}
+
+// ---------------------------------------------------------------------------
 // Ownership
 // ---------------------------------------------------------------------------
 

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -460,6 +460,12 @@ export interface IngestOptions {
    * user. Defaults to `author`.
    */
   owner?: string;
+  /**
+   * Optional page `type` frontmatter (e.g. "agent-knowledge"). When set, marks
+   * the page as agent-scoped so it is excluded from the public browse feed and
+   * general search, surfacing only via an `agent:` scope.
+   */
+  pageType?: string;
 }
 
 /**
@@ -697,6 +703,12 @@ export async function ingest(
     aliases: [],
     content_hash: hash,
   };
+
+  // Agent-scoped pages carry a `type` (e.g. "agent-knowledge") so they're
+  // filtered from the public browse feed and general search.
+  if (options?.pageType) {
+    frontmatter.type = options.pageType;
+  }
 
   // Persist the original source URL when provided (URL-based ingest).
   if (options?.sourceUrl) {

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -461,11 +461,13 @@ export interface IngestOptions {
    */
   owner?: string;
   /**
-   * Optional page `type` frontmatter (e.g. "agent-knowledge"). When set, marks
-   * the page as agent-scoped so it is excluded from the public browse feed and
-   * general search, surfacing only via an `agent:` scope.
+   * Optional page `type` frontmatter. When set on a NEW page, marks it as
+   * agent-scoped so it is excluded from the public browse feed and general
+   * search, surfacing only via an `agent:` scope. A union (not open string) so
+   * a typo can't silently produce an unscoped page. Ignored on re-ingest of an
+   * existing page (its scope is preserved — see below).
    */
-  pageType?: string;
+  pageType?: "agent-knowledge" | "agent-identity";
 }
 
 /**
@@ -794,6 +796,14 @@ export async function ingest(
     // Preserve visibility (don't silently re-publish a private page).
     if (existing.frontmatter.visibility === "private") {
       frontmatter.visibility = "private";
+    }
+    // Don't change an existing page's scope on re-ingest: preserve its `type`
+    // (or lack of one), so an agent ingest can't flip a public page into
+    // agent-scope (out of the feed/search) by colliding on a slug.
+    if (typeof existing.frontmatter.type === "string") {
+      frontmatter.type = existing.frontmatter.type;
+    } else {
+      delete frontmatter.type;
     }
     // Append the acting identity to contributors if not already present.
     const existingContribs = Array.isArray(existing.frontmatter.contributors)

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -4,6 +4,7 @@ import {
   listWikiPages,
   writeWikiPageWithSideEffects,
   withPageCache,
+  isAgentScopedType,
 } from "./wiki";
 import { slugify } from "./slugify";
 import { extractSummary } from "./ingest";
@@ -171,7 +172,7 @@ export async function query(
   scope?: string,
 ): Promise<QueryResult> {
   return withPageCache(async () => {
-    const entries = await listWikiPages();
+    let entries = await listWikiPages();
 
     // Resolve scope to a set of slugs when provided
     let scopeSlugs: string[] | undefined;
@@ -190,6 +191,12 @@ export async function query(
           sources: [],
         };
       }
+    }
+
+    // General (unscoped) query excludes agent-scoped pages — agent knowledge
+    // surfaces only via an `agent:` scope.
+    if (!scopeSlugs) {
+      entries = entries.filter((e) => !isAgentScopedType(e.type));
     }
 
     // Empty wiki — nothing to query

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -11,6 +11,7 @@ import {
   listWikiPages,
   withPageCache,
   wikiRelPath,
+  isAgentScopedType,
 } from "./wiki";
 import { isEnoent } from "./errors";
 import { getAgent, resolveAgentPages, sharedPagesFor } from "./agents";
@@ -284,6 +285,17 @@ export function fuzzyMatch(
  * When `scope` is provided, only pages whose slug appears in `scope.slugs`
  * are searched.
  */
+/**
+ * Slugs whose page is agent-scoped (`agent-*` type) — excluded from general
+ * (unscoped) search so agent knowledge surfaces only via an `agent:` scope.
+ */
+async function agentScopedSlugSet(): Promise<Set<string>> {
+  const pages = await listWikiPages();
+  return new Set(
+    pages.filter((p) => isAgentScopedType(p.type)).map((p) => p.slug),
+  );
+}
+
 export async function searchWikiContent(
   query: string,
   maxResults = 10,
@@ -307,6 +319,9 @@ export async function searchWikiContent(
 
   const SKIP = new Set(["index.md", "log.md"]);
   const scopeSlugs = scope ? new Set(scope.slugs) : null;
+  // Without a scope, exclude agent-scoped pages from general search — they
+  // surface only via an `agent:` scope.
+  const excludedSlugs = scope ? null : await agentScopedSlugSet();
 
   const scored: Array<{
     slug: string;
@@ -322,6 +337,8 @@ export async function searchWikiContent(
 
     // Scope filtering: skip pages not in the scope's slug set
     if (scopeSlugs && !scopeSlugs.has(slug)) continue;
+    // General search: skip agent-scoped pages
+    if (excludedSlugs && excludedSlugs.has(slug)) continue;
 
     let content: string;
     try {
@@ -434,6 +451,7 @@ export async function fuzzySearchWikiContent(
   const SKIP = new Set(["index.md", "log.md"]);
   const exactSlugs = new Set(exactResults.map((r) => r.slug));
   const scopeSlugs = scope ? new Set(scope.slugs) : null;
+  const excludedSlugs = scope ? null : await agentScopedSlugSet();
 
   const fuzzyResults: ContentSearchResult[] = [];
 
@@ -443,6 +461,8 @@ export async function fuzzySearchWikiContent(
 
     // Scope filtering: skip pages not in the scope's slug set
     if (scopeSlugs && !scopeSlugs.has(slug)) continue;
+    // General search: skip agent-scoped pages
+    if (excludedSlugs && excludedSlugs.has(slug)) continue;
 
     // Skip pages already in exact results
     if (exactSlugs.has(slug)) continue;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -191,6 +191,11 @@ export interface AgentProfile {
    *  the template's pages by reference — see resolveAgentPages() — so base
    *  updates keep flowing through until the fork overrides a page (future). */
   template?: string;
+  /** SHA-256 hash (hex) of the agent's credential secret, or undefined if no
+   *  token has been issued. Only the hash is stored — the raw token is shown to
+   *  the owner once at generation. NEVER serialize this to public responses
+   *  (use publicAgent() to strip it). */
+  tokenHash?: string;
   /** Wiki page slugs that form this agent's identity context (its OWN pages;
    *  inherited pages come from the template via resolveAgentPages). */
   identityPages: string[];

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -40,6 +40,15 @@ export function wikiRelPath(filename: string): string {
 }
 
 /**
+ * True when a page `type` marks it as agent-scoped (`agent-identity`,
+ * `agent-knowledge`, …). Such pages are excluded from the public browse feed
+ * and general search, surfacing only via an `agent:` scope.
+ */
+export function isAgentScopedType(type: string | undefined): boolean {
+  return typeof type === "string" && type.startsWith("agent-");
+}
+
+/**
  * Compute a storage-relative path for a raw source file.
  *
  * Same logic as {@link wikiRelPath} but for the `raw/` directory. Used by

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,20 +9,27 @@ const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 // stay public — yopedia is a public observer surface (see yopedia-concept.md).
 // Attribution (which user) is read per-route from `getPrincipal()`.
 //
-// Exception: /api/agents/seed authenticates IN-ROUTE because it accepts either
-// a Clerk session OR a service token (getServicePrincipal) for automated
-// re-seeding. It still rejects unauthenticated callers — the auth just lives in
-// the handler, not here — so this is not a hole.
+// Exception: some routes authenticate IN-ROUTE with a token instead of a Clerk
+// session, so they're exempt from this gate (they still reject unauthenticated
+// callers — the auth just lives in the handler):
+//   - /api/agents/seed            — Clerk session OR the system service token
+//   - /api/agents/<id>/ingest     — the agent's own per-agent token
+// This is not a hole.
 //
 // The MCP server is stdio-only and not exposed over HTTP, so it is unaffected.
 const IN_ROUTE_AUTH_PATHS = new Set(["/api/agents/seed"]);
+const AGENT_INGEST_RE = /^\/api\/agents\/[^/]+\/ingest$/;
+
+function authenticatesInRoute(pathname: string): boolean {
+  return IN_ROUTE_AUTH_PATHS.has(pathname) || AGENT_INGEST_RE.test(pathname);
+}
 
 export default clerkMiddleware(async (auth, req) => {
   const { pathname } = req.nextUrl;
   if (
     WRITE_METHODS.has(req.method) &&
     pathname.startsWith("/api/") &&
-    !IN_ROUTE_AUTH_PATHS.has(pathname)
+    !authenticatesInRoute(pathname)
   ) {
     const { userId } = await auth();
     if (!userId) {


### PR DESCRIPTION
## What
"yoyo ingests content" — the model you described: an external runtime (e.g. **openclaw**) uses the **agent's own token** to ingest into that agent's knowledge. **Your Clerk session is never used for ingest.** A separate system token (the existing `YOPEDIA_SERVICE_TOKEN`) is reserved for scheduled / `@mention` ingestion later.

## Per-agent credentials (show-once + rotate — your choice A)
- `AgentProfile.tokenHash` stores only the **SHA-256** of the secret; **`publicAgent()`** strips it from every agent-returning response (so it never leaks via the public `GET /api/agents/<id>`).
- `generate`/`verify`/`revoke` helpers. Token format **`<agentId>.<secret>`** → O(1) verification and **self-scoping** (a token can only authenticate its own agent). Constant-time compare.
- **`POST`/`DELETE /api/agents/<id>/token`** — owner-gated (Clerk session); returns the raw token **once**.

## Agent self-ingest
- **`POST /api/agents/<id>/ingest`** — authenticated by the **agent token** (Bearer), **not** a session; **exempt from the Clerk write-gate** in middleware; the token must match the path agent (else **403**).
- Body `{ url }` or `{ text, title? }`. Reuses the ingest pipeline via a new **`pageType`** option → the page is **`agent-knowledge`**, attributed to the agent, and appended to its `learningPages`.

## Scoping (C2-4)
Agent-`*` typed pages are excluded from the **public browse feed**, **general search**, and **general query** — they surface only via an **`agent:` scope**. New `isAgentScopedType()`; the feed filter broadened from `agent-identity` to all `agent-*`.

## Profile (C2-1)
`/u/<handle>/a/<name>` restructured: **Knowledge** listed like a user's page list (cards), **Identity** as its own section, **Shared by owner** labeled. The owner additionally sees the **credential panel** (generate / rotate / revoke).

## Tests
Token gen/verify/rotate/revoke, `publicAgent` strip, `addAgentLearningPage`; token route (200/401/403/404); ingest route (200 url+text / 401 / 403 mismatch / 400); general-search exclusion of `agent-knowledge`. Full suite **2236 passing**; build + lint clean.

## Flow once merged + deployed
1. Owner opens `/u/<you>/a/yoyo` → **Generate token** → copies it.
2. Pastes into openclaw, which `POST`s sources to `/api/agents/<you>--yoyo/ingest` with `Authorization: Bearer <token>`.
3. Ingested pages show under the agent's **Knowledge**, searchable via `agent:<you>--yoyo`, hidden from the public feed/search.

## Next (separate)
The **system-token autonomous path** (scheduled / `@yoyoevolve` mention loop) can hit the same ingest endpoint with the system credential — a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)