### PR TITLE
yoyo: bump deprecated Node-20 GitHub Actions to v6

### DIFF
--- a/.github/workflows/architect.yml
+++ b/.github/workflows/architect.yml
@@ -37,17 +37,17 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.bot-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,18 +34,18 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.bot-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -31,15 +31,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 

--- a/.github/workflows/deploy-journal-pages.yml
+++ b/.github/workflows/deploy-journal-pages.yml
@@ -28,15 +28,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 

--- a/.github/workflows/hello.yml
+++ b/.github/workflows/hello.yml
@@ -17,7 +17,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.bot-token.outputs.token }}
 

--- a/.github/workflows/infra-setup.yml
+++ b/.github/workflows/infra-setup.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 

--- a/.github/workflows/office-hour.yml
+++ b/.github/workflows/office-hour.yml
@@ -33,17 +33,17 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.bot-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 

--- a/.github/workflows/pm.yml
+++ b/.github/workflows/pm.yml
@@ -35,17 +35,17 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.bot-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 

--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -35,17 +35,17 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.bot-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -32,18 +32,18 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.bot-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 

--- a/.github/workflows/seed-yoyo.yml
+++ b/.github/workflows/seed-yoyo.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out yoyo-evolve identity (public repo)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: yologdev/yoyo-evolve
           path: yoyo-evolve


### PR DESCRIPTION
## What
Bumps `actions/checkout`, `actions/setup-node`, and `pnpm/action-setup` from **v4 → v6** across all 10 workflows.

## Why
The 2026-06-01 deploy run flagged these three as Node-20 actions, which GitHub deprecates on **2026-06-16** (removed 2026-09-16). v6 is the current latest major and runs on Node 24.

## Safety
- `pnpm/action-setup@v6` requires a pinned `version` or a `packageManager` field — every workflow already sets `version: 9`, so no change needed there (verified across all 9 pnpm workflows).
- `setup-node@v6` keeps `node-version: "22"`; `checkout@v6` needs no config change.
- Merging triggers `deploy-cloudflare.yml` (it watches its own path), which exercises all three v6 actions end-to-end.

Left as-is (not flagged as deprecated): `actions/create-github-app-token@v1`, `configure-pages@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)