### PR TITLE
yoyo: image vision via configured LLM (DeepSeek) — fixes empty descriptions

### DIFF
--- a/src/app/api/ingest/image/route.ts
+++ b/src/app/api/ingest/image/route.ts
@@ -55,7 +55,10 @@ export async function POST(request: NextRequest) {
         options.tags = tags.split(",").map((t) => t.trim()).filter(Boolean);
       }
       const bytes = await file.arrayBuffer();
-      const result = await ingestImage({ bytes, filename: file.name }, options);
+      const result = await ingestImage(
+        { bytes, filename: file.name, contentType: file.type || undefined },
+        options,
+      );
       return NextResponse.json(result);
     }
 

--- a/src/lib/__tests__/vision.test.ts
+++ b/src/lib/__tests__/vision.test.ts
@@ -1,42 +1,77 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../embeddings", () => ({ getWorkersAiBinding: vi.fn() }));
+vi.mock("../llm", () => ({ hasLLMKey: vi.fn(() => false), callVisionLLM: vi.fn() }));
 
 import { getWorkersAiBinding } from "../embeddings";
+import { hasLLMKey, callVisionLLM } from "../llm";
 import { describeImage } from "../vision";
 
 const mockedBinding = vi.mocked(getWorkersAiBinding);
+const mockedHasLLMKey = vi.mocked(hasLLMKey);
+const mockedCallVisionLLM = vi.mocked(callVisionLLM);
 
 function bindingReturning(run: (...a: unknown[]) => unknown) {
   mockedBinding.mockReturnValue({ run } as never);
 }
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedHasLLMKey.mockReturnValue(false); // default: exercise the Workers AI path
+});
 
