### PR TITLE
yoyo: exclude agent-scoped pages from contributors + homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import { ContributorBadge } from "@/components/ContributorBadge";
 import { GlobalSearch } from "@/components/GlobalSearch";
 import { StatCard } from "@/components/StatCard";
 import { TagChip } from "@/components/TagChip";
-import { listWikiPages } from "@/lib/wiki";
+import { listWikiPages, isAgentScopedType } from "@/lib/wiki";
 import { listContributors } from "@/lib/contributors";
 
 export default async function Home() {
@@ -15,9 +15,10 @@ export default async function Home() {
     listContributors(),
   ]);
 
-  // Match the public /wiki "all" view: hide agent-identity pages so the stats,
-  // recent grid, and topics reflect the human-facing commons.
-  const pages = allPages.filter((p) => p.type !== "agent-identity");
+  // Match the public /wiki "all" view: hide all agent-scoped pages (identity +
+  // knowledge) so the stats, recent grid, and topics reflect the human-facing
+  // commons rather than an agent's private workspace.
+  const pages = allPages.filter((p) => !isAgentScopedType(p.type));
 
   const pageCount = pages.length;
   const sourceCount = pages.reduce((n, p) => n + (p.sourceCount ?? 0), 0);

--- a/src/lib/__tests__/contributors.test.ts
+++ b/src/lib/__tests__/contributors.test.ts
@@ -92,6 +92,24 @@ describe("contributors data layer", () => {
       expect(contributors[1].handle).toBe("bob");
       expect(contributors[1].editCount).toBe(1);
     });
+
+    it("excludes agent-scoped pages so agents aren't listed as contributors", async () => {
+      // A human page edited by a human...
+      await createPage("page-a", "Page A", "# Page A\n\nContent.");
+      await saveRevision("page-a", "# Page A\n\nv1", "alice");
+
+      // ...and an agent-scoped page authored by the agent itself. Its author
+      // (the agent's composite id) must NOT surface as a human contributor.
+      await createPage(
+        "agent-note",
+        "Agent Note",
+        "---\ntype: agent-knowledge\n---\n\n# Agent Note\n\nLearned.",
+      );
+      await saveRevision("agent-note", "# Agent Note\n\nv1", "yuanhao--yoyo");
+
+      const contributors = await listContributors();
+      expect(contributors.map((c) => c.handle)).toEqual(["alice"]);
+    });
   });
 
   describe("buildContributorProfile", () => {

--- a/src/lib/contributors.ts
+++ b/src/lib/contributors.ts
@@ -12,7 +12,7 @@
 // ---------------------------------------------------------------------------
 
 import { getStorage } from "./storage";
-import { listWikiPages } from "./wiki";
+import { listWikiPages, isAgentScopedType } from "./wiki";
 import { listRevisions } from "./revisions";
 import { getDiscussRelPrefix } from "./talk";
 import { isEnoent } from "./errors";
@@ -79,6 +79,9 @@ async function scanRevisions(): Promise<Map<string, AuthorActivity>> {
   const pages = await listWikiPages();
 
   for (const page of pages) {
+    // Agent-scoped pages are authored by the agent itself (e.g. "yuanhao--yoyo",
+    // "yoyo"); they're not human contributors, so don't count them.
+    if (isAgentScopedType(page.type)) continue;
     const revisions = await listRevisions(page.slug);
     for (const rev of revisions) {
       if (!rev.author) continue;
@@ -140,6 +143,7 @@ async function detectReverts(): Promise<Map<string, number>> {
   const pages = await listWikiPages();
 
   for (const page of pages) {
+    if (isAgentScopedType(page.type)) continue;
     const revisions = await listRevisions(page.slug);
     if (revisions.length < 2) continue;
 


### PR DESCRIPTION
## Problem

The homepage **Contributors** section was showing agent handles (`yoyo`, `yuanhao--yoyo`) alongside human contributors. Agents aren't humans and shouldn't appear there.

## Root cause

`listContributors()` → `computeScanData()` iterates `listWikiPages()` over **all** pages, keying activity by `rev.author`. Agent-scoped pages (`type` starting with `agent-`) are authored by the agent itself, so the agent's name/composite-id leaked into the contributor map.

## Fix

- **`contributors.ts`** — skip agent-scoped pages (`isAgentScopedType(page.type)`) in both `scanRevisions` and `detectReverts`, so agent authors are never counted as contributors anywhere (homepage + `/wiki/contributors`).
- **`page.tsx`** — filter the homepage stats / recent grid / topics on `!isAgentScopedType(p.type)` (all agent-scoped pages) instead of only `agent-identity`, so the human-facing commons stays consistent with the agent-content-is-scoped model.

## Tests

- New test: agent-scoped page authored by `yuanhao--yoyo` is excluded; only the human `alice` is listed.
- `pnpm lint` clean; full suite passes (2281 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)