### PR TITLE
yoyo: x-ingest → call yopedia via service binding (fixes ingest 404)

### DIFF
--- a/src/app/api/agents/[id]/ingest/route.ts
+++ b/src/app/api/agents/[id]/ingest/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { verifyAgentToken, addAgentLearningPage, getAgent } from "@/lib/agents";
 import { getServicePrincipal } from "@/lib/auth";
 import { ingestUrl, ingest, type IngestOptions } from "@/lib/ingest";
-import { getStorage } from "@/lib/storage";
 import { logger } from "@/lib/logger";
 
 interface RouteParams {
@@ -79,20 +78,6 @@ export async function POST(req: Request, { params }: RouteParams) {
         }
       }
       if (!agentRecord) {
-        // DIAGNOSTIC: a system-token ingest 404 means getAgent saw no file.
-        // Log what storage actually contains under agents/ so we can tell a
-        // genuine "not a user" from a storage/context mismatch.
-        let dbg = "?";
-        try {
-          const files = await getStorage().listFiles("agents");
-          dbg = files.map((f) => f.name).join(",") || "(empty)";
-        } catch (e) {
-          dbg = `list-error: ${e instanceof Error ? e.message : String(e)}`;
-        }
-        logger.error(
-          "agents",
-          `[ingest] system-token getAgent(${JSON.stringify(id)}) → null; agents/ = [${dbg}]`,
-        );
         return NextResponse.json(
           { error: `Agent "${id}" not found` },
           { status: 404 },

--- a/workers/x-ingest/README.md
+++ b/workers/x-ingest/README.md
@@ -14,9 +14,12 @@ What it does each run:
   (`tweet.fields=article`) and/or its **external links** — into **that user's own
   yopedia content** (a normal page owned/authored by them, in their `/u/<handle>`
   + the public commons), via `POST /api/agents/<handle>--yoyo/ingest` with the
-  system token and **`asOwner: true`**. The `@yoyoevolve` mention is the "save
-  this to my wiki" command channel — it is **not** written to the agent's scoped
-  knowledge, and plain tweet text is never ingested.
+  system token and **`asOwner: true`**, dispatched through a **service binding**
+  to the yopedia Worker (`env.YOPEDIA.fetch`) — a plain `fetch()` to its
+  `workers.dev` URL is short-circuited at the edge for same-account Worker→Worker
+  calls (a cached 404 that never reaches origin). The `@yoyoevolve` mention is the
+  "save this to my wiki" command channel — it is **not** written to the agent's
+  scoped knowledge, and plain tweet text is never ingested.
 - Tracks a **`since_id` cursor in KV** (near-zero overlap); first run / missing /
   stale cursor falls back to a 48h window. The cursor advances only on a clean
   run, so a failed ingest is retried.

--- a/workers/x-ingest/index.ts
+++ b/workers/x-ingest/index.ts
@@ -20,8 +20,16 @@ interface KVNamespace {
   put(key: string, value: string): Promise<void>;
   delete(key: string): Promise<void>;
 }
+/** A service-binding Fetcher (the bound Worker), invoked instead of HTTP. */
+interface Fetcher {
+  fetch(input: string | Request, init?: RequestInit): Promise<Response>;
+}
 interface Env {
   CURSOR: KVNamespace;
+  // Service binding to the main yopedia Worker (see wrangler.jsonc). Routes
+  // subrequests directly to it, bypassing the workers.dev edge that otherwise
+  // short-circuits same-account Worker→Worker fetches with a cached 404.
+  YOPEDIA?: Fetcher;
   X_BEARER_TOKEN?: string;
   YOPEDIA_SERVICE_TOKEN?: string;
   YOPEDIA_URL?: string;
@@ -166,11 +174,18 @@ async function run(env: Env): Promise<Summary> {
   // (<handle>--yoyo) is only used to resolve the owner + gate on "registered
   // user" (404 ⇒ not a user); the resulting page is owned/authored by <handle>.
   async function ingestForOwner(agentId: string, body: object, label: string): Promise<IngestOutcome> {
-    const res = await fetch(`${BASE}/api/agents/${agentId}/ingest`, {
+    const target = `${BASE}/api/agents/${agentId}/ingest`;
+    const init: RequestInit = {
       method: "POST",
       headers: { Authorization: `Bearer ${SERVICE}`, "Content-Type": "application/json" },
       body: JSON.stringify({ ...body, asOwner: true }),
-    });
+    };
+    // Prefer the service binding (direct Worker→Worker dispatch). Fall back to
+    // plain HTTP only if the binding is absent (e.g. local dev) — note that the
+    // HTTP path is unreliable on the same account's workers.dev (cached 404).
+    const res = env.YOPEDIA
+      ? await env.YOPEDIA.fetch(target, init)
+      : await fetch(target, init);
     if (res.status === 200) {
       // A 200 means the server committed the page, so the outcome is
       // authoritative even if the body is unreadable — but warn rather than

--- a/workers/x-ingest/wrangler.jsonc
+++ b/workers/x-ingest/wrangler.jsonc
@@ -17,6 +17,15 @@
     { "binding": "CURSOR", "id": "31e48c3fc033443788f1d3fe130e6266" }
   ],
 
+  // Service binding to the main yopedia Worker. We call it via env.YOPEDIA.fetch()
+  // instead of fetch("https://yopedia.…workers.dev") because a Worker fetching
+  // another Worker on the same account's workers.dev hostname is short-circuited
+  // at the edge (a cached/synthetic 404 that never reaches origin). The binding
+  // routes the subrequest directly to the Worker, bypassing DNS + edge cache.
+  "services": [{ "binding": "YOPEDIA", "service": "yopedia" }],
+
+  // YOPEDIA_URL is only used to build the request path; the host is ignored when
+  // the request is dispatched through the service binding.
   "vars": { "YOPEDIA_URL": "https://yopedia.yuanhao-li.workers.dev" }
 
   // Secrets (set with `wrangler secret put --config workers/x-ingest/wrangler.jsonc`):


### PR DESCRIPTION
## Root cause
The `@yoyoevolve` reply was matched and its article parsed fine, but ingest always 404'd. **The x-ingest Worker's `fetch()` to `yopedia.…workers.dev/api/agents/<id>/ingest` never reached the origin Worker** — a same-account Worker→Worker call to a `workers.dev` hostname is short-circuited at the edge (cached/synthetic 404).

Confirmed via `wrangler tail` on the `yopedia` worker: an **external curl** to the exact URL hit origin (401), but the **Worker's subrequest** returned 404 with **zero origin traffic** logged.

## Fix
- Add a **service binding** `services: [{ binding: "YOPEDIA", service: "yopedia" }]` to `workers/x-ingest/wrangler.jsonc`.
- Dispatch the ingest via `env.YOPEDIA.fetch()` (direct Worker→Worker, bypassing DNS + edge cache); falls back to plain `fetch` when the binding is absent (local dev).
- Revert the temporary storage diagnostic from #310 — the request never reached the route, so `getAgent` was never the issue.

## Verified
Worker type-checks under `--strict`; `pnpm lint` clean; 12 ingest-route tests pass (asOwner coverage intact).

Deploy order in `deploy-cloudflare.yml` already deploys `yopedia` before `yopedia-x-ingest`, so the bound service exists at bind time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)