### PR TITLE
feat(x-ingest): require "@yoyoevolve yopedia" trigger phrase

### DIFF
--- a/.github/workflows/x-ingest.yml
+++ b/.github/workflows/x-ingest.yml
@@ -1,9 +1,11 @@
 name: X mention ingest
 
 # The @yoyoevolve autonomous loop. When a registered yopedia user *replies* to a
-# tweet and mentions @yoyoevolve, yoyo ingests what the REPLIED-TO (parent) tweet
-# points to — its full long-form X **Article** (via the X API `article` field)
-# and/or its external **links** — into that user's yoyo as scoped agent-knowledge.
+# tweet with the trigger phrase "@yoyoevolve yopedia", yoyo ingests what the
+# REPLIED-TO (parent) tweet points to — its full long-form X **Article** (via the
+# X API `article` field) and/or its external **links** — into that user's yoyo as
+# scoped agent-knowledge. The "yopedia" trigger word keeps an incidental
+# @yoyoevolve mention from being treated as a save command.
 # It never ingests plain tweet text. A mention from a non-user hits a 404 and is
 # skipped (no base fallback). Closes the loop in yopedia-concept.md / issue #21.
 #
@@ -44,6 +46,9 @@ jobs:
           const SERVICE = process.env.YOPEDIA_SERVICE_TOKEN;
           const BASE = process.env.YOPEDIA_URL;
           const HANDLE = "yoyoevolve";
+          // Trigger word: only replies that say "@yoyoevolve yopedia ..." fire the
+          // loop, so an incidental @yoyoevolve mention isn't treated as a command.
+          const TRIGGER = "yopedia";
 
           // Graceful no-op when not configured — "nothing to ingest" is the happy path.
           if (!X_BEARER || !SERVICE) {
@@ -72,7 +77,7 @@ jobs:
 
           // Overlapping window (idempotent ingest dedups the overlap).
           const startTime = new Date(Date.now() - 7 * 3600 * 1000).toISOString();
-          const q = encodeURIComponent(`@${HANDLE} is:reply -is:retweet`);
+          const q = encodeURIComponent(`@${HANDLE} ${TRIGGER} is:reply -is:retweet`);
           const url =
             `https://api.twitter.com/2/tweets/search/recent?query=${q}` +
             `&max_results=50&start_time=${startTime}` +


### PR DESCRIPTION
Adds a **`yopedia`** trigger word so the X-ingest loop only fires on intentional save commands. The recent-search query now requires both the `@yoyoevolve` mention **and** the word `yopedia` in the reply (`@yoyoevolve yopedia is:reply -is:retweet`). An incidental `@yoyoevolve` mention is no longer treated as an ingest command. Workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)