### PR TITLE
feat(x-ingest): persist since_id via actions/cache (near-zero overlap)

### DIFF
--- a/.github/workflows/x-ingest.yml
+++ b/.github/workflows/x-ingest.yml
@@ -14,11 +14,14 @@ name: X mention ingest
 #   - secret YOPEDIA_SERVICE_TOKEN   (the system write credential)
 #   - optional var YOPEDIA_URL       (defaults to the production Worker URL)
 #
-# Cadence: every 10 minutes, polling a 30-minute lookback window (3× overlap so a
-# delayed/dropped cron run doesn't miss a trigger). Stateless — no cursor to
-# persist; idempotent ingest (re-ingesting the same URL attaches/no-ops — see
-# addAgentLearningPage in src/lib/agents.ts) absorbs the overlap. On pay-as-you-go
-# X pricing this is cheap: empty polls read 0 posts ($0); cost ≈ triggers × $0.01.
+# Cadence: every 10 minutes. Polls with `since_id` (the X-recommended pattern):
+# each run fetches only mentions NEWER than the last one processed, so overlap is
+# near-zero. The cursor is persisted across runs via actions/cache; on a cache
+# miss (first run / eviction) or a stale cursor it falls back to a 48h safety
+# window — so a dropped run never loses a trigger. The cursor only advances when
+# a run had no failures (a failed ingest is retried next run; idempotent ingest
+# dedups). On pay-as-you-go X pricing this is the cheapest option: empty polls
+# read 0 posts ($0), and each trigger is read ~once.
 
 on:
   schedule:
@@ -37,6 +40,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # Persist the since_id cursor across runs. The unique key never hits on
+      # restore (so restore-keys fetches the latest prior cursor); the post step
+      # then saves the updated cursor under this run's key.
+      - name: Restore since_id cursor
+        uses: actions/cache@v4
+        with:
+          path: .x-ingest-state
+          key: x-ingest-since-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            x-ingest-since-
       - name: Poll @yoyoevolve reply-mentions and ingest the parent tweet's article/links
         env:
           X_BEARER_TOKEN: ${{ secrets.X_BEARER_TOKEN }}
@@ -44,6 +57,8 @@ jobs:
           YOPEDIA_URL: ${{ vars.YOPEDIA_URL || 'https://yopedia.yuanhao-li.workers.dev' }}
         run: |
           cat > x-ingest.mjs <<'EOF'
+          import { readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+
           const X_BEARER = process.env.X_BEARER_TOKEN;
           const SERVICE = process.env.YOPEDIA_SERVICE_TOKEN;
           const BASE = process.env.YOPEDIA_URL;
@@ -77,13 +92,34 @@ jobs:
                 }
               });
 
-          // 30-min lookback on a 10-min cron = 3× overlap, so a late/dropped run
-          // doesn't miss a trigger. Idempotent ingest dedups the overlap.
-          const startTime = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+          // Cursor (since_id) persisted via actions/cache. Each run fetches only
+          // mentions newer than the last processed; first run / cache miss /
+          // stale cursor → 48h safety window.
+          const STATE_DIR = ".x-ingest-state";
+          const STATE_FILE = `${STATE_DIR}/since_id.json`;
+          const loadSinceId = () => {
+            try {
+              return JSON.parse(readFileSync(STATE_FILE, "utf8")).since_id ?? null;
+            } catch {
+              return null;
+            }
+          };
+          const saveSinceId = (id) => {
+            mkdirSync(STATE_DIR, { recursive: true });
+            writeFileSync(STATE_FILE, JSON.stringify({ since_id: id, updated_at: new Date().toISOString() }));
+          };
+          const clearSinceId = () => {
+            try { rmSync(STATE_FILE); } catch {}
+          };
+
+          const sinceId = loadSinceId();
           const q = encodeURIComponent(`@${HANDLE} ${TRIGGER} is:reply -is:retweet`);
+          const bound = sinceId
+            ? `&since_id=${sinceId}`
+            : `&start_time=${new Date(Date.now() - 48 * 3600 * 1000).toISOString()}`;
           const url =
             `https://api.twitter.com/2/tweets/search/recent?query=${q}` +
-            `&max_results=50&start_time=${startTime}` +
+            `&max_results=100${bound}` +
             `&expansions=referenced_tweets.id,author_id` +
             `&tweet.fields=entities,author_id,referenced_tweets,article,created_at` +
             `&user.fields=username`;
@@ -100,6 +136,10 @@ jobs:
                 console.error(`FATAL: X rejected the bearer token (${res.status}: ${bodyText}) — check X_BEARER_TOKEN. Aborting.`);
                 process.exit(1);
               }
+              // A stale since_id (idle > ~7d) can make recent-search reject the
+              // request — drop the cursor so the next run self-heals via the 48h
+              // safety window.
+              if (sinceId) clearSinceId();
               console.warn(`X search failed (${res.status}: ${bodyText}) — transient, skipping this run.`);
               process.exit(0);
             }
@@ -198,6 +238,13 @@ jobs:
           }
 
           console.log(`Done: ${ingested} ingested, ${skipped} skipped, ${failed} failed (from ${mentions.length} mentions).`);
+
+          // Advance the cursor only on a clean run — a failed ingest (e.g.
+          // yopedia 5xx) must be retried next run, not skipped past. Idempotent
+          // ingest dedups anything re-fetched.
+          if (failed === 0 && payload.meta?.newest_id) {
+            saveSinceId(payload.meta.newest_id);
+          }
 
           // Loud failure when ingest attempts were made but none succeeded —
           // otherwise a dead loop (yopedia down / bad token) shows green forever.


### PR DESCRIPTION
Upgrades the @yoyoevolve loop from a time-window to the X-recommended **`since_id`** pattern, persisted across GitHub Actions runs via **`actions/cache`** — the requested design.

## How
- **`actions/cache`** stores `.x-ingest-state/since_id.json`. A unique per-run `key` never hits on restore, so `restore-keys` fetches the **latest prior cursor**; the post step saves the updated one. No tokens, no repo commits.
- Each run queries **`since_id=<last seen>`** → only mentions newer than the last processed → **near-zero overlap** (cheapest on pay-as-you-go: each trigger read ~once).
- **Hybrid fallback:** cache miss (first run / eviction) → **48h safety window**; a stale cursor X rejects **clears itself** so the next run falls back.
- **At-least-once:** the cursor advances **only on a clean run** (`failed === 0`) via `payload.meta.newest_id` — a failed ingest (e.g. yopedia 5xx) is retried next run, not skipped past; idempotent ingest dedups re-fetches.
- `max_results` 50 → 100 (catch-up after a gap). Cadence stays **every 10 min**.

All reply / `@yoyoevolve yopedia` / article+links logic unchanged. YAML + embedded ESM script validated. Workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)