### PR TITLE
yoyo: diagnostic — log storage contents on system-token ingest 404

### DIFF
--- a/src/app/api/agents/[id]/ingest/route.ts
+++ b/src/app/api/agents/[id]/ingest/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { verifyAgentToken, addAgentLearningPage, getAgent } from "@/lib/agents";
 import { getServicePrincipal } from "@/lib/auth";
 import { ingestUrl, ingest, type IngestOptions } from "@/lib/ingest";
+import { getStorage } from "@/lib/storage";
 import { logger } from "@/lib/logger";
 
 interface RouteParams {
@@ -78,6 +79,20 @@ export async function POST(req: Request, { params }: RouteParams) {
         }
       }
       if (!agentRecord) {
+        // DIAGNOSTIC: a system-token ingest 404 means getAgent saw no file.
+        // Log what storage actually contains under agents/ so we can tell a
+        // genuine "not a user" from a storage/context mismatch.
+        let dbg = "?";
+        try {
+          const files = await getStorage().listFiles("agents");
+          dbg = files.map((f) => f.name).join(",") || "(empty)";
+        } catch (e) {
+          dbg = `list-error: ${e instanceof Error ? e.message : String(e)}`;
+        }
+        logger.error(
+          "agents",
+          `[ingest] system-token getAgent(${JSON.stringify(id)}) → null; agents/ = [${dbg}]`,
+        );
         return NextResponse.json(
           { error: `Agent "${id}" not found` },
           { status: 404 },


### PR DESCRIPTION
Temporary diagnostic to explain why a @yoyoevolve reply from a registered user (yuanhao) 404s at ingest while GET /api/agents/yuanhao--yoyo returns the agent. Logs what getStorage().listFiles sees under agents/ on the 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)