### PR TITLE
yoyo: image support — render ingested images, render raw markdown, ingest images via vision

### DIFF
--- a/src/app/api/agents/[id]/ingest/route.ts
+++ b/src/app/api/agents/[id]/ingest/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { verifyAgentToken, addAgentLearningPage, getAgent } from "@/lib/agents";
 import { getServicePrincipal } from "@/lib/auth";
-import { ingestUrl, ingest, type IngestOptions } from "@/lib/ingest";
+import { ingestUrl, ingest, ingestImage, type IngestOptions } from "@/lib/ingest";
 import { logger } from "@/lib/logger";
 
 interface RouteParams {
@@ -87,7 +87,13 @@ export async function POST(req: Request, { params }: RouteParams) {
       return NextResponse.json({ error: "Invalid token." }, { status: 401 });
     }
 
-    let body: { url?: unknown; text?: unknown; title?: unknown; asOwner?: unknown };
+    let body: {
+      url?: unknown;
+      text?: unknown;
+      title?: unknown;
+      imageUrl?: unknown;
+      asOwner?: unknown;
+    };
     try {
       body = await req.json();
     } catch {
@@ -97,9 +103,10 @@ export async function POST(req: Request, { params }: RouteParams) {
     const url = typeof body.url === "string" ? body.url.trim() : "";
     const text = typeof body.text === "string" ? body.text : "";
     const title = typeof body.title === "string" ? body.title : "";
-    if (!url && !text) {
+    const imageUrl = typeof body.imageUrl === "string" ? body.imageUrl.trim() : "";
+    if (!url && !text && !imageUrl) {
       return NextResponse.json(
-        { error: "Provide a 'url' or 'text' to ingest." },
+        { error: "Provide a 'url', 'text', or 'imageUrl' to ingest." },
         { status: 400 },
       );
     }
@@ -129,9 +136,11 @@ export async function POST(req: Request, { params }: RouteParams) {
         pageType: AGENT_KNOWLEDGE_TYPE,
       };
     }
-    const result = url
-      ? await ingestUrl(url, opts)
-      : await ingest(title || "Untitled", text, opts);
+    const result = imageUrl
+      ? await ingestImage({ imageUrl }, { ...opts, title: title || undefined })
+      : url
+        ? await ingestUrl(url, opts)
+        : await ingest(title || "Untitled", text, opts);
 
     // Agent-knowledge ingests attach to the agent's learnings; owner-content
     // ingests do not (they live in the owner's normal content space).

--- a/src/app/api/assets/[...path]/route.ts
+++ b/src/app/api/assets/[...path]/route.ts
@@ -1,0 +1,89 @@
+import { rawRelPath } from "@/lib/wiki";
+import { getStorage } from "@/lib/storage";
+
+/**
+ * GET /api/assets/[...path]
+ *
+ * Serves a binary asset (image) that was stored during ingest. Ingested images
+ * live at the storage key `raw/assets/{slug}/{file}` and are referenced in
+ * markdown by the relative path `assets/{slug}/{file}` (see `downloadImages` in
+ * `lib/fetch.ts`). This route maps a request path back to that storage key and
+ * streams the bytes with the right Content-Type.
+ *
+ * Public + read-only: the middleware only gates write methods on `/api`.
+ */
+
+/** Map a file extension to a Content-Type. */
+const CONTENT_TYPES: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  avif: "image/avif",
+  bmp: "image/bmp",
+  ico: "image/x-icon",
+};
+
+function contentTypeFor(name: string): string {
+  const dot = name.lastIndexOf(".");
+  const ext = dot >= 0 ? name.slice(dot + 1).toLowerCase() : "";
+  return CONTENT_TYPES[ext] ?? "application/octet-stream";
+}
+
+/** Reject a path segment that could escape the assets dir. */
+function isUnsafeSegment(seg: string): boolean {
+  return (
+    seg.length === 0 ||
+    seg === "." ||
+    seg === ".." ||
+    seg.includes("/") ||
+    seg.includes("\\") ||
+    seg.includes("\0")
+  );
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const { path: segments } = await params;
+
+  // Traversal guard: the filesystem provider resolves keys with path.resolve,
+  // so a `..` segment could otherwise escape the data dir. 404 (not 400) to
+  // avoid leaking which paths exist.
+  if (!segments?.length || segments.some(isUnsafeSegment)) {
+    return new Response(null, { status: 404 });
+  }
+
+  // markdown ref `assets/<...>` → storage key `raw/assets/<...>` (rawRelPath is
+  // the single source of truth used by the writer, so a RAW_DIR override stays
+  // consistent).
+  const storageKey = rawRelPath(`assets/${segments.join("/")}`);
+
+  let bytes: ArrayBuffer;
+  try {
+    bytes = await getStorage().readAsset(storageKey);
+  } catch {
+    return new Response(null, { status: 404 });
+  }
+
+  const name = segments[segments.length - 1];
+  const contentType = contentTypeFor(name);
+  const headers: Record<string, string> = {
+    "Content-Type": contentType,
+    "Content-Length": String(bytes.byteLength),
+    "Cache-Control": "public, max-age=31536000, immutable",
+    "X-Content-Type-Options": "nosniff",
+  };
+  // SVGs are served same-origin and can carry inline script — sandbox + a
+  // restrictive CSP let them render as images without executing anything.
+  if (contentType === "image/svg+xml") {
+    headers["Content-Security-Policy"] =
+      "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+    headers["Content-Disposition"] = "inline";
+  }
+
+  return new Response(bytes, { status: 200, headers });
+}

--- a/src/app/api/assets/[...path]/route.ts
+++ b/src/app/api/assets/[...path]/route.ts
@@ -1,5 +1,7 @@
 import { rawRelPath } from "@/lib/wiki";
 import { getStorage } from "@/lib/storage";
+import { isEnoent } from "@/lib/errors";
+import { logger } from "@/lib/logger";
 
 /**
  * GET /api/assets/[...path]
@@ -65,8 +67,13 @@ export async function GET(
   let bytes: ArrayBuffer;
   try {
     bytes = await getStorage().readAsset(storageKey);
-  } catch {
-    return new Response(null, { status: 404 });
+  } catch (err) {
+    // A genuinely missing asset is a 404; anything else (R2 outage, binding
+    // failure) is a real incident — surface it as 500 + log so it isn't
+    // indistinguishable from "file not found".
+    if (isEnoent(err)) return new Response(null, { status: 404 });
+    logger.error("assets", `readAsset failed for ${storageKey}`, err);
+    return new Response(null, { status: 500 });
   }
 
   const name = segments[segments.length - 1];

--- a/src/app/api/ingest/image/route.ts
+++ b/src/app/api/ingest/image/route.ts
@@ -3,7 +3,7 @@ import { ingestImage } from "@/lib/ingest";
 import type { IngestOptions } from "@/lib/ingest";
 import { isUrl } from "@/lib/fetch";
 import { getPrincipal } from "@/lib/auth";
-import { getErrorMessage } from "@/lib/errors";
+import { ClientInputError, getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 import { MAX_RESPONSE_SIZE } from "@/lib/constants";
 
@@ -76,12 +76,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(result);
   } catch (error) {
     const msg = getErrorMessage(error);
-    // Bad-input failures from fetching/storing the image are the caller's fault.
-    const clientError =
-      /not an image|too large|Failed to fetch image|unsafe|blocked|private|Invalid/i.test(
-        msg,
-      );
-    if (!clientError) logger.error("ingest", "Image ingest error", error);
-    return NextResponse.json({ error: msg }, { status: clientError ? 400 : 500 });
+    // Bad-input failures (unsafe/oversized/non-image URL) are tagged
+    // ClientInputError by the store helpers → 400. Anything else is a real
+    // server failure → 500 + error log (always log so nothing is masked).
+    if (error instanceof ClientInputError) {
+      logger.warn("ingest", `Image ingest rejected: ${msg}`);
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    logger.error("ingest", "Image ingest error", error);
+    return NextResponse.json({ error: msg }, { status: 500 });
   }
 }

--- a/src/app/api/ingest/image/route.ts
+++ b/src/app/api/ingest/image/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ingestImage } from "@/lib/ingest";
+import type { IngestOptions } from "@/lib/ingest";
+import { isUrl } from "@/lib/fetch";
+import { getPrincipal } from "@/lib/auth";
+import { getErrorMessage } from "@/lib/errors";
+import { logger } from "@/lib/logger";
+import { MAX_RESPONSE_SIZE } from "@/lib/constants";
+
+/**
+ * POST /api/ingest/image
+ *
+ * Ingest a single image — by URL (JSON) or file upload (multipart). The image
+ * is stored as an asset, described by a vision model, and written as a wiki page
+ * that embeds the image + description. Session-gated like /api/ingest.
+ *
+ *   JSON:      { imageUrl: string, title?: string, tags?: string[] }
+ *   multipart: file=<blob>, title?=<string>, tags?=<comma-separated>
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    // Attribution comes from the session, never the request body.
+    const options: IngestOptions & { title?: string } = {
+      author: principal.handle,
+      owner: principal.handle,
+      triggeredBy: principal.handle,
+    };
+
+    const contentType = request.headers.get("content-type") || "";
+
+    if (contentType.includes("multipart/form-data")) {
+      const form = await request.formData();
+      const file = form.get("file");
+      if (!(file instanceof File) || file.size === 0) {
+        return NextResponse.json(
+          { error: "A non-empty 'file' is required." },
+          { status: 400 },
+        );
+      }
+      if (file.size > MAX_RESPONSE_SIZE) {
+        return NextResponse.json(
+          { error: `Image too large (max ${MAX_RESPONSE_SIZE} bytes).` },
+          { status: 400 },
+        );
+      }
+      const title = form.get("title");
+      if (typeof title === "string" && title.trim()) options.title = title.trim();
+      const tags = form.get("tags");
+      if (typeof tags === "string" && tags.trim()) {
+        options.tags = tags.split(",").map((t) => t.trim()).filter(Boolean);
+      }
+      const bytes = await file.arrayBuffer();
+      const result = await ingestImage({ bytes, filename: file.name }, options);
+      return NextResponse.json(result);
+    }
+
+    // JSON path: { imageUrl, title?, tags? }
+    const body = await request.json();
+    const { imageUrl, title, tags } = body;
+    if (typeof imageUrl !== "string" || !isUrl(imageUrl.trim())) {
+      return NextResponse.json(
+        { error: "imageUrl is required and must be a valid URL." },
+        { status: 400 },
+      );
+    }
+    if (typeof title === "string" && title.trim()) options.title = title.trim();
+    if (Array.isArray(tags) && tags.every((t: unknown) => typeof t === "string")) {
+      options.tags = tags;
+    }
+    const result = await ingestImage({ imageUrl: imageUrl.trim() }, options);
+    return NextResponse.json(result);
+  } catch (error) {
+    const msg = getErrorMessage(error);
+    // Bad-input failures from fetching/storing the image are the caller's fault.
+    const clientError =
+      /not an image|too large|Failed to fetch image|unsafe|blocked|private|Invalid/i.test(
+        msg,
+      );
+    if (!clientError) logger.error("ingest", "Image ingest error", error);
+    return NextResponse.json({ error: msg }, { status: clientError ? 400 : 500 });
+  }
+}

--- a/src/app/ingest/page.tsx
+++ b/src/app/ingest/page.tsx
@@ -14,6 +14,8 @@ export default function IngestPage() {
     title,
     content,
     url,
+    imageUrl,
+    imageFile,
     loading,
     error,
     result,
@@ -23,9 +25,12 @@ export default function IngestPage() {
     setTitle,
     setContent,
     setUrl,
+    setImageUrl,
+    setImageFile,
     handlePreview,
     handleApprove,
     handleDirectIngest,
+    handleImageIngest,
     reset,
     cancelPreview,
     toggleRawMarkdown,
@@ -78,7 +83,7 @@ export default function IngestPage() {
 
       {/* Mode tabs */}
       <div className="mb-6 flex gap-2 overflow-x-auto">
-        {(["text", "url", "batch"] as const).map((m) => (
+        {(["text", "url", "image", "batch"] as const).map((m) => (
           <button
             key={m}
             type="button"
@@ -89,13 +94,79 @@ export default function IngestPage() {
                 : "border border-foreground/20 text-foreground/60 hover:text-foreground"
             }`}
           >
-            {m === "text" ? "Paste Text" : m === "url" ? "From URL" : "Batch URLs"}
+            {m === "text"
+              ? "Paste Text"
+              : m === "url"
+                ? "From URL"
+                : m === "image"
+                  ? "Image"
+                  : "Batch URLs"}
           </button>
         ))}
       </div>
 
-      {/* Batch mode */}
-      {mode === "batch" ? (
+      {/* Image mode */}
+      {mode === "image" ? (
+        <form onSubmit={handleImageIngest} className="space-y-6">
+          <div>
+            <label htmlFor="imageUrl" className="block text-sm font-medium mb-2">
+              Image URL
+            </label>
+            <input
+              id="imageUrl"
+              type="url"
+              value={imageUrl}
+              onChange={(e) => setImageUrl(e.target.value)}
+              disabled={!!imageFile}
+              placeholder="https://example.com/image.png"
+              className="w-full rounded-lg border border-foreground/20 bg-transparent px-4 py-2.5 text-sm placeholder:text-foreground/40 focus:border-foreground/50 focus:outline-none transition-colors disabled:opacity-50"
+            />
+          </div>
+
+          <div className="text-center text-xs text-foreground/40">— or —</div>
+
+          <div>
+            <label htmlFor="imageFile" className="block text-sm font-medium mb-2">
+              Upload an image
+            </label>
+            <input
+              id="imageFile"
+              type="file"
+              accept="image/*"
+              onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
+              className="w-full text-sm text-foreground/80 file:mr-3 file:rounded-lg file:border file:border-foreground/20 file:bg-transparent file:px-4 file:py-2 file:text-sm file:text-foreground hover:file:border-foreground/50"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="imageTitle" className="block text-sm font-medium mb-2">
+              Title <span className="text-foreground/40">(optional)</span>
+            </label>
+            <input
+              id="imageTitle"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Defaults to the filename"
+              className="w-full rounded-lg border border-foreground/20 bg-transparent px-4 py-2.5 text-sm placeholder:text-foreground/40 focus:border-foreground/50 focus:outline-none transition-colors"
+            />
+            <p className="mt-2 text-xs text-foreground/40">
+              A vision model reads the image into a page that embeds it.
+            </p>
+          </div>
+
+          {error && <Alert variant="error">{error}</Alert>}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="inline-block rounded-lg bg-foreground px-6 py-3 text-sm font-medium text-background hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? "Processing..." : "Ingest image"}
+          </button>
+        </form>
+      ) : /* Batch mode */
+      mode === "batch" ? (
         <BatchIngestForm />
       ) : (
       <form onSubmit={handlePreview} className="space-y-6">

--- a/src/app/raw/[slug]/page.tsx
+++ b/src/app/raw/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { decodeSlug } from "@/lib/slugify";
 import { notFound } from "next/navigation";
 import { readRawSource } from "@/lib/wiki";
+import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 
 interface RawSourcePageProps {
   params: Promise<{ slug: string }>;
@@ -79,9 +80,11 @@ export default async function RawSourcePage({ params }: RawSourcePageProps) {
         </div>
       )}
 
-      <pre className="mt-6 max-h-[70vh] overflow-auto whitespace-pre-wrap break-words rounded-lg border border-foreground/10 bg-foreground/[0.03] p-4 font-mono text-sm text-foreground/90">
-        {displayedContent}
-      </pre>
+      {/* Render the markdown so images and formatting show. The "View raw"
+          link above serves the unrendered plaintext via /api/raw. */}
+      <div className="mt-6 max-h-[70vh] overflow-auto rounded-lg border border-foreground/10 bg-foreground/[0.03] p-4">
+        <MarkdownRenderer content={displayedContent} />
+      </div>
     </main>
   );
 }

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -17,6 +17,29 @@ function stripFrontmatter(content: string): string {
   return content.replace(/^---\n[\s\S]*?\n---\n?\n?/, "");
 }
 
+/**
+ * Resolve a markdown image `src` to something the browser can load. Images
+ * ingested from sources are stored as assets and referenced by the relative
+ * path `assets/{slug}/{file}` (or occasionally the physical `raw/assets/...`);
+ * those are served by `/api/assets/...`. Absolute URLs (http(s)/data) are left
+ * untouched so images that weren't downloaded still render.
+ */
+function resolveImageSrc(src: string): string {
+  if (
+    src.startsWith("data:") ||
+    src.startsWith("http://") ||
+    src.startsWith("https://") ||
+    src.startsWith("/api/assets/")
+  ) {
+    return src;
+  }
+  const ref = src.startsWith("raw/assets/") ? src.slice("raw/".length) : src;
+  if (ref.startsWith("assets/")) {
+    return `/api/assets/${ref.slice("assets/".length)}`;
+  }
+  return src;
+}
+
 export function MarkdownRenderer({ content }: MarkdownRendererProps) {
   const body = stripFrontmatter(content);
   return (
@@ -24,6 +47,21 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
+          img: ({ src, alt, ...props }) => {
+            if (typeof src !== "string") return null;
+            return (
+              // Source images come from arbitrary origins/our asset route, not a
+              // configured next/image loader, so a plain <img> is correct here.
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={resolveImageSrc(src)}
+                alt={alt ?? ""}
+                loading="lazy"
+                style={{ maxWidth: "100%", height: "auto" }}
+                {...props}
+              />
+            );
+          },
           a: ({ href, children, ...props }) => {
             // Rewrite internal .md links to /wiki/ routes using Next.js Link
             if (href && href.endsWith(".md") && !href.startsWith("http")) {

--- a/src/hooks/useIngest.ts
+++ b/src/hooks/useIngest.ts
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import type { PreviewData } from "@/components/IngestPreview";
 
-export type Mode = "text" | "url" | "batch";
+export type Mode = "text" | "url" | "batch" | "image";
 export type Stage = "form" | "preview" | "success";
 
 export interface IngestResponse {
@@ -23,6 +23,8 @@ export interface UseIngestReturn {
   title: string;
   content: string;
   url: string;
+  imageUrl: string;
+  imageFile: File | null;
   loading: boolean;
   error: string | null;
   result: IngestResponse | null;
@@ -33,9 +35,12 @@ export interface UseIngestReturn {
   setTitle: (v: string) => void;
   setContent: (v: string) => void;
   setUrl: (v: string) => void;
+  setImageUrl: (v: string) => void;
+  setImageFile: (f: File | null) => void;
   handlePreview: (e: React.FormEvent) => void;
   handleApprove: () => void;
   handleDirectIngest: (e: React.FormEvent) => void;
+  handleImageIngest: (e: React.FormEvent) => void;
   reset: () => void;
   cancelPreview: () => void;
   toggleRawMarkdown: () => void;
@@ -77,6 +82,8 @@ export function useIngest(): UseIngestReturn {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const [url, setUrl] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const [imageFile, setImageFile] = useState<File | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<IngestResponse | null>(null);
@@ -91,10 +98,17 @@ export function useIngest(): UseIngestReturn {
       setContent("");
     } else if (newMode === "text") {
       setUrl("");
+    } else if (newMode === "image") {
+      setContent("");
+      setUrl("");
     } else {
       setTitle("");
       setContent("");
       setUrl("");
+    }
+    if (newMode !== "image") {
+      setImageUrl("");
+      setImageFile(null);
     }
   }
 
@@ -220,10 +234,66 @@ export function useIngest(): UseIngestReturn {
     }
   }
 
+  /** Image ingest: store image, describe via vision model, write a page. No
+   *  preview stage (the body is just the image + description). */
+  async function handleImageIngest(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (!imageFile && !imageUrl.trim()) {
+      setError("Provide an image URL or choose a file");
+      return;
+    }
+    if (!imageFile && imageUrl.trim()) {
+      try {
+        new URL(imageUrl.trim());
+      } catch {
+        setError("Please enter a valid image URL");
+        return;
+      }
+    }
+
+    setLoading(true);
+    setResult(null);
+
+    try {
+      let res: Response;
+      if (imageFile) {
+        const fd = new FormData();
+        fd.append("file", imageFile);
+        if (title.trim()) fd.append("title", title.trim());
+        res = await fetch("/api/ingest/image", { method: "POST", body: fd });
+      } else {
+        res = await fetch("/api/ingest/image", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            imageUrl: imageUrl.trim(),
+            title: title.trim() || undefined,
+          }),
+        });
+      }
+
+      const data: IngestResponse = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Something went wrong");
+        return;
+      }
+      setResult(data);
+      setStage("success");
+    } catch {
+      setError("Network error — could not reach the server");
+    } finally {
+      setLoading(false);
+    }
+  }
+
   function reset() {
     setTitle("");
     setContent("");
     setUrl("");
+    setImageUrl("");
+    setImageFile(null);
     setError(null);
     setResult(null);
     setPreview(null);
@@ -248,6 +318,8 @@ export function useIngest(): UseIngestReturn {
     title,
     content,
     url,
+    imageUrl,
+    imageFile,
     loading,
     error,
     result,
@@ -257,9 +329,12 @@ export function useIngest(): UseIngestReturn {
     setTitle,
     setContent,
     setUrl,
+    setImageUrl,
+    setImageFile,
     handlePreview,
     handleApprove,
     handleDirectIngest,
+    handleImageIngest,
     reset,
     cancelPreview,
     toggleRawMarkdown,

--- a/src/lib/__tests__/assets-route.test.ts
+++ b/src/lib/__tests__/assets-route.test.ts
@@ -43,12 +43,21 @@ describe("GET /api/assets/[...path]", () => {
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
   });
 
-  it("404s on a missing asset (readAsset throws) without leaking the error", async () => {
-    readAssetReturning(new Error("ENOENT"));
+  it("404s on a genuinely missing asset (ENOENT)", async () => {
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    readAssetReturning(enoent);
     const res = await GET(req(), {
       params: Promise.resolve({ path: ["alice", "missing.png"] }),
     });
     expect(res.status).toBe(404);
+  });
+
+  it("500s on a real storage failure (not ENOENT) so an outage isn't masked as 404", async () => {
+    readAssetReturning(new Error("R2 service unavailable"));
+    const res = await GET(req(), {
+      params: Promise.resolve({ path: ["alice", "x.png"] }),
+    });
+    expect(res.status).toBe(500);
   });
 
   it.each([["..", "x.png"], ["alice", ".."], ["alice", "a/b.png"], ["", "x.png"]])(

--- a/src/lib/__tests__/assets-route.test.ts
+++ b/src/lib/__tests__/assets-route.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/storage", () => ({
+  getStorage: vi.fn(() => ({ readAsset: vi.fn() })),
+}));
+// rawRelPath maps a markdown ref to the physical storage key (raw/ prefix).
+vi.mock("@/lib/wiki", () => ({
+  rawRelPath: (f: string) => `raw/${f}`,
+}));
+
+import { getStorage } from "@/lib/storage";
+import { GET } from "@/app/api/assets/[...path]/route";
+
+const mockedGetStorage = vi.mocked(getStorage);
+
+function readAssetReturning(buf: ArrayBuffer | Error) {
+  const readAsset = vi.fn(() =>
+    buf instanceof Error ? Promise.reject(buf) : Promise.resolve(buf),
+  );
+  mockedGetStorage.mockReturnValue({ readAsset } as never);
+  return readAsset;
+}
+
+function req() {
+  return new Request("http://localhost/api/assets/x");
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /api/assets/[...path]", () => {
+  it("serves an asset, mapping assets/<...> → raw/assets/<...> with the right Content-Type", async () => {
+    const bytes = new Uint8Array([1, 2, 3]).buffer;
+    const readAsset = readAssetReturning(bytes);
+
+    const res = await GET(req(), {
+      params: Promise.resolve({ path: ["alice", "diagram.png"] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(readAsset).toHaveBeenCalledWith("raw/assets/alice/diagram.png");
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+    expect(res.headers.get("Cache-Control")).toContain("immutable");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("404s on a missing asset (readAsset throws) without leaking the error", async () => {
+    readAssetReturning(new Error("ENOENT"));
+    const res = await GET(req(), {
+      params: Promise.resolve({ path: ["alice", "missing.png"] }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it.each([["..", "x.png"], ["alice", ".."], ["alice", "a/b.png"], ["", "x.png"]])(
+    "404s and never reads storage on a traversal/unsafe segment: %j",
+    async (...path) => {
+      const readAsset = readAssetReturning(new Uint8Array().buffer);
+      const res = await GET(req(), { params: Promise.resolve({ path }) });
+      expect(res.status).toBe(404);
+      expect(readAsset).not.toHaveBeenCalled();
+    },
+  );
+
+  it("adds a sandbox CSP for SVGs (same-origin script neutralization)", async () => {
+    readAssetReturning(new Uint8Array([60]).buffer);
+    const res = await GET(req(), {
+      params: Promise.resolve({ path: ["alice", "logo.svg"] }),
+    });
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml");
+    expect(res.headers.get("Content-Security-Policy")).toContain("sandbox");
+  });
+
+  it("falls back to application/octet-stream for an unknown extension", async () => {
+    readAssetReturning(new Uint8Array([0]).buffer);
+    const res = await GET(req(), {
+      params: Promise.resolve({ path: ["alice", "file.bin"] }),
+    });
+    expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
+  });
+});

--- a/src/lib/__tests__/ingest-image-route.test.ts
+++ b/src/lib/__tests__/ingest-image-route.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/auth", () => ({ getPrincipal: vi.fn() }));
+vi.mock("@/lib/ingest", () => ({ ingestImage: vi.fn() }));
+
+import { getPrincipal } from "@/lib/auth";
+import { ingestImage } from "@/lib/ingest";
+import { ClientInputError } from "@/lib/errors";
+import { POST } from "@/app/api/ingest/image/route";
+
+const mockedPrincipal = vi.mocked(getPrincipal);
+const mockedIngestImage = vi.mocked(ingestImage);
+
+function jsonReq(body: unknown): Request {
+  return new Request("http://localhost/api/ingest/image", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedPrincipal.mockResolvedValue({ handle: "alice", id: "alice" } as never);
+  mockedIngestImage.mockResolvedValue({ primarySlug: "img", wikiPages: ["img"] } as never);
+});
+
+describe("POST /api/ingest/image", () => {
+  it("401 when not signed in", async () => {
+    mockedPrincipal.mockResolvedValue(null);
+    const res = await POST(jsonReq({ imageUrl: "https://x/a.png" }) as never);
+    expect(res.status).toBe(401);
+    expect(mockedIngestImage).not.toHaveBeenCalled();
+  });
+
+  it("400 when imageUrl is missing or not a URL", async () => {
+    expect((await POST(jsonReq({}) as never)).status).toBe(400);
+    expect((await POST(jsonReq({ imageUrl: "not-a-url" }) as never)).status).toBe(400);
+  });
+
+  it("ingests by URL with session attribution", async () => {
+    const res = await POST(jsonReq({ imageUrl: "https://x/a.png", title: "Pic" }) as never);
+    expect(res.status).toBe(200);
+    expect(mockedIngestImage).toHaveBeenCalledWith(
+      { imageUrl: "https://x/a.png" },
+      expect.objectContaining({ owner: "alice", author: "alice", title: "Pic" }),
+    );
+  });
+
+  it("maps a ClientInputError (bad/unsafe/oversized image) to 400", async () => {
+    mockedIngestImage.mockRejectedValue(new ClientInputError("URL is not an image"));
+    const res = await POST(jsonReq({ imageUrl: "https://x/a.png" }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("maps an unexpected error (e.g. storage outage) to 500, not 400", async () => {
+    mockedIngestImage.mockRejectedValue(new Error("R2 unavailable"));
+    const res = await POST(jsonReq({ imageUrl: "https://x/a.png" }) as never);
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/lib/__tests__/ingest-image.test.ts
+++ b/src/lib/__tests__/ingest-image.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+// LLM off — ingestImage uses generatedContent so the LLM is skipped anyway.
+vi.mock("../llm", () => ({ hasLLMKey: vi.fn(() => false), callLLM: vi.fn() }));
+// Vision is mocked (no Workers AI binding in tests).
+vi.mock("../vision", () => ({ describeImage: vi.fn() }));
+// Keep the real fetch module but stub the network-touching image helpers.
+vi.mock("../fetch", async (orig) => {
+  const actual = await orig<typeof import("../fetch")>();
+  return { ...actual, storeImageAsset: vi.fn(), storeImageBytes: vi.fn() };
+});
+
+import { ingest, ingestImage } from "../ingest";
+import { hasLLMKey, callLLM } from "../llm";
+import { describeImage } from "../vision";
+import { storeImageAsset } from "../fetch";
+import { readWikiPageWithFrontmatter } from "../wiki";
+import { parseSources } from "../sources";
+import { resetSourceIndex } from "../source-index";
+import { resetAliasIndex } from "../alias-index";
+
+const mockedDescribe = vi.mocked(describeImage);
+const mockedStore = vi.mocked(storeImageAsset);
+const mockedHasLLMKey = vi.mocked(hasLLMKey);
+const mockedCallLLM = vi.mocked(callLLM);
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ingest-image-"));
+  for (const k of ["DATA_DIR", "WIKI_DIR", "RAW_DIR"]) saved[k] = process.env[k];
+  process.env.DATA_DIR = tmpDir;
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  resetSourceIndex();
+  resetAliasIndex();
+  vi.clearAllMocks();
+  mockedStore.mockResolvedValue({
+    localPath: "assets/photo/photo.png",
+    bytes: new Uint8Array([1, 2, 3]).buffer,
+    filename: "photo.png",
+    contentType: "image/png",
+  });
+});
+
+afterEach(async () => {
+  for (const k of ["DATA_DIR", "WIKI_DIR", "RAW_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("ingestImage", () => {
+  it("creates a page embedding the image + vision description, attributed to the owner with sourceType image", async () => {
+    mockedDescribe.mockResolvedValue({ text: "A red square on white." });
+
+    const result = await ingestImage(
+      { imageUrl: "https://example.com/photo.png" },
+      { author: "alice", owner: "alice", triggeredBy: "alice", title: "My Photo" },
+    );
+
+    expect(mockedStore).toHaveBeenCalledWith("https://example.com/photo.png", "my-photo");
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect(page!.content).toContain("![My Photo](assets/photo/photo.png)");
+    expect(page!.content).toContain("A red square on white.");
+    expect(page!.frontmatter.owner).toBe("alice");
+    expect(page!.frontmatter.source_url).toBe("https://example.com/photo.png");
+    const sources = parseSources(page!.frontmatter.sources as string);
+    expect(sources[0]?.type).toBe("image");
+  });
+
+  it("still creates an image-only page when vision is unavailable (fail-soft)", async () => {
+    mockedDescribe.mockResolvedValue(null);
+
+    const result = await ingestImage(
+      { imageUrl: "https://example.com/photo.png" },
+      { author: "bob", owner: "bob", title: "Diagram" },
+    );
+
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect(page!.content).toContain("![Diagram](assets/photo/photo.png)");
+    // No description paragraph, but the page exists and embeds the image.
+    expect(page!.content.trim().endsWith("(assets/photo/photo.png)")).toBe(true);
+  });
+
+  it("does not duplicate the embedded image in a ## Images section", async () => {
+    mockedDescribe.mockResolvedValue({ text: "desc" });
+    const result = await ingestImage(
+      { imageUrl: "https://example.com/photo.png" },
+      { author: "alice", owner: "alice", title: "Once" },
+    );
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    const occurrences = page!.content.split("assets/photo/photo.png").length - 1;
+    expect(occurrences).toBe(1);
+    expect(page!.content).not.toContain("## Images");
+  });
+});
+
+describe("appendSourceImages (via ingest, LLM path)", () => {
+  it("appends a ## Images section with source images the LLM distillation dropped", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    mockedCallLLM.mockResolvedValue("# Doc\n\n## Summary\n\nDistilled text, no images.");
+
+    const result = await ingest(
+      "Doc With Pics",
+      "Some text.\n\n![a chart](assets/doc/chart.png)\n\nmore text.",
+      { author: "alice", owner: "alice" },
+    );
+
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect(page!.content).toContain("## Images");
+    expect(page!.content).toContain("![a chart](assets/doc/chart.png)");
+  });
+});

--- a/src/lib/__tests__/vision.test.ts
+++ b/src/lib/__tests__/vision.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../embeddings", () => ({ getWorkersAiBinding: vi.fn() }));
+
+import { getWorkersAiBinding } from "../embeddings";
+import { describeImage } from "../vision";
+
+const mockedBinding = vi.mocked(getWorkersAiBinding);
+
+function bindingReturning(run: (...a: unknown[]) => unknown) {
+  mockedBinding.mockReturnValue({ run } as never);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("describeImage", () => {
+  const bytes = new Uint8Array([1, 2, 3]).buffer;
+
+  it("returns null when the AI binding is unavailable (off-Workers)", async () => {
+    mockedBinding.mockReturnValue(null);
+    expect(await describeImage(bytes)).toBeNull();
+  });
+
+  it("reads the `response` field (llama-vision) and passes image bytes as a number[]", async () => {
+    const run = vi.fn().mockResolvedValue({ response: "  a red square  " });
+    bindingReturning(run);
+
+    const result = await describeImage(bytes);
+
+    expect(result).toEqual({ text: "a red square" });
+    const [model, input] = run.mock.calls[0];
+    expect(model).toContain("vision");
+    expect(input.image).toEqual([1, 2, 3]);
+    expect(typeof input.prompt).toBe("string");
+  });
+
+  it("falls back to the `description` field (llava)", async () => {
+    bindingReturning(vi.fn().mockResolvedValue({ description: "a cat" }));
+    expect(await describeImage(bytes)).toEqual({ text: "a cat" });
+  });
+
+  it("returns null on an empty description", async () => {
+    bindingReturning(vi.fn().mockResolvedValue({ response: "   " }));
+    expect(await describeImage(bytes)).toBeNull();
+  });
+
+  it("fails soft (null) when the model run throws", async () => {
+    bindingReturning(vi.fn().mockRejectedValue(new Error("model error")));
+    expect(await describeImage(bytes)).toBeNull();
+  });
+
+  it("honors the VISION_MODEL override", async () => {
+    const prev = process.env.VISION_MODEL;
+    process.env.VISION_MODEL = "@cf/custom/model";
+    const run = vi.fn().mockResolvedValue({ response: "x" });
+    bindingReturning(run);
+
+    await describeImage(bytes);
+
+    expect(run.mock.calls[0][0]).toBe("@cf/custom/model");
+    if (prev === undefined) delete process.env.VISION_MODEL;
+    else process.env.VISION_MODEL = prev;
+  });
+});

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -28,6 +28,9 @@ export const MAX_LLM_INPUT_CHARS = 12_000;
 /** Maximum number of images to download per source during ingest. */
 export const MAX_IMAGES_PER_SOURCE = 20;
 
+/** Maximum number of source images surfaced in a wiki page's `## Images` section. */
+export const MAX_APPENDED_IMAGES = 12;
+
 // ---- Batch ingest ---------------------------------------------------------
 
 /** Maximum number of URLs accepted in a single batch-ingest request. */

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -59,7 +59,7 @@ const WORKERS_AI_MODEL_PREFIX = "@cf/";
  * misconfiguration, not "no embeddings", so we surface it with a warning
  * rather than silently degrading to BM25-only search.
  */
-function getWorkersAiBinding(): Ai | null {
+export function getWorkersAiBinding(): Ai | null {
   let env: { AI?: Ai };
   try {
     ({ env } = getCloudflareContext() as { env: { AI?: Ai } });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -13,6 +13,18 @@ export function getErrorMessage(
   return fallback;
 }
 
+/**
+ * A caller-supplied-input error (bad/oversized/unsafe input) that a route
+ * should surface as a 4xx, distinct from a server-side failure. Lets routes
+ * classify by type rather than by string-matching the message.
+ */
+export class ClientInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClientInputError";
+  }
+}
+
 /** Check whether an unknown caught value is a Node.js ENOENT (file-not-found) error. */
 export function isEnoent(err: unknown): boolean {
   return (

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -24,6 +24,7 @@ import {
 import { validateUrlSafety } from "./url-safety";
 import { getStorage } from "./storage";
 import { rawRelPath } from "./wiki";
+import { ClientInputError, getErrorMessage } from "./errors";
 
 // Re-export HTML parsing utilities for backwards compatibility
 export { stripHtml, htmlToMarkdown, extractTitle, extractWithReadability } from "./html-parse";
@@ -378,19 +379,27 @@ export async function storeImageAsset(
   url: string,
   slug: string,
 ): Promise<{ localPath: string; bytes: ArrayBuffer; filename: string; contentType: string }> {
-  validateUrlSafety(url); // SSRF guard — throws on private/unsafe hosts
+  // SSRF guard — throws on private/unsafe hosts. Re-tag as client input so the
+  // route classifies it as a 4xx (the bad URL is the caller's).
+  try {
+    validateUrlSafety(url);
+  } catch (err) {
+    throw new ClientInputError(getErrorMessage(err));
+  }
 
   const resp = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
   if (!resp.ok) {
-    throw new Error(`Failed to fetch image: HTTP ${resp.status}`);
+    throw new ClientInputError(`Failed to fetch image: HTTP ${resp.status}`);
   }
   const contentType = resp.headers.get("content-type") || "";
   if (!contentType.startsWith("image/")) {
-    throw new Error(`URL is not an image (content-type: ${contentType || "unknown"})`);
+    throw new ClientInputError(
+      `URL is not an image (content-type: ${contentType || "unknown"})`,
+    );
   }
   const bytes = await resp.arrayBuffer();
   if (bytes.byteLength > MAX_RESPONSE_SIZE) {
-    throw new Error(
+    throw new ClientInputError(
       `Image too large (${bytes.byteLength} bytes, max ${MAX_RESPONSE_SIZE})`,
     );
   }
@@ -410,7 +419,7 @@ export async function storeImageBytes(
   suggestedName: string,
 ): Promise<{ localPath: string; filename: string }> {
   if (bytes.byteLength > MAX_RESPONSE_SIZE) {
-    throw new Error(
+    throw new ClientInputError(
       `Image too large (${bytes.byteLength} bytes, max ${MAX_RESPONSE_SIZE})`,
     );
   }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -361,3 +361,61 @@ export async function downloadImages(
 
   return result;
 }
+
+/**
+ * Fetch a single image by URL and store it as an asset under
+ * `assets/<slug>/<filename>`. Used by the image-ingest flow.
+ *
+ * Unlike {@link downloadImages} (which degrades gracefully across many embedded
+ * images), this **throws** on hard failures (unsafe URL, non-image, oversized,
+ * fetch error) so the calling route can return a clear client error — the user
+ * gave us a single URL and expects feedback if it's bad.
+ *
+ * @returns the local markdown ref, the raw bytes (for the vision model), the
+ *          filename, and the content type.
+ */
+export async function storeImageAsset(
+  url: string,
+  slug: string,
+): Promise<{ localPath: string; bytes: ArrayBuffer; filename: string; contentType: string }> {
+  validateUrlSafety(url); // SSRF guard — throws on private/unsafe hosts
+
+  const resp = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch image: HTTP ${resp.status}`);
+  }
+  const contentType = resp.headers.get("content-type") || "";
+  if (!contentType.startsWith("image/")) {
+    throw new Error(`URL is not an image (content-type: ${contentType || "unknown"})`);
+  }
+  const bytes = await resp.arrayBuffer();
+  if (bytes.byteLength > MAX_RESPONSE_SIZE) {
+    throw new Error(
+      `Image too large (${bytes.byteLength} bytes, max ${MAX_RESPONSE_SIZE})`,
+    );
+  }
+
+  const { localPath, filename } = await storeImageBytes(bytes, slug, url);
+  return { localPath, bytes, filename, contentType };
+}
+
+/**
+ * Store raw image bytes (e.g. an uploaded file) as an asset under
+ * `assets/<slug>/<filename>`. `suggestedName` may be a URL or a plain filename;
+ * it's sanitized. Enforces {@link MAX_RESPONSE_SIZE}.
+ */
+export async function storeImageBytes(
+  bytes: ArrayBuffer,
+  slug: string,
+  suggestedName: string,
+): Promise<{ localPath: string; filename: string }> {
+  if (bytes.byteLength > MAX_RESPONSE_SIZE) {
+    throw new Error(
+      `Image too large (${bytes.byteLength} bytes, max ${MAX_RESPONSE_SIZE})`,
+    );
+  }
+  const filename = sanitizeImageFilename(suggestedName);
+  const localPath = `assets/${slug}/${filename}`;
+  await getStorage().writeAsset(rawRelPath(localPath), bytes);
+  return { localPath, filename };
+}

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -8,7 +8,8 @@ import {
   type Frontmatter,
 } from "./wiki";
 import { callLLM, hasLLMKey } from "./llm";
-import { fetchUrlContent, downloadImages } from "./fetch";
+import { fetchUrlContent, downloadImages, storeImageAsset, storeImageBytes } from "./fetch";
+import { describeImage } from "./vision";
 import type { IngestResult } from "./types";
 import {
   serializeSources,
@@ -18,6 +19,7 @@ import {
 import {
   MAX_LLM_INPUT_CHARS,
   INGEST_MAX_OUTPUT_TOKENS,
+  MAX_APPENDED_IMAGES,
 } from "./constants";
 import { slugify } from "./slugify";
 import { loadPageConventions } from "./schema";
@@ -135,11 +137,82 @@ export async function ingestUrl(
     }
   }
 
-  const { title, content: rawContent } = await fetchUrlContent(url);
-  // Download images referenced in the fetched content to local storage
-  const slug = slugify(title);
-  const content = await downloadImages(rawContent, slug, getRawDir());
+  const { title, content } = await fetchUrlContent(url);
+  // Image downloading is centralized in ingest() so every path (url, text,
+  // agent, X) captures embedded images uniformly.
   return ingest(title, content, { ...options, sourceUrl: url });
+}
+
+/** Derive a human-ish title from a filename or URL (e.g. "diagram-2.png" →
+ *  "diagram 2"). Falls back to "Image". */
+function humanizeFilename(nameOrUrl: string): string {
+  let base = nameOrUrl;
+  try {
+    base = new URL(nameOrUrl).pathname.split("/").pop() || nameOrUrl;
+  } catch {
+    // not a URL — use as-is
+  }
+  base = base.split("?")[0].split("#")[0].replace(/\.[a-z0-9]+$/i, "");
+  return base.replace(/[-_]+/g, " ").trim() || "Image";
+}
+
+/**
+ * Ingest a single image. Stores the image as an asset, runs a vision model to
+ * extract a description (fail-soft), and writes a wiki page that embeds the
+ * image followed by the description. The LLM re-distillation is skipped (the
+ * body is already small and correct) but frontmatter/dedup/embedding all reuse
+ * the normal {@link ingest} pipeline.
+ *
+ * Accepts either an `imageUrl` (fetched + SSRF-guarded) or raw `bytes` (upload).
+ */
+export async function ingestImage(
+  input: { imageUrl?: string; bytes?: ArrayBuffer; filename?: string },
+  options?: IngestOptions & { title?: string },
+): Promise<IngestResult> {
+  const { imageUrl, bytes: uploadedBytes, filename: uploadName } = input;
+
+  // Dedup by URL first — cheapest path (no fetch, no vision, no LLM).
+  if (imageUrl && !options?.preview && !options?.generatedContent) {
+    const dupSlug = await resolveSourceUrl(imageUrl);
+    if (dupSlug) {
+      const result = await attachIngestTrigger(dupSlug, {
+        url: imageUrl,
+        type: "image",
+        triggeredBy: options?.triggeredBy,
+      });
+      if (result) return result;
+    }
+  }
+
+  const title = options?.title?.trim() || humanizeFilename(uploadName || imageUrl || "image");
+  const slug = slugify(title);
+
+  // Store the image as an asset and get its bytes for the vision model.
+  let localPath: string;
+  let bytes: ArrayBuffer;
+  if (imageUrl) {
+    ({ localPath, bytes } = await storeImageAsset(imageUrl, slug));
+  } else if (uploadedBytes) {
+    bytes = uploadedBytes;
+    ({ localPath } = await storeImageBytes(uploadedBytes, slug, uploadName || "image"));
+  } else {
+    throw new Error("ingestImage requires either imageUrl or bytes");
+  }
+
+  // Vision description — fail-soft (null → image-only page).
+  const vision = await describeImage(bytes);
+
+  const body =
+    `# ${title}\n\n![${title}](${localPath})` + (vision ? `\n\n${vision.text}` : "");
+
+  // generatedContent writes `body` as-is (skip the wiki-editor LLM) while still
+  // reusing frontmatter, dedup, embedding, cross-refs, and the ledger.
+  return ingest(title, body, {
+    ...options,
+    generatedContent: body,
+    sourceUrl: imageUrl ?? "upload",
+    sourceType: "image",
+  });
 }
 
 /**
@@ -197,6 +270,43 @@ export async function ingestXMention(
 function generateFallbackPage(title: string, content: string): string {
   const preview = content.length > 200 ? content.slice(0, 200) + "..." : content;
   return `# ${title}\n\n## Summary\n\n${preview}\n\n## Raw Content\n\n${content}`;
+}
+
+// ---------------------------------------------------------------------------
+// Image preservation
+// ---------------------------------------------------------------------------
+
+/**
+ * Append the source's downloaded images to the wiki body as a trailing
+ * `## Images` section. The LLM distills text and drops image refs, so this
+ * deterministically re-surfaces them (no LLM cost, no hallucinated paths).
+ *
+ * Only locally-downloaded images (`assets/...` refs, produced by
+ * {@link downloadImages}) are included — they're guaranteed servable via
+ * `/api/assets`. Idempotent: if the body already has an `## Images` heading
+ * (e.g. a preview→commit round-trip), it's returned unchanged.
+ */
+function appendSourceImages(wikiBody: string, sourceContent: string): string {
+  if (/^##\s+Images\s*$/m.test(wikiBody)) return wikiBody;
+
+  const re = /!\[([^\]]*)\]\((assets\/[^)\s]+)\)/g;
+  const seen = new Set<string>();
+  const refs: { alt: string; ref: string }[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(sourceContent)) !== null) {
+    const ref = m[2];
+    if (seen.has(ref)) continue;
+    seen.add(ref);
+    // Don't duplicate an image the body already embeds (e.g. the image-ingest
+    // page, where the image is the page's centerpiece).
+    if (wikiBody.includes(`](${ref})`)) continue;
+    refs.push({ alt: m[1], ref });
+    if (refs.length >= MAX_APPENDED_IMAGES) break;
+  }
+  if (refs.length === 0) return wikiBody;
+
+  const section = refs.map(({ alt, ref }) => `![${alt}](${ref})`).join("\n\n");
+  return `${wikiBody}\n\n## Images\n\n${section}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -436,7 +546,7 @@ export interface IngestOptions {
    * default `"url"` / `"text"` heuristic when building the `sources[]` entry.
    * Used by `ingestXMention()` to set `"x-mention"` provenance.
    */
-  sourceType?: "url" | "text" | "x-mention";
+  sourceType?: "url" | "text" | "x-mention" | "image";
   /**
    * Who triggered the ingest (user handle or agent ID). Defaults to `"system"`.
    * Passed through to the `triggered_by` field on the `SourceEntry`.
@@ -482,7 +592,7 @@ async function attachIngestTrigger(
   slug: string,
   source: {
     url: string;
-    type: "url" | "text" | "x-mention" | "wiki-ref";
+    type: "url" | "text" | "x-mention" | "wiki-ref" | "image";
     triggeredBy?: string;
   },
 ): Promise<IngestResult | null> {
@@ -599,6 +709,13 @@ export async function ingest(
   const isPreview = options?.preview === true;
   const preGeneratedContent = options?.generatedContent;
 
+  // Download any images referenced in the source to local storage and rewrite
+  // their markdown refs to `assets/<slug>/...`. Centralized here (not in
+  // ingestUrl) so URL, pasted-text, agent, and X ingests all capture images.
+  // No-op when the content has no remote image refs (e.g. already-local refs
+  // from a re-ingest or the image-ingest path), so it's safe to run always.
+  content = await downloadImages(content, slug, getRawDir());
+
   // Dedup by content: if identical content was already ingested (any slug),
   // attach the triggerer and skip the LLM + embedding. Not for preview /
   // commit-from-preview.
@@ -649,6 +766,10 @@ export async function ingest(
   } else {
     wikiContent = generateFallbackPage(title, content);
   }
+
+  // The LLM distills text and drops image refs, so deterministically append the
+  // source's downloaded images as a trailing section — reliable, no LLM cost.
+  wikiContent = appendSourceImages(wikiContent, content);
 
   // 2. Compute the index summary from the *raw* source so the index reflects
   // the original document, not the LLM's reformatting.

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -712,9 +712,12 @@ export async function ingest(
   // Download any images referenced in the source to local storage and rewrite
   // their markdown refs to `assets/<slug>/...`. Centralized here (not in
   // ingestUrl) so URL, pasted-text, agent, and X ingests all capture images.
-  // No-op when the content has no remote image refs (e.g. already-local refs
-  // from a re-ingest or the image-ingest path), so it's safe to run always.
-  content = await downloadImages(content, slug, getRawDir());
+  // Skipped when committing pre-generated content (commit-from-preview or the
+  // image-ingest body): those already ran image capture / carry local refs, so
+  // re-downloading would refetch every image needlessly.
+  if (!preGeneratedContent) {
+    content = await downloadImages(content, slug, getRawDir());
+  }
 
   // Dedup by content: if identical content was already ingested (any slug),
   // attach the triggerer and skip the LLM + embedding. Not for preview /

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -9,7 +9,7 @@
 import type { SourceEntry } from "./types";
 
 /** Valid provenance types. */
-const VALID_TYPES = new Set<SourceEntry["type"]>(["url", "text", "x-mention", "wiki-ref"]);
+const VALID_TYPES = new Set<SourceEntry["type"]>(["url", "text", "x-mention", "wiki-ref", "image"]);
 
 /**
  * Serialize a `SourceEntry[]` into a JSON string suitable for frontmatter.

--- a/src/lib/storage/cloudflare-types.ts
+++ b/src/lib/storage/cloudflare-types.ts
@@ -113,9 +113,27 @@ export interface AiEmbeddingInputs {
   pooling?: "cls" | "mean";
 }
 
-/** Minimal Workers AI binding surface — we only call `run()` for embeddings. */
+/** Inputs for an image-to-text / vision model run (e.g.
+ *  @cf/meta/llama-3.2-11b-vision-instruct or @cf/llava-hf/llava-1.5-7b-hf).
+ *  `image` is the raw bytes as an array of integers. */
+export interface AiImageToTextInputs {
+  image: number[];
+  prompt: string;
+  max_tokens?: number;
+}
+
+/** Response from a vision model run. Different models name the text field
+ *  differently (`response` for llama-vision, `description` for llava), so both
+ *  are optional and read defensively. */
+export interface AiImageToTextResponse {
+  response?: string;
+  description?: string;
+}
+
+/** Minimal Workers AI binding surface — `run()` for embeddings and vision. */
 export interface Ai {
   run(model: string, inputs: AiEmbeddingInputs): Promise<AiEmbeddingResponse>;
+  run(model: string, inputs: AiImageToTextInputs): Promise<AiImageToTextResponse>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/storage/cloudflare-types.ts
+++ b/src/lib/storage/cloudflare-types.ts
@@ -130,7 +130,9 @@ export interface AiImageToTextResponse {
   description?: string;
 }
 
-/** Minimal Workers AI binding surface — `run()` for embeddings and vision. */
+/** Minimal Workers AI binding surface — `run()` for embeddings and vision.
+ *  Overload resolution relies on the inputs' required keys being DISJOINT
+ *  (`text` for embeddings vs `image`+`prompt` for vision); keep them disjoint. */
 export interface Ai {
   run(model: string, inputs: AiEmbeddingInputs): Promise<AiEmbeddingResponse>;
   run(model: string, inputs: AiImageToTextInputs): Promise<AiImageToTextResponse>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -95,7 +95,7 @@ export interface LintResult {
 /** A single provenance entry in the structured `sources[]` array. */
 export interface SourceEntry {
   /** Provenance type: how the source was acquired. */
-  type: "url" | "text" | "x-mention" | "wiki-ref";
+  type: "url" | "text" | "x-mention" | "wiki-ref" | "image";
   /** Source URL or "text-paste" for pasted content. */
   url: string;
   /** ISO date string of when the source was fetched/ingested. */

--- a/src/lib/vision.ts
+++ b/src/lib/vision.ts
@@ -40,6 +40,7 @@ export async function describeImage(
   const bytes = image instanceof Uint8Array ? image : new Uint8Array(image);
   const model = visionModel();
 
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     const result = await Promise.race([
       ai.run(model, {
@@ -47,9 +48,9 @@ export async function describeImage(
         prompt: opts?.prompt ?? DEFAULT_PROMPT,
         max_tokens: opts?.maxTokens ?? 512,
       }),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("vision timeout")), VISION_TIMEOUT_MS),
-      ),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("vision timeout")), VISION_TIMEOUT_MS);
+      }),
     ]);
 
     // Different models name the field differently (llama → response, llava →
@@ -66,5 +67,7 @@ export async function describeImage(
       `Image description failed (${model}): ${err instanceof Error ? err.message : String(err)}`,
     );
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }

--- a/src/lib/vision.ts
+++ b/src/lib/vision.ts
@@ -1,0 +1,70 @@
+import { getWorkersAiBinding } from "./embeddings";
+import { logger } from "./logger";
+
+/**
+ * Vision (image → text) extraction via the Workers AI binding.
+ *
+ * Mirrors the embeddings pattern (`getWorkersAiBinding().run(...)`). Used by the
+ * image-ingest flow to turn an image into a factual description that becomes the
+ * wiki page body. Fails SOFT: any problem (no binding, timeout, model error,
+ * empty result) returns `null` so ingestion proceeds with an image-only page —
+ * vision must never break the pipeline.
+ */
+
+/** Default model — overridable via the `VISION_MODEL` env var.
+ *  llama-3.2-vision reads text/diagrams notably better than llava. */
+const DEFAULT_VISION_MODEL = "@cf/meta/llama-3.2-11b-vision-instruct";
+
+const DEFAULT_PROMPT =
+  "Describe this image in detail. Include any visible text, diagrams, charts, " +
+  "people, objects, and the overall context. Be factual and concise.";
+
+/** Hard ceiling so a slow/hung model run can't stall an ingest. */
+const VISION_TIMEOUT_MS = 20_000;
+
+function visionModel(): string {
+  return process.env.VISION_MODEL || DEFAULT_VISION_MODEL;
+}
+
+/**
+ * Describe an image from its raw bytes. Returns `{ text }` or `null` when vision
+ * is unavailable / fails (caller then produces a minimal image-only page).
+ */
+export async function describeImage(
+  image: ArrayBuffer | Uint8Array,
+  opts?: { prompt?: string; maxTokens?: number },
+): Promise<{ text: string } | null> {
+  const ai = getWorkersAiBinding();
+  if (!ai) return null; // off-Workers or AI binding unbound — degrade gracefully
+
+  const bytes = image instanceof Uint8Array ? image : new Uint8Array(image);
+  const model = visionModel();
+
+  try {
+    const result = await Promise.race([
+      ai.run(model, {
+        image: [...bytes],
+        prompt: opts?.prompt ?? DEFAULT_PROMPT,
+        max_tokens: opts?.maxTokens ?? 512,
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("vision timeout")), VISION_TIMEOUT_MS),
+      ),
+    ]);
+
+    // Different models name the field differently (llama → response, llava →
+    // description); read defensively.
+    const text = (result.response ?? result.description ?? "").trim();
+    if (!text) {
+      logger.warn("vision", `Model ${model} returned an empty description.`);
+      return null;
+    }
+    return { text };
+  } catch (err) {
+    logger.warn(
+      "vision",
+      `Image description failed (${model}): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}

--- a/workers/x-ingest/README.md
+++ b/workers/x-ingest/README.md
@@ -17,6 +17,12 @@ What it does each run:
   system token and **`asOwner: true`**. The `@yoyoevolve` mention is the "save
   this to my wiki" command channel — it is **not** written to the agent's scoped
   knowledge, and plain tweet text is never ingested.
+- **Article images (best-effort):** the search also expands `attachments.media_keys`
+  + `media.fields`, and any image URLs the X API exposes for the parent (attached
+  media, article entities, image refs in the article text) are appended to the
+  ingest text as markdown so the pipeline downloads + renders them. If the API
+  exposes none, it degrades to text-only. Use `?debug=1` to see what's available
+  (the probe reports `articleImageUrls` / `includesMedia` per sample).
 
 > **Same-zone fetch note:** the ingest call targets the main yopedia Worker on
 > the same account (`yopedia.<sub>.workers.dev`). A plain Worker→Worker `fetch()`

--- a/workers/x-ingest/index.ts
+++ b/workers/x-ingest/index.ts
@@ -69,7 +69,7 @@ type IngestOutcome = "ingested" | "not-a-user" | "dropped" | "failed";
 // every access below is optional-chained or guarded).
 // ---------------------------------------------------------------------------
 interface XMedia {
-  media_key: string;
+  media_key?: string; // unchecked cast — guarded by the `if (u)` consumer
   type?: string; // photo | video | animated_gif
   url?: string; // photos
   preview_image_url?: string; // video / gif poster frame
@@ -196,7 +196,9 @@ async function run(env: Env): Promise<Summary> {
     (payload.includes?.tweets ?? []).map((t) => [t.id, t]),
   );
   const mediaByKey = Object.fromEntries(
-    (payload.includes?.media ?? []).map((m) => [m.media_key, m]),
+    (payload.includes?.media ?? [])
+      .filter((m) => m.media_key)
+      .map((m) => [m.media_key as string, m]),
   );
   if (mentions.length === 0) {
     console.log(`No new mentions for query [${QUERY}]. Nothing to ingest.`);
@@ -354,7 +356,9 @@ async function probe(env: Env, hours: number): Promise<unknown> {
       (payload.includes?.tweets ?? []).map((t) => [t.id, t]),
     );
     const mediaByKey = Object.fromEntries(
-      (payload.includes?.media ?? []).map((m) => [m.media_key, m]),
+      (payload.includes?.media ?? [])
+      .filter((m) => m.media_key)
+      .map((m) => [m.media_key as string, m]),
     );
     results[name] = {
       query,

--- a/workers/x-ingest/index.ts
+++ b/workers/x-ingest/index.ts
@@ -68,40 +68,83 @@ type IngestOutcome = "ingested" | "not-a-user" | "dropped" | "failed";
 // X API types (only the fields we read; res.json() is an unchecked cast, so
 // every access below is optional-chained or guarded).
 // ---------------------------------------------------------------------------
+interface XMedia {
+  media_key: string;
+  type?: string; // photo | video | animated_gif
+  url?: string; // photos
+  preview_image_url?: string; // video / gif poster frame
+  alt_text?: string;
+}
+interface XArticleEntityUrl {
+  expanded_url?: string;
+  url?: string;
+}
 interface XTweet {
   id: string;
   author_id?: string;
   text?: string;
   referenced_tweets?: { type: string; id: string }[];
-  article?: { title?: string; text?: string };
+  article?: { title?: string; text?: string; entities?: { urls?: XArticleEntityUrl[] } };
   entities?: { urls?: { expanded_url?: string; url?: string }[] };
+  attachments?: { media_keys?: string[] };
 }
 interface XSearchPayload {
   data?: XTweet[];
-  includes?: { users?: { id: string; username: string }[]; tweets?: XTweet[] };
+  includes?: {
+    users?: { id: string; username: string }[];
+    tweets?: XTweet[];
+    media?: XMedia[];
+  };
   meta?: { newest_id?: string; result_count?: number };
+}
+
+function isUsableHttpUrl(u: string): boolean {
+  try {
+    const { protocol, hostname } = new URL(u);
+    return /^https?:$/.test(protocol) && !SKIP_HOSTS.has(hostname);
+  } catch {
+    return false; // malformed/relative URL from X — unusable, drop it
+  }
 }
 
 function externalLinks(tweet: XTweet): string[] {
   return (tweet.entities?.urls ?? [])
     .map((u) => u.expanded_url || u.url || "")
-    .filter((u) => {
-      try {
-        const { protocol, hostname } = new URL(u);
-        return /^https?:$/.test(protocol) && !SKIP_HOSTS.has(hostname);
-      } catch {
-        return false; // malformed/relative URL from X — unusable, drop it
-      }
-    });
+    .filter(isUsableHttpUrl);
 }
 
-/** Build the X recent-search URL for a query + time/cursor bound. */
+/**
+ * Best-effort image URLs the X API exposes for a tweet/article: attached media
+ * (photos → url, video/gif → poster), image-looking URLs in the article's
+ * entities, and markdown image refs already in the article text. The X Article
+ * API surface is thin, so this returns whatever is available (possibly none).
+ */
+function articleImageUrls(parent: XTweet, mediaByKey: Record<string, XMedia>): string[] {
+  const urls = new Set<string>();
+  for (const key of parent.attachments?.media_keys ?? []) {
+    const m = mediaByKey[key];
+    const u = m?.url || m?.preview_image_url;
+    if (u) urls.add(u);
+  }
+  const text = parent.article?.text ?? "";
+  for (const m of text.matchAll(/!\[[^\]]*\]\((https?:\/\/[^)\s]+)\)/g)) urls.add(m[1]);
+  for (const e of parent.article?.entities?.urls ?? []) {
+    const u = e.expanded_url || e.url;
+    if (u && /\.(png|jpe?g|gif|webp|avif)(\?|$)/i.test(u)) urls.add(u);
+  }
+  return [...urls].filter(isUsableHttpUrl).slice(0, 12);
+}
+
+/** Build the X recent-search URL for a query + time/cursor bound. The media
+ *  expansion + fields surface any images the API exposes for the parent
+ *  tweet/article so they can be ingested too (best-effort). */
 function searchUrl(query: string, bound: string): string {
   return (
     `https://api.twitter.com/2/tweets/search/recent?query=${encodeURIComponent(query)}` +
     `&max_results=100${bound}` +
-    `&expansions=referenced_tweets.id,author_id` +
-    `&tweet.fields=entities,author_id,referenced_tweets,article,created_at` +
+    `&expansions=referenced_tweets.id,author_id,attachments.media_keys` +
+    `&tweet.fields=entities,author_id,referenced_tweets,article,attachments,created_at` +
+    `&media.fields=url,preview_image_url,type,alt_text` +
     `&user.fields=username`
   );
 }
@@ -151,6 +194,9 @@ async function run(env: Env): Promise<Summary> {
   );
   const tweetById = Object.fromEntries(
     (payload.includes?.tweets ?? []).map((t) => [t.id, t]),
+  );
+  const mediaByKey = Object.fromEntries(
+    (payload.includes?.media ?? []).map((m) => [m.media_key, m]),
   );
   if (mentions.length === 0) {
     console.log(`No new mentions for query [${QUERY}]. Nothing to ingest.`);
@@ -228,7 +274,14 @@ async function run(env: Env): Promise<Summary> {
     const article = parent.article;
     if (article && (article.text || article.title)) {
       const title = article.title || `X Article (shared by @${handle})`;
-      jobs.push({ body: { text: article.text || title, title }, label: `article "${title}"` });
+      // Append any image URLs the API exposes as markdown so the ingest
+      // pipeline downloads + renders them with the article.
+      const imgs = articleImageUrls(parent, mediaByKey);
+      const imgBlock = imgs.length ? "\n\n" + imgs.map((u) => `![](${u})`).join("\n\n") : "";
+      jobs.push({
+        body: { text: (article.text || title) + imgBlock, title },
+        label: `article "${title}"${imgs.length ? ` (+${imgs.length} img)` : ""}`,
+      });
     } else if (article) {
       console.warn(`! @${handle}: parent 'article' has an unexpected shape — skipping the article`);
     }
@@ -300,6 +353,9 @@ async function probe(env: Env, hours: number): Promise<unknown> {
     const tweetById = Object.fromEntries(
       (payload.includes?.tweets ?? []).map((t) => [t.id, t]),
     );
+    const mediaByKey = Object.fromEntries(
+      (payload.includes?.media ?? []).map((m) => [m.media_key, m]),
+    );
     results[name] = {
       query,
       result_count: payload.meta?.result_count ?? (payload.data?.length ?? 0),
@@ -313,6 +369,12 @@ async function probe(env: Env, hours: number): Promise<unknown> {
           parentId: parentId ?? null,
           parentHasArticle: !!parent?.article,
           parentLinks: parent ? externalLinks(parent).length : 0,
+          // Image diagnostics (Phase 3): what media the API actually exposes.
+          articleTitle: parent?.article?.title ?? null,
+          articleTextLen: parent?.article?.text?.length ?? 0,
+          parentMediaKeys: parent?.attachments?.media_keys ?? [],
+          articleImageUrls: parent ? articleImageUrls(parent, mediaByKey) : [],
+          includesMedia: payload.includes?.media ?? [],
         };
       }),
     };


### PR DESCRIPTION
Adds three image capabilities, mostly by wiring up the existing (under-used) image plumbing (`downloadImages` already stored R2 assets; the markdown renderer already supported `![]()`).

## Phase 1 — render ingested images
- **`GET /api/assets/[...path]`** serves stored R2 image assets (`assets/...` → `raw/assets/...` via `rawRelPath`), with a path-traversal guard, content-type, immutable cache, and an SVG sandbox CSP. ENOENT → 404; real storage errors → 500 + log (no incident masking).
- **`MarkdownRenderer`** gains an `img` component rewriting `assets/...` → `/api/assets/...` (absolute/data URLs untouched), lazy-loaded.
- **`appendSourceImages()`** re-surfaces source images the LLM distillation drops, as a trailing `## Images` section (idempotent, deduped, skips already-embedded, capped).
- **`downloadImages` centralized into `ingest()`** (was `ingestUrl`-only) → URL, text, agent, and X ingests all capture embedded images. Skipped on the `generatedContent` commit path (no redundant re-download).
- **Raw view renders markdown** (images show); `/api/raw` remains the plaintext link.

## Phase 2 — ingest an image (vision)
- **`src/lib/vision.ts` `describeImage()`** via Workers AI **`@cf/meta/llama-3.2-11b-vision-instruct`** (`VISION_MODEL` override), fail-soft to `null` (image-only page).
- **`storeImageAsset`/`storeImageBytes`** (SSRF guard, image/size checks; throw a typed `ClientInputError` so routes classify 4xx structurally).
- **`ingestImage()`** stores the image, describes it, writes a page embedding the image + description (skips LLM re-distillation), `sourceType: "image"`.
- **`POST /api/ingest/image`** (URL JSON **and** multipart upload); the agent ingest route gains `{ imageUrl }`; the ingest UI gains an **Image** tab (URL or file).

## Phase 3 — X Article images (best-effort)
- The x-ingest worker expands `attachments.media_keys` + `media.fields` and appends any exposed article image URLs to the ingest text as markdown (Phase 1e then downloads them). Degrades to text-only if the API exposes none. `?debug=1` now reports `articleImageUrls`/`includesMedia` per sample.

## Review addressed
Two incident-hiding bugs fixed (assets 404-masking, image-route regex classifier → typed `ClientInputError`), redundant-download perf fix, vision timer cleanup, type-invariant comments.

## Verified
`pnpm lint` clean · **2277 tests pass** (+24) · worker type-checks under `--strict`. Reviewed by code-reviewer, silent-failure-hunter, type-design-analyzer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)