### PR TITLE
yoyo: transcribe image text verbatim + title image pages from vision

### DIFF
--- a/src/lib/__tests__/ingest-image.test.ts
+++ b/src/lib/__tests__/ingest-image.test.ts
@@ -10,20 +10,22 @@ vi.mock("../vision", () => ({ describeImage: vi.fn() }));
 // Keep the real fetch module but stub the network-touching image helpers.
 vi.mock("../fetch", async (orig) => {
   const actual = await orig<typeof import("../fetch")>();
-  return { ...actual, storeImageAsset: vi.fn(), storeImageBytes: vi.fn() };
+  return { ...actual, fetchImageBytes: vi.fn(), storeImageBytes: vi.fn() };
 });
 
 import { ingest, ingestImage } from "../ingest";
 import { hasLLMKey, callLLM } from "../llm";
 import { describeImage } from "../vision";
-import { storeImageAsset } from "../fetch";
+import { fetchImageBytes, storeImageBytes } from "../fetch";
 import { readWikiPageWithFrontmatter } from "../wiki";
 import { parseSources } from "../sources";
 import { resetSourceIndex } from "../source-index";
 import { resetAliasIndex } from "../alias-index";
+import { _resetStorage } from "../storage";
 
 const mockedDescribe = vi.mocked(describeImage);
-const mockedStore = vi.mocked(storeImageAsset);
+const mockedFetchBytes = vi.mocked(fetchImageBytes);
+const mockedStoreBytes = vi.mocked(storeImageBytes);
 const mockedHasLLMKey = vi.mocked(hasLLMKey);
 const mockedCallLLM = vi.mocked(callLLM);
 
