### PR TITLE
docs(agent-api): drop credential-tiers + future-skill sections

### DIFF
--- a/public/agent-api.md
+++ b/public/agent-api.md
@@ -108,31 +108,3 @@ agent-scoped pages surface *only* under `agent:<agent-id>`.
 > **private** agent content, the same per-agent token is the natural credential
 > to gate those reads — the token already identifies the agent. Until then,
 > treat the token as write-only and read freely with the `agent:` scope.
-
----
-
-## 4. Two credential tiers (how this fits together)
-
-| Credential | Who holds it | Can do |
-|---|---|---|
-| **Per-agent token** (this doc) | a user's external runtime (openclaw, scripts) | ingest **as that one agent** |
-| **System token** | yopedia's own automation | scheduled / `@yoyoevolve`-mention ingestion. Can target any agent **that exists** (a non-user → 404, which is how "registered users only" is enforced) — not self-scoping like a per-agent token. |
-
-A per-agent token never touches another agent; the system token is for
-yopedia's own loops, not handed to users.
-
----
-
-## 5. Future: a yopedia skill
-
-The endpoints above are the raw API. Planned (not yet built) is a packaged
-**yopedia skill** so an agent can use yopedia without hand-rolling HTTP calls:
-
-- An installable skill / tool that wraps **ingest** and **consume** (context,
-  scoped query, scoped search) and reads the token from config.
-- Likely exposed over **MCP** so any MCP-capable agent can `ingest`,
-  `query(scope)`, and `get_context` as first-class tools.
-- Goal: "point your agent at yopedia, give it its token, and it reads/writes its
-  own knowledge" — no bespoke integration per runtime.
-
-Until the skill ships, use the HTTP API above directly.


### PR DESCRIPTION
Per request: removes sections **4 (Two credential tiers)** and **5 (Future: a yopedia skill)** from the public /agent-api guide. It now ends after section 3 (Consume), covering just what an integrator needs — get the credential, ingest, consume. Static-asset doc only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)