### PR TITLE
yoyo: capture X Article cover image via syndication CDN

### DIFF
--- a/workers/x-ingest/README.md
+++ b/workers/x-ingest/README.md
@@ -17,12 +17,15 @@ What it does each run:
   system token and **`asOwner: true`**. The `@yoyoevolve` mention is the "save
   this to my wiki" command channel — it is **not** written to the agent's scoped
   knowledge, and plain tweet text is never ingested.
-- **Article images (best-effort):** the search also expands `attachments.media_keys`
+- **Article images (best-effort):** the search expands `attachments.media_keys`
   + `media.fields`, and any image URLs the X API exposes for the parent (attached
   media, article entities, image refs in the article text) are appended to the
-  ingest text as markdown so the pipeline downloads + renders them. If the API
-  exposes none, it degrades to text-only. Use `?debug=1` to see what's available
-  (the probe reports `articleImageUrls` / `includesMedia` per sample).
+  ingest text as markdown. The official `article` API field exposes **no** image
+  URLs, so for Articles the worker additionally fetches the **cover image** from
+  the unauthenticated syndication CDN (`cdn.syndication.twimg.com/tweet-result`
+  → `article.cover_media...original_img_url`) — fail-soft (any error → text-only).
+  Inline Article body images aren't exposed by any X surface. Use `?debug=1` to
+  see API-exposed media (`articleImageUrls` / `includesMedia`) per sample.
 
 > **Same-zone fetch note:** the ingest call targets the main yopedia Worker on
 > the same account (`yopedia.<sub>.workers.dev`). A plain Worker→Worker `fetch()`

--- a/workers/x-ingest/index.ts
+++ b/workers/x-ingest/index.ts
@@ -135,6 +135,30 @@ function articleImageUrls(parent: XTweet, mediaByKey: Record<string, XMedia>): s
   return [...urls].filter(isUsableHttpUrl).slice(0, 12);
 }
 
+/**
+ * Fetch an X Article's cover image via the unauthenticated syndication CDN (the
+ * endpoint that powers tweet embeds). The official `article` API field exposes
+ * NO image URLs, but this returns `article.cover_media...original_img_url` —
+ * usually the Article's hero image. Inline body images are not exposed anywhere.
+ * Fail-soft: any error / shape change → null (the article still ingests as text).
+ */
+async function fetchArticleCoverImage(tweetId: string): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `https://cdn.syndication.twimg.com/tweet-result?id=${tweetId}&lang=en&token=a`,
+      { headers: { "User-Agent": "Mozilla/5.0" } },
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      article?: { cover_media?: { media_info?: { original_img_url?: string } } };
+    };
+    const u = data.article?.cover_media?.media_info?.original_img_url;
+    return u && isUsableHttpUrl(u) ? u : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Build the X recent-search URL for a query + time/cursor bound. The media
  *  expansion + fields surface any images the API exposes for the parent
  *  tweet/article so they can be ingested too (best-effort). */
@@ -276,9 +300,12 @@ async function run(env: Env): Promise<Summary> {
     const article = parent.article;
     if (article && (article.text || article.title)) {
       const title = article.title || `X Article (shared by @${handle})`;
-      // Append any image URLs the API exposes as markdown so the ingest
-      // pipeline downloads + renders them with the article.
-      const imgs = articleImageUrls(parent, mediaByKey);
+      // Image URLs from the API (usually none for Articles) + the cover image
+      // from the syndication CDN. Appended as markdown so the ingest pipeline
+      // downloads + renders them with the article.
+      const apiImgs = articleImageUrls(parent, mediaByKey);
+      const cover = await fetchArticleCoverImage(parent.id);
+      const imgs = [...new Set([...(cover ? [cover] : []), ...apiImgs])].slice(0, 12);
       const imgBlock = imgs.length ? "\n\n" + imgs.map((u) => `![](${u})`).join("\n\n") : "";
       jobs.push({
         body: { text: (article.text || title) + imgBlock, title },


### PR DESCRIPTION
The official X API `article` field exposes no image URLs (probe confirmed `articleImageUrls=[]`, `parentMediaKeys=[]`). The unauthenticated syndication endpoint (`cdn.syndication.twimg.com/tweet-result`) returns `article.cover_media...original_img_url` — the Article's hero image.

The worker now fetches that cover for Article parents and appends it as markdown so the ingest pipeline downloads + renders it. **Fail-soft** (any error → text-only, no regression). Inline Article body images remain unavailable (no X surface exposes them).

Worker type-checks under `--strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)