### PR TITLE
yoyo: clean up source provenance (drop text-paste, resolve X author handle)

### DIFF
--- a/src/lib/__tests__/ingest-image.test.ts
+++ b/src/lib/__tests__/ingest-image.test.ts
@@ -117,3 +117,31 @@ describe("appendSourceImages (via ingest, LLM path)", () => {
     expect(page!.content).toContain("![a chart](assets/doc/chart.png)");
   });
 });
+
+describe("source provenance — text-paste supersession", () => {
+  it("a real source URL replaces a prior text-paste placeholder of the same type", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    mockedCallLLM.mockResolvedValue("# X\n\n## Summary\n\nv1.");
+    // First ingest with no URL → an x-mention source with a "text-paste" placeholder.
+    await ingest("Recur Src", "version one content here", {
+      sourceType: "x-mention",
+      author: "a",
+      owner: "a",
+    });
+
+    mockedCallLLM.mockResolvedValue("# X\n\n## Summary\n\nv2.");
+    // Re-ingest (changed content) now WITH the real article URL.
+    const r = await ingest("Recur Src", "version two content, changed", {
+      sourceType: "x-mention",
+      sourceUrl: "https://x.com/i/status/123",
+      author: "a",
+      owner: "a",
+    });
+
+    const page = await readWikiPageWithFrontmatter(r.primarySlug);
+    const sources = parseSources(page!.frontmatter.sources as string);
+    // The stale text-paste is gone; only the real URL remains.
+    expect(sources).toHaveLength(1);
+    expect(sources[0]).toMatchObject({ type: "x-mention", url: "https://x.com/i/status/123" });
+  });
+});

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -10,12 +10,32 @@ import {
 import { callLLM, hasLLMKey } from "./llm";
 import { fetchUrlContent, downloadImages, storeImageAsset, storeImageBytes } from "./fetch";
 import { describeImage } from "./vision";
-import type { IngestResult } from "./types";
+import type { IngestResult, SourceEntry } from "./types";
 import {
   serializeSources,
   parseSources,
   buildSourceEntry,
 } from "./sources";
+
+/**
+ * Merge a provenance entry into a sources list. A real source URL supersedes a
+ * stale `"text-paste"` placeholder of the same type (the placeholder just means
+ * "no URL was known"), so once a real URL arrives the placeholder is dropped.
+ * Updates an existing match in place; otherwise appends.
+ */
+function mergeSourceEntry(sources: SourceEntry[], entry: SourceEntry): SourceEntry[] {
+  const base =
+    entry.url !== "text-paste"
+      ? sources.filter((s) => !(s.type === entry.type && s.url === "text-paste"))
+      : sources;
+  const idx = base.findIndex((s) => s.url === entry.url && s.type === entry.type);
+  if (idx >= 0) {
+    base[idx] = { ...base[idx], fetched: entry.fetched, triggered_by: entry.triggered_by };
+  } else {
+    base.push(entry);
+  }
+  return base;
+}
 import {
   MAX_LLM_INPUT_CHARS,
   INGEST_MAX_OUTPUT_TOKENS,
@@ -613,20 +633,9 @@ async function attachIngestTrigger(
         ? existingSourcesRaw
         : undefined,
   );
-  const matchIdx = sources.findIndex(
-    (s) => s.url === entry.url && s.type === entry.type,
-  );
-  if (matchIdx >= 0) {
-    sources[matchIdx] = {
-      ...sources[matchIdx],
-      fetched: entry.fetched,
-      triggered_by: entry.triggered_by,
-    };
-  } else {
-    sources.push(entry);
-  }
-  frontmatter.sources = serializeSources(sources);
-  frontmatter.source_count = String(sources.length);
+  const merged = mergeSourceEntry(sources, entry);
+  frontmatter.sources = serializeSources(merged);
+  frontmatter.source_count = String(merged.length);
 
   // Record the triggerer as a contributor (deduped) — drives the "Mine" lens.
   const triggeredBy = source.triggeredBy?.trim();
@@ -896,17 +905,9 @@ export async function ingest(
           ? existingSourcesRaw
           : undefined,
     );
-    // If the new source URL already has an entry, update its fetched date.
-    // Otherwise append the new entry.
-    const matchIdx = existingSources.findIndex(
-      (s) => s.url === sourceEntry.url && s.type === sourceEntry.type,
-    );
-    if (matchIdx >= 0) {
-      existingSources[matchIdx] = { ...existingSources[matchIdx], fetched: sourceEntry.fetched };
-    } else {
-      existingSources.push(sourceEntry);
-    }
-    frontmatter.sources = serializeSources(existingSources);
+    // Merge the new entry, superseding a stale "text-paste" placeholder.
+    // (source_count is the ingest counter, set above — not the array length.)
+    frontmatter.sources = serializeSources(mergeSourceEntry(existingSources, sourceEntry));
 
     // --- Phase 1 fields: preserve on re-ingest ---
     // Preserve authors from existing page (don't reset).

--- a/workers/x-ingest/index.ts
+++ b/workers/x-ingest/index.ts
@@ -166,7 +166,7 @@ function searchUrl(query: string, bound: string): string {
   return (
     `https://api.twitter.com/2/tweets/search/recent?query=${encodeURIComponent(query)}` +
     `&max_results=100${bound}` +
-    `&expansions=referenced_tweets.id,author_id,attachments.media_keys` +
+    `&expansions=referenced_tweets.id,author_id,referenced_tweets.id.author_id,attachments.media_keys` +
     `&tweet.fields=entities,author_id,referenced_tweets,article,attachments,created_at` +
     `&media.fields=url,preview_image_url,type,alt_text` +
     `&user.fields=username`


### PR DESCRIPTION
Two cosmetic fixes for X-article source links:

1. A real source URL **supersedes a stale `text-paste` placeholder** of the same type when `sources[]` is merged on re-ingest (shared `mergeSourceEntry` helper used by both the full-ingest and attach-trigger paths). Pages first ingested without a URL self-heal to a single clean source. `source_count` stays the ingest counter.
2. The worker adds the `referenced_tweets.id.author_id` expansion so the parent author handle resolves → pretty `x.com/<handle>/status/<id>` source URL instead of the `/i/status/` fallback.

+1 test (supersession). 2278 pass, lint clean, worker type-checks.