@@ -36,15 +38,20 @@ beforeEach(async () => {
   process.env.DATA_DIR = tmpDir;
   process.env.WIKI_DIR = path.join(tmpDir, "wiki");
   process.env.RAW_DIR = path.join(tmpDir, "raw");
+  _resetStorage(); // re-root storage at this test's fresh tmpDir (avoid cross-test bleed)
   resetSourceIndex();
   resetAliasIndex();
   vi.clearAllMocks();
-  mockedStore.mockResolvedValue({
-    localPath: "assets/photo/photo.png",
+  mockedFetchBytes.mockResolvedValue({
     bytes: new Uint8Array([1, 2, 3]).buffer,
     filename: "photo.png",
     contentType: "image/png",
   });
+  // localPath reflects the final (vision/title-derived) slug.
+  mockedStoreBytes.mockImplementation(async (_bytes, slug, fname) => ({
+    localPath: `assets/${slug}/${fname}`,
+    filename: fname,
+  }));
 });
 
 afterEach(async () => {
@@ -64,9 +71,9 @@ describe("ingestImage", () => {
       { author: "alice", owner: "alice", triggeredBy: "alice", title: "My Photo" },
     );
 
-    expect(mockedStore).toHaveBeenCalledWith("https://example.com/photo.png", "my-photo");
+    expect(mockedFetchBytes).toHaveBeenCalledWith("https://example.com/photo.png");
     const page = await readWikiPageWithFrontmatter(result.primarySlug);
-    expect(page!.content).toContain("![My Photo](assets/photo/photo.png)");
+    expect(page!.content).toContain("![My Photo](assets/my-photo/photo.png)");
     expect(page!.content).toContain("A red square on white.");
     expect(page!.frontmatter.owner).toBe("alice");
     expect(page!.frontmatter.source_url).toBe("https://example.com/photo.png");
@@ -83,9 +90,9 @@ describe("ingestImage", () => {
     );
 
     const page = await readWikiPageWithFrontmatter(result.primarySlug);
-    expect(page!.content).toContain("![Diagram](assets/photo/photo.png)");
+    expect(page!.content).toContain("![Diagram](assets/diagram/photo.png)");
     // No description paragraph, but the page exists and embeds the image.
-    expect(page!.content.trim().endsWith("(assets/photo/photo.png)")).toBe(true);
+    expect(page!.content.trim().endsWith("(assets/diagram/photo.png)")).toBe(true);
   });
 
   it("does not duplicate the embedded image in a ## Images section", async () => {
@@ -95,9 +102,30 @@ describe("ingestImage", () => {
       { author: "alice", owner: "alice", title: "Once" },
     );
     const page = await readWikiPageWithFrontmatter(result.primarySlug);
-    const occurrences = page!.content.split("assets/photo/photo.png").length - 1;
+    const occurrences = page!.content.split("assets/once/photo.png").length - 1;
     expect(occurrences).toBe(1);
     expect(page!.content).not.toContain("## Images");
+  });
+
+  it("titles the page from the vision text when no title is given (not the random filename)", async () => {
+    mockedFetchBytes.mockResolvedValue({
+      bytes: new Uint8Array([1]).buffer,
+      filename: "HI6bsa_a0AAqUJC.jpeg", // random upload name
+      contentType: "image/jpeg",
+    });
+    mockedDescribe.mockResolvedValue({
+      text: "模型 + 手脚架 = 智能体\n\nA blue advertisement for an agent harness.",
+    });
+
+    const result = await ingestImage(
+      { imageUrl: "https://example.com/x.jpeg" },
+      { author: "alice", owner: "alice" }, // no title
+    );
+
+    // Slug derived from the transcribed first line, not "hi6bsa-a0aaqujc".
+    expect(result.primarySlug).not.toBe("hi6bsa-a0aaqujc");
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect(page!.content).toContain("模型 + 手脚架 = 智能体");
   });
 });
 

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -375,14 +375,16 @@ export async function downloadImages(
  * @returns the local markdown ref, the raw bytes (for the vision model), the
  *          filename, and the content type.
  */
-export async function storeImageAsset(
+/**
+ * Fetch an image by URL and validate it WITHOUT storing it yet (so the caller
+ * can run vision and pick a slug before the asset path is fixed). Throws a
+ * {@link ClientInputError} on unsafe/non-image/oversized input (→ 4xx).
+ */
+export async function fetchImageBytes(
   url: string,
-  slug: string,
-): Promise<{ localPath: string; bytes: ArrayBuffer; filename: string; contentType: string }> {
-  // SSRF guard — throws on private/unsafe hosts. Re-tag as client input so the
-  // route classifies it as a 4xx (the bad URL is the caller's).
+): Promise<{ bytes: ArrayBuffer; filename: string; contentType: string }> {
   try {
-    validateUrlSafety(url);
+    validateUrlSafety(url); // SSRF guard — throws on private/unsafe hosts
   } catch (err) {
     throw new ClientInputError(getErrorMessage(err));
   }
@@ -403,8 +405,15 @@ export async function storeImageAsset(
       `Image too large (${bytes.byteLength} bytes, max ${MAX_RESPONSE_SIZE})`,
     );
   }
+  return { bytes, filename: sanitizeImageFilename(url), contentType };
+}
 
-  const { localPath, filename } = await storeImageBytes(bytes, slug, url);
+export async function storeImageAsset(
+  url: string,
+  slug: string,
+): Promise<{ localPath: string; bytes: ArrayBuffer; filename: string; contentType: string }> {
+  const { bytes, filename, contentType } = await fetchImageBytes(url);
+  const { localPath } = await storeImageBytes(bytes, slug, filename);
   return { localPath, bytes, filename, contentType };
 }
 

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -8,7 +8,7 @@ import {
   type Frontmatter,
 } from "./wiki";
 import { callLLM, hasLLMKey } from "./llm";
-import { fetchUrlContent, downloadImages, storeImageAsset, storeImageBytes } from "./fetch";
+import { fetchUrlContent, downloadImages, fetchImageBytes, storeImageBytes } from "./fetch";
 import { describeImage } from "./vision";
 import type { IngestResult, SourceEntry } from "./types";
 import {
@@ -163,6 +163,22 @@ export async function ingestUrl(
   return ingest(title, content, { ...options, sourceUrl: url });
 }
 
+/** Derive a concise page title from the vision description's first meaningful
+ *  line (e.g. a transcribed headline). Returns undefined if nothing usable. */
+function deriveImageTitle(visionText?: string): string | undefined {
+  if (!visionText) return undefined;
+  const firstLine = visionText
+    .split("\n")
+    .map((l) => l.replace(/^[#>\-*\d.\s)]+/, "").trim())
+    .find((l) => l.length > 0);
+  if (!firstLine) return undefined;
+  let title = firstLine;
+  const sentenceEnd = title.search(/[.!?。！？\n]/);
+  if (sentenceEnd >= 8 && sentenceEnd < 80) title = title.slice(0, sentenceEnd);
+  title = title.slice(0, 80).trim();
+  return title || undefined;
+}
+
 /** Derive a human-ish title from a filename or URL (e.g. "diagram-2.png" →
  *  "diagram 2"). Falls back to "Image". */
 function humanizeFilename(nameOrUrl: string): string {
@@ -204,26 +220,36 @@ export async function ingestImage(
     }
   }
 
-  const title = options?.title?.trim() || humanizeFilename(uploadName || imageUrl || "image");
-  const slug = slugify(title);
-
-  // Store the image as an asset and get its bytes for the vision model.
-  let localPath: string;
+  // 1. Obtain the bytes + metadata WITHOUT storing yet — we may title the page
+  //    (and thus the slug) from the vision text, so the slug isn't known yet.
   let bytes: ArrayBuffer;
-  let mediaType: string | undefined = input.contentType;
+  let filename: string;
+  let mediaType: string | undefined;
   if (imageUrl) {
-    const stored = await storeImageAsset(imageUrl, slug);
-    ({ localPath, bytes } = stored);
-    mediaType = stored.contentType;
+    const fetched = await fetchImageBytes(imageUrl);
+    bytes = fetched.bytes;
+    filename = fetched.filename;
+    mediaType = fetched.contentType;
   } else if (uploadedBytes) {
     bytes = uploadedBytes;
-    ({ localPath } = await storeImageBytes(uploadedBytes, slug, uploadName || "image"));
+    filename = uploadName || "image";
+    mediaType = input.contentType;
   } else {
     throw new Error("ingestImage requires either imageUrl or bytes");
   }
 
-  // Vision description — fail-soft (null → image-only page).
+  // 2. Vision description — fail-soft (null → image-only page).
   const vision = await describeImage(bytes, { mediaType });
+
+  // 3. Title: explicit → derived from the vision text → humanized filename.
+  const title =
+    options?.title?.trim() ||
+    deriveImageTitle(vision?.text) ||
+    humanizeFilename(filename || imageUrl || "image");
+  const slug = slugify(title);
+
+  // 4. Store the asset under the final slug.
+  const { localPath } = await storeImageBytes(bytes, slug, filename);
 
   const body =
     `# ${title}\n\n![${title}](${localPath})` + (vision ? `\n\n${vision.text}` : "");

--- a/src/lib/vision.ts
+++ b/src/lib/vision.ts
@@ -18,9 +18,13 @@ import { logger } from "./logger";
 const DEFAULT_WAI_VISION_MODEL = "@cf/llava-hf/llava-1.5-7b-hf";
 
 const DEFAULT_PROMPT =
-  "Describe this image in detail. Transcribe any visible text exactly (in its " +
-  "original language), and note diagrams, charts, objects, and overall context. " +
-  "Be factual and concise.";
+  "Read this image carefully.\n" +
+  "1. First, TRANSCRIBE every piece of visible text exactly as written, in its " +
+  "ORIGINAL language — do not translate or paraphrase. Preserve line breaks and " +
+  "any formulas/equations.\n" +
+  "2. Then add a short factual description of the visuals (diagrams, charts, " +
+  "objects, layout) and the overall purpose.\n" +
+  "If there is no text, just describe the image.";
 
 /** Hard ceiling so a slow/hung Workers AI run can't stall an ingest. */
 const WAI_TIMEOUT_MS = 20_000;


### PR DESCRIPTION
Prompted by a Chinese-text upload that got an English description and an ugly filename slug (`hi6bsa-a0aaqujc`):

1. **Verbatim transcription** — the vision prompt now makes transcribing visible text *in its original language* (no translation) the primary task, then a short description. So Chinese/text in the image is extracted, not paraphrased.
2. **Title from vision** — image pages are titled from the vision text (e.g. the transcribed headline) when no title is given, instead of the random filename. `ingestImage` now fetches+describes *before* choosing the slug (`fetchImageBytes` factored out of `storeImageAsset`), then stores under the final slug; falls back to a humanized filename.

+1 test; fixed latent cross-test storage bleed with `_resetStorage`. 2281 pass, lint clean.