### PR TITLE
yoyo: fix x-ingest same-zone block (error 1042)

### DIFF
--- a/src/app/api/agents/[id]/ingest/route.ts
+++ b/src/app/api/agents/[id]/ingest/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { verifyAgentToken, addAgentLearningPage, getAgent } from "@/lib/agents";
 import { getServicePrincipal } from "@/lib/auth";
 import { ingestUrl, ingest, type IngestOptions } from "@/lib/ingest";
-import { getStorage } from "@/lib/storage";
 import { logger } from "@/lib/logger";
 
 interface RouteParams {
@@ -79,24 +78,6 @@ export async function POST(req: Request, { params }: RouteParams) {
         }
       }
       if (!agentRecord) {
-        // DIAGNOSTIC: getAgent saw no file for a system-token ingest. Log the
-        // resolved storage provider + what it lists under agents/, to tell a
-        // genuine "not a user" from a wrong-storage-context (e.g. fs fallback
-        // when invoked via service binding).
-        let prov = "?";
-        let dbg = "?";
-        try {
-          const s = getStorage();
-          prov = s.constructor?.name ?? "unknown";
-          const files = await s.listFiles("agents");
-          dbg = files.map((f) => f.name).join(",") || "(empty)";
-        } catch (e) {
-          dbg = `err:${e instanceof Error ? e.message : String(e)}`;
-        }
-        logger.error(
-          "agents",
-          `[ingest-dbg] getAgent(${JSON.stringify(id)})=null provider=${prov} agents/=[${dbg}]`,
-        );
         return NextResponse.json(
           { error: `Agent "${id}" not found` },
           { status: 404 },

--- a/workers/x-ingest/README.md
+++ b/workers/x-ingest/README.md
@@ -14,12 +14,16 @@ What it does each run:
   (`tweet.fields=article`) and/or its **external links** — into **that user's own
   yopedia content** (a normal page owned/authored by them, in their `/u/<handle>`
   + the public commons), via `POST /api/agents/<handle>--yoyo/ingest` with the
-  system token and **`asOwner: true`**, dispatched through a **service binding**
-  to the yopedia Worker (`env.YOPEDIA.fetch`) — a plain `fetch()` to its
-  `workers.dev` URL is short-circuited at the edge for same-account Worker→Worker
-  calls (a cached 404 that never reaches origin). The `@yoyoevolve` mention is the
-  "save this to my wiki" command channel — it is **not** written to the agent's
-  scoped knowledge, and plain tweet text is never ingested.
+  system token and **`asOwner: true`**. The `@yoyoevolve` mention is the "save
+  this to my wiki" command channel — it is **not** written to the agent's scoped
+  knowledge, and plain tweet text is never ingested.
+
+> **Same-zone fetch note:** the ingest call targets the main yopedia Worker on
+> the same account (`yopedia.<sub>.workers.dev`). A plain Worker→Worker `fetch()`
+> on the same zone is blocked by Cloudflare (**error 1042**), so this Worker sets
+> the **`global_fetch_strictly_public`** compatibility flag, which makes `fetch()`
+> resolve as a normal public request. (A service binding is the alternative, but
+> it still 1042s when called with the real same-zone hostname as the URL.)
 - Tracks a **`since_id` cursor in KV** (near-zero overlap); first run / missing /
   stale cursor falls back to a 48h window. The cursor advances only on a clean
   run, so a failed ingest is retried.

--- a/workers/x-ingest/index.ts
+++ b/workers/x-ingest/index.ts
@@ -20,16 +20,8 @@ interface KVNamespace {
   put(key: string, value: string): Promise<void>;
   delete(key: string): Promise<void>;
 }
-/** A service-binding Fetcher (the bound Worker), invoked instead of HTTP. */
-interface Fetcher {
-  fetch(input: string | Request, init?: RequestInit): Promise<Response>;
-}
 interface Env {
   CURSOR: KVNamespace;
-  // Service binding to the main yopedia Worker (see wrangler.jsonc). Routes
-  // subrequests directly to it, bypassing the workers.dev edge that otherwise
-  // short-circuits same-account Worker→Worker fetches with a cached 404.
-  YOPEDIA?: Fetcher;
   X_BEARER_TOKEN?: string;
   YOPEDIA_SERVICE_TOKEN?: string;
   YOPEDIA_URL?: string;
@@ -180,12 +172,10 @@ async function run(env: Env): Promise<Summary> {
       headers: { Authorization: `Bearer ${SERVICE}`, "Content-Type": "application/json" },
       body: JSON.stringify({ ...body, asOwner: true }),
     };
-    // Prefer the service binding (direct Worker→Worker dispatch). Fall back to
-    // plain HTTP only if the binding is absent (e.g. local dev) — note that the
-    // HTTP path is unreliable on the same account's workers.dev (cached 404).
-    const res = env.YOPEDIA
-      ? await env.YOPEDIA.fetch(target, init)
-      : await fetch(target, init);
+    // Plain public fetch to the yopedia Worker. The worker sets the
+    // `global_fetch_strictly_public` compat flag so this same-zone request
+    // resolves as a normal public request instead of being blocked (error 1042).
+    const res = await fetch(target, init);
     if (res.status === 200) {
       // A 200 means the server committed the page, so the outcome is
       // authoritative even if the body is unreadable — but warn rather than
@@ -197,22 +187,25 @@ async function run(env: Env): Promise<Summary> {
       console.log(`✓ ${agentId} (owner content): ${label} → ${data.slug ?? "(ok)"}${data.deduped ? " (deduped)" : ""}`);
       return "ingested";
     }
+    // Non-200: capture a short body snippet for context (it surfaces both the
+    // route's JSON error and any Cloudflare edge error like 1042).
+    const errBody = (await res.text().catch(() => "")).slice(0, 200).replace(/\s+/g, " ");
     if (res.status === 404) {
       console.log(`· ${agentId} is not a yopedia user — skipped (${label})`);
       return "not-a-user";
     }
     if (res.status === 401 || res.status === 403) {
-      throw new Error(`service token rejected (${res.status}) — check YOPEDIA_SERVICE_TOKEN`);
+      throw new Error(`service token rejected (${res.status}: ${errBody}) — check YOPEDIA_SERVICE_TOKEN`);
     }
     if (res.status >= 500 || res.status === 429) {
       // Transient — retry next run. Counting as `failed` holds the cursor.
-      console.warn(`! ${agentId}: ingest transient failure (${res.status}) (${label}) — will retry`);
+      console.warn(`! ${agentId}: ingest transient failure (${res.status}: ${errBody}) (${label}) — will retry`);
       return "failed";
     }
     // Other 4xx (e.g. 400 bad body): permanent for this exact payload. Retrying
     // is futile and would wedge the cursor forever, blocking all later mentions
     // — so drop it loudly and let the cursor advance past it.
-    console.error(`✗ ${agentId}: ingest permanently rejected (${res.status}) (${label}) — dropping`);
+    console.error(`✗ ${agentId}: ingest permanently rejected (${res.status}: ${errBody}) (${label}) — dropping`);
     return "dropped";
   }
 

--- a/workers/x-ingest/wrangler.jsonc
+++ b/workers/x-ingest/wrangler.jsonc
@@ -8,6 +8,14 @@
   "main": "index.ts",
   "compatibility_date": "2025-01-01",
 
+  // The ingest call targets the main yopedia Worker on the same account/zone
+  // (yopedia.<sub>.workers.dev). A plain Worker→Worker fetch on the same zone is
+  // blocked by Cloudflare (error 1042). This flag makes fetch() resolve as a
+  // normal public request (like an external client), which is exactly how the
+  // endpoint is reached successfully. (Service bindings are the alternative, but
+  // they still 1042 when called with the real same-zone hostname as the URL.)
+  "compatibility_flags": ["global_fetch_strictly_public"],
+
   // Reliable cadence (Cloudflare crons fire dependably, unlike GitHub schedules).
   "triggers": { "crons": ["*/10 * * * *"] },
 
@@ -17,15 +25,6 @@
     { "binding": "CURSOR", "id": "31e48c3fc033443788f1d3fe130e6266" }
   ],
 
-  // Service binding to the main yopedia Worker. We call it via env.YOPEDIA.fetch()
-  // instead of fetch("https://yopedia.…workers.dev") because a Worker fetching
-  // another Worker on the same account's workers.dev hostname is short-circuited
-  // at the edge (a cached/synthetic 404 that never reaches origin). The binding
-  // routes the subrequest directly to the Worker, bypassing DNS + edge cache.
-  "services": [{ "binding": "YOPEDIA", "service": "yopedia" }],
-
-  // YOPEDIA_URL is only used to build the request path; the host is ignored when
-  // the request is dispatched through the service binding.
   "vars": { "YOPEDIA_URL": "https://yopedia.yuanhao-li.workers.dev" }
 
   // Secrets (set with `wrangler secret put --config workers/x-ingest/wrangler.jsonc`):


### PR DESCRIPTION
## Root cause
The `@yoyoevolve` ingest always 404'd because the x-ingest Worker calling the main `yopedia` Worker on the **same account** (`yopedia.<sub>.workers.dev`) is a same-zone Worker→Worker `fetch()`, which **Cloudflare blocks with error 1042**. It surfaced as a generic 404 the worker mislabeled "not a yopedia user." Search, cursor, owner-attribution, and article parsing were all correct — the request just never reached the route.

## Fix
Set the **`global_fetch_strictly_public`** compatibility flag on the x-ingest Worker so its `fetch()` to the yopedia URL resolves as a normal public request (the exact path an external client already uses successfully).

- `wrangler.jsonc`: add the flag; remove the service binding (it still 1042s when called with the real same-zone hostname as the URL).
- `index.ts`: plain `fetch()`; log a short response-body snippet on failures so an edge error like 1042 is visible next time.
- Revert the temporary diagnostics from #310/#312.

## Verified end-to-end
The reply now ingests as the user's **own content** (`owner: yuanhao`, normal page in /u/yuanhao), `Done: 1 ingested`, and agent `learningPages` stays empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)