-describe("describeImage", () => {
-  const bytes = new Uint8Array([1, 2, 3]).buffer;
+const bytes = new Uint8Array([1, 2, 3]).buffer;
 
-  it("returns null when the AI binding is unavailable (off-Workers)", async () => {
+describe("describeImage — LLM (multimodal) path", () => {
+  it("uses the configured LLM when a key is present, and does NOT call Workers AI", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    mockedCallVisionLLM.mockResolvedValue("  一只猫  ");
+    const run = vi.fn();
+    bindingReturning(run);
+
+    const result = await describeImage(bytes, { mediaType: "image/png" });
+
+    expect(result).toEqual({ text: "一只猫" });
+    expect(mockedCallVisionLLM).toHaveBeenCalledWith(
+      expect.any(String),
+      bytes,
+      expect.objectContaining({ mediaType: "image/png" }),
+    );
+    expect(run).not.toHaveBeenCalled(); // Workers AI not used when the LLM succeeds
+  });
+
+  it("falls back to Workers AI when the LLM vision call throws", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    mockedCallVisionLLM.mockRejectedValue(new Error("not multimodal"));
+    const run = vi.fn().mockResolvedValue({ description: "a cat" });
+    bindingReturning(run);
+
+    expect(await describeImage(bytes)).toEqual({ text: "a cat" });
+    expect(run).toHaveBeenCalled();
+  });
+});
+
+describe("describeImage — Workers AI fallback", () => {
+  it("returns null when neither the LLM nor the AI binding is available", async () => {
     mockedBinding.mockReturnValue(null);
     expect(await describeImage(bytes)).toBeNull();
   });
 
-  it("reads the `response` field (llama-vision) and passes image bytes as a number[]", async () => {
-    const run = vi.fn().mockResolvedValue({ response: "  a red square  " });
+  it("calls the binding with the llava fallback model and image bytes as a number[]", async () => {
+    const run = vi.fn().mockResolvedValue({ description: "a red square" });
     bindingReturning(run);
 
     const result = await describeImage(bytes);
 
     expect(result).toEqual({ text: "a red square" });
     const [model, input] = run.mock.calls[0];
-    expect(model).toContain("vision");
+    expect(model).toContain("llava");
     expect(input.image).toEqual([1, 2, 3]);
-    expect(typeof input.prompt).toBe("string");
   });
 
-  it("falls back to the `description` field (llava)", async () => {
-    bindingReturning(vi.fn().mockResolvedValue({ description: "a cat" }));
-    expect(await describeImage(bytes)).toEqual({ text: "a cat" });
+  it("reads the `response` field too (model variance)", async () => {
+    bindingReturning(vi.fn().mockResolvedValue({ response: "desc" }));
+    expect(await describeImage(bytes)).toEqual({ text: "desc" });
   });
 
   it("returns null on an empty description", async () => {
@@ -44,12 +79,12 @@ describe("describeImage", () => {
     expect(await describeImage(bytes)).toBeNull();
   });
 
-  it("fails soft (null) when the model run throws", async () => {
+  it("fails soft (null) when the binding run throws", async () => {
     bindingReturning(vi.fn().mockRejectedValue(new Error("model error")));
     expect(await describeImage(bytes)).toBeNull();
   });
 
-  it("honors the VISION_MODEL override", async () => {
+  it("honors the VISION_MODEL override for the Workers AI model", async () => {
     const prev = process.env.VISION_MODEL;
     process.env.VISION_MODEL = "@cf/custom/model";
     const run = vi.fn().mockResolvedValue({ response: "x" });

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -186,7 +186,7 @@ function humanizeFilename(nameOrUrl: string): string {
  * Accepts either an `imageUrl` (fetched + SSRF-guarded) or raw `bytes` (upload).
  */
 export async function ingestImage(
-  input: { imageUrl?: string; bytes?: ArrayBuffer; filename?: string },
+  input: { imageUrl?: string; bytes?: ArrayBuffer; filename?: string; contentType?: string },
   options?: IngestOptions & { title?: string },
 ): Promise<IngestResult> {
   const { imageUrl, bytes: uploadedBytes, filename: uploadName } = input;
@@ -210,8 +210,11 @@ export async function ingestImage(
   // Store the image as an asset and get its bytes for the vision model.
   let localPath: string;
   let bytes: ArrayBuffer;
+  let mediaType: string | undefined = input.contentType;
   if (imageUrl) {
-    ({ localPath, bytes } = await storeImageAsset(imageUrl, slug));
+    const stored = await storeImageAsset(imageUrl, slug);
+    ({ localPath, bytes } = stored);
+    mediaType = stored.contentType;
   } else if (uploadedBytes) {
     bytes = uploadedBytes;
     ({ localPath } = await storeImageBytes(uploadedBytes, slug, uploadName || "image"));
@@ -220,7 +223,7 @@ export async function ingestImage(
   }
 
   // Vision description — fail-soft (null → image-only page).
-  const vision = await describeImage(bytes);
+  const vision = await describeImage(bytes, { mediaType });
 
   const body =
     `# ${title}\n\n![${title}](${localPath})` + (vision ? `\n\n${vision.text}` : "");

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -311,6 +311,44 @@ export async function callLLM(
 }
 
 /**
+ * Describe an image using the configured LLM provider's multimodal capability
+ * (e.g. DeepSeek V4, GPT-4o, Gemini). Sends the image bytes + a text prompt as
+ * a single user message. Throws if the provider/model isn't multimodal or the
+ * response is empty — the caller (vision.ts) handles the fallback.
+ *
+ * @param mediaType — e.g. "image/jpeg"; helps the provider; inferred if omitted.
+ */
+export async function callVisionLLM(
+  prompt: string,
+  image: ArrayBuffer | Uint8Array,
+  options?: { maxOutputTokens?: number; mediaType?: string },
+): Promise<string> {
+  const model = getModel();
+  const bytes = image instanceof Uint8Array ? image : new Uint8Array(image);
+
+  const { text } = await retryWithBackoff(() =>
+    generateText({
+      model,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: prompt },
+            { type: "image", image: bytes, mediaType: options?.mediaType },
+          ],
+        },
+      ],
+      maxOutputTokens: options?.maxOutputTokens ?? 512,
+    }),
+  );
+
+  if (!text) {
+    throw new Error("Vision LLM response contained no text");
+  }
+  return text;
+}
+
+/**
  * Call the configured LLM provider and return a streaming result.
  *
  * Returns a `StreamTextResult` from the Vercel AI SDK. Use

--- a/src/lib/vision.ts
+++ b/src/lib/vision.ts
@@ -1,70 +1,86 @@
 import { getWorkersAiBinding } from "./embeddings";
+import { hasLLMKey, callVisionLLM } from "./llm";
 import { logger } from "./logger";
 
 /**
- * Vision (image → text) extraction via the Workers AI binding.
+ * Vision (image → text) extraction.
  *
- * Mirrors the embeddings pattern (`getWorkersAiBinding().run(...)`). Used by the
- * image-ingest flow to turn an image into a factual description that becomes the
- * wiki page body. Fails SOFT: any problem (no binding, timeout, model error,
- * empty result) returns `null` so ingestion proceeds with an image-only page —
- * vision must never break the pipeline.
+ * Prefers the configured LLM provider's multimodal capability (e.g. DeepSeek V4,
+ * which is Chinese-native and far better at CJK text than the free Workers AI
+ * vision models) — reusing the existing API key, no extra model/license. Falls
+ * back to the Workers AI binding (llava, no license required) when no LLM key is
+ * present (e.g. local dev). Fails SOFT: any problem returns `null` so an image
+ * still ingests as an image-only page — vision must never break the pipeline.
  */
 
-/** Default model — overridable via the `VISION_MODEL` env var.
- *  llama-3.2-vision reads text/diagrams notably better than llava. */
-const DEFAULT_VISION_MODEL = "@cf/meta/llama-3.2-11b-vision-instruct";
+/** Workers AI fallback model — overridable via `VISION_MODEL`. llava needs no
+ *  license agreement (unlike llama-3.2-vision). */
+const DEFAULT_WAI_VISION_MODEL = "@cf/llava-hf/llava-1.5-7b-hf";
 
 const DEFAULT_PROMPT =
-  "Describe this image in detail. Include any visible text, diagrams, charts, " +
-  "people, objects, and the overall context. Be factual and concise.";
+  "Describe this image in detail. Transcribe any visible text exactly (in its " +
+  "original language), and note diagrams, charts, objects, and overall context. " +
+  "Be factual and concise.";
 
-/** Hard ceiling so a slow/hung model run can't stall an ingest. */
-const VISION_TIMEOUT_MS = 20_000;
-
-function visionModel(): string {
-  return process.env.VISION_MODEL || DEFAULT_VISION_MODEL;
-}
+/** Hard ceiling so a slow/hung Workers AI run can't stall an ingest. */
+const WAI_TIMEOUT_MS = 20_000;
 
 /**
- * Describe an image from its raw bytes. Returns `{ text }` or `null` when vision
- * is unavailable / fails (caller then produces a minimal image-only page).
+ * Describe an image from its raw bytes. Returns `{ text }` or `null` when no
+ * vision backend is available / it fails.
  */
 export async function describeImage(
   image: ArrayBuffer | Uint8Array,
-  opts?: { prompt?: string; maxTokens?: number },
+  opts?: { prompt?: string; maxTokens?: number; mediaType?: string },
 ): Promise<{ text: string } | null> {
-  const ai = getWorkersAiBinding();
-  if (!ai) return null; // off-Workers or AI binding unbound — degrade gracefully
+  const prompt = opts?.prompt ?? DEFAULT_PROMPT;
+  const maxTokens = opts?.maxTokens ?? 512;
 
+  // 1. Preferred: the configured LLM's multimodal vision (DeepSeek etc.).
+  if (hasLLMKey()) {
+    try {
+      const text = (
+        await callVisionLLM(prompt, image, {
+          maxOutputTokens: maxTokens,
+          mediaType: opts?.mediaType,
+        })
+      ).trim();
+      if (text) return { text };
+      logger.warn("vision", "Vision LLM returned an empty description.");
+    } catch (err) {
+      logger.warn(
+        "vision",
+        `Vision LLM failed (${err instanceof Error ? err.message : String(err)}) — ` +
+          "falling back to Workers AI.",
+      );
+    }
+  }
+
+  // 2. Fallback: the Workers AI binding (llava).
+  const ai = getWorkersAiBinding();
+  if (!ai) return null;
   const bytes = image instanceof Uint8Array ? image : new Uint8Array(image);
-  const model = visionModel();
+  const model = process.env.VISION_MODEL || DEFAULT_WAI_VISION_MODEL;
 
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     const result = await Promise.race([
-      ai.run(model, {
-        image: [...bytes],
-        prompt: opts?.prompt ?? DEFAULT_PROMPT,
-        max_tokens: opts?.maxTokens ?? 512,
-      }),
+      ai.run(model, { image: [...bytes], prompt, max_tokens: maxTokens }),
       new Promise<never>((_, reject) => {
-        timer = setTimeout(() => reject(new Error("vision timeout")), VISION_TIMEOUT_MS);
+        timer = setTimeout(() => reject(new Error("vision timeout")), WAI_TIMEOUT_MS);
       }),
     ]);
-
-    // Different models name the field differently (llama → response, llava →
-    // description); read defensively.
+    // Field name varies by model (llava → description, llama → response).
     const text = (result.response ?? result.description ?? "").trim();
     if (!text) {
-      logger.warn("vision", `Model ${model} returned an empty description.`);
+      logger.warn("vision", `Workers AI ${model} returned an empty description.`);
       return null;
     }
     return { text };
   } catch (err) {
     logger.warn(
       "vision",
-      `Image description failed (${model}): ${err instanceof Error ? err.message : String(err)}`,
+      `Workers AI image description failed (${model}): ${err instanceof Error ? err.message : String(err)}`,
     );
     return null;
   } finally {


### PR DESCRIPTION
Image-ingest vision was broken: it defaulted to `@cf/meta/llama-3.2-11b-vision-instruct`, which needs a one-time Meta license agreement (every call errored) AND I'd coded the llava request shape, not llama-vision's chat shape. So `describeImage` always failed soft → no description.

**Fix:** describe images using the **configured LLM's multimodal capability** (`callVisionLLM` → ai-sdk `generateText` with an image part). The deployment uses **DeepSeek V4** — natively multimodal and **Chinese-native**, so it reads CJK text far better than the free Workers AI models, reuses `DEEPSEEK_API_KEY`, needs no license. Falls back to Workers AI **llava** (no license) when no LLM key. `mediaType` threaded through; all fail-soft.

Vision tests rewritten (LLM-first + WAI fallback). 2280 pass, lint clean.