### PR TITLE
yoyo: record original X article URL as page source (clickable)

### DIFF
--- a/src/app/api/agents/[id]/ingest/route.ts
+++ b/src/app/api/agents/[id]/ingest/route.ts
@@ -92,6 +92,7 @@ export async function POST(req: Request, { params }: RouteParams) {
       text?: unknown;
       title?: unknown;
       imageUrl?: unknown;
+      sourceUrl?: unknown;
       asOwner?: unknown;
     };
     try {
@@ -136,11 +137,19 @@ export async function POST(req: Request, { params }: RouteParams) {
         pageType: AGENT_KNOWLEDGE_TYPE,
       };
     }
+    // A caller-provided source URL (e.g. the original X article) is recorded as
+    // the page's provenance so the wiki page links back to it. The `url`/
+    // `imageUrl` paths set their own source, so this only applies to text.
+    const sourceUrl =
+      typeof body.sourceUrl === "string" && /^https?:\/\//.test(body.sourceUrl.trim())
+        ? body.sourceUrl.trim()
+        : undefined;
+
     const result = imageUrl
       ? await ingestImage({ imageUrl }, { ...opts, title: title || undefined })
       : url
         ? await ingestUrl(url, opts)
-        : await ingest(title || "Untitled", text, opts);
+        : await ingest(title || "Untitled", text, { ...opts, sourceUrl });
 
     // Agent-knowledge ingests attach to the agent's learnings; owner-content
     // ingests do not (they live in the owner's normal content space).

--- a/src/app/wiki/[slug]/page.tsx
+++ b/src/app/wiki/[slug]/page.tsx
@@ -92,6 +92,12 @@ function sourceTypeBadge(type: SourceEntry["type"]): {
         className:
           "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-400",
       };
+    case "image":
+      return {
+        label: "Image",
+        className:
+          "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
+      };
     default:
       return {
         label: String(type),

--- a/workers/x-ingest/index.ts
+++ b/workers/x-ingest/index.ts
@@ -296,6 +296,14 @@ async function run(env: Env): Promise<Summary> {
       continue;
     }
 
+    // The original article/tweet URL — recorded as the page's source so the
+    // wiki page links back to it. Author handle if expanded, else the
+    // handle-agnostic /i/status/ form (which X redirects correctly).
+    const parentAuthor = parent.author_id ? userById[parent.author_id] : undefined;
+    const sourceUrl = parentAuthor
+      ? `https://x.com/${parentAuthor}/status/${parent.id}`
+      : `https://x.com/i/status/${parent.id}`;
+
     const jobs: { body: object; label: string }[] = [];
     const article = parent.article;
     if (article && (article.text || article.title)) {
@@ -308,7 +316,7 @@ async function run(env: Env): Promise<Summary> {
       const imgs = [...new Set([...(cover ? [cover] : []), ...apiImgs])].slice(0, 12);
       const imgBlock = imgs.length ? "\n\n" + imgs.map((u) => `![](${u})`).join("\n\n") : "";
       jobs.push({
-        body: { text: (article.text || title) + imgBlock, title },
+        body: { text: (article.text || title) + imgBlock, title, sourceUrl },
         label: `article "${title}"${imgs.length ? ` (+${imgs.length} img)` : ""}`,
       });
     } else if (article) {


### PR DESCRIPTION
X-article ingests had no real source URL (the worker sent text only → source entry `text-paste`, shown as non-clickable). Now the worker passes the parent article/tweet URL and the agent ingest route threads a body `sourceUrl` into the text-ingest opts, so the page's `sources[]` carries the real URL and the existing Provenance UI renders it as a clickable link back to the article. Adds an Image badge for the new sourceType. Worker type-checks; lint clean.