### PR TITLE
yoyo: editorial UI refresh — type pairing, indigo accent, restructured reading view

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,11 +6,35 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+
+  /* Neutral surfaces & borders — single source of truth for the muted
+     greys that were previously expressed ad-hoc as gray-100/gray-800 and
+     foreground/X opacity. */
+  --surface: #f5f5f4;
+  --surface-strong: #e7e5e4;
+  --border: #e5e5e5;
+  --muted: #6b6b6b;
+
+  /* Brand accent — indigo. Used for primary actions, links, active nav,
+     and focus rings. */
+  --accent: #4f46e5;
+  --accent-hover: #4338ca;
+  --accent-foreground: #ffffff;
 }
 
 .dark {
   --background: #0a0a0a;
   --foreground: #ededed;
+
+  --surface: #1c1c1c;
+  --surface-strong: #2a2a2a;
+  --border: #2a2a2a;
+  --muted: #a3a3a3;
+
+  /* Brighter indigo + dark text so fills keep AA contrast on near-black. */
+  --accent: #818cf8;
+  --accent-hover: #a5b4fc;
+  --accent-foreground: #0a0a0a;
 }
 
 /* Fallback for when JS hasn't loaded yet */
@@ -18,18 +42,40 @@
   :root:not(.light) {
     --background: #0a0a0a;
     --foreground: #ededed;
+
+    --surface: #1c1c1c;
+    --surface-strong: #2a2a2a;
+    --border: #2a2a2a;
+    --muted: #a3a3a3;
+
+    --accent: #818cf8;
+    --accent-hover: #a5b4fc;
+    --accent-foreground: #0a0a0a;
   }
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-surface-strong: var(--surface-strong);
+  --color-border: var(--border);
+  --color-muted: var(--muted);
+  --color-accent: var(--accent);
+  --color-accent-hover: var(--accent-hover);
+  --color-accent-foreground: var(--accent-foreground);
+
+  /* Fonts — wired to the next/font CSS variables set in layout.tsx, with
+     graceful fallbacks before the web fonts load. */
+  --font-sans: var(--font-sans-next), system-ui, -apple-system, sans-serif;
+  --font-serif: var(--font-serif-next), Georgia, "Times New Roman", serif;
+  --font-mono: var(--font-mono-next), ui-monospace, SFMono-Regular, monospace;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family: var(--font-sans);
 }
 
 /* Skip-nav link — visually hidden until focused */
@@ -56,13 +102,67 @@ body {
   font-size: 1rem;
 }
 
-/* Focus-visible ring for interactive elements */
+/* Focus-visible ring for interactive elements — accent-colored. */
 a:focus-visible,
 button:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible,
 [tabindex]:focus-visible {
-  outline: 2px solid var(--foreground);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------------
+   Article reading body — opt-in serif typography for long-form wiki pages.
+   Scoped to `.prose-article` so shared MarkdownRenderer consumers (query
+   answers, slide previews) keep the neutral sans look.
+   --------------------------------------------------------------------------- */
+.prose-article {
+  --tw-prose-body: var(--foreground);
+  --tw-prose-headings: var(--foreground);
+  --tw-prose-bold: var(--foreground);
+  --tw-prose-code: var(--foreground);
+  --tw-prose-links: var(--accent);
+  --tw-prose-quotes: var(--muted);
+  --tw-prose-quote-borders: var(--border);
+  --tw-prose-hr: var(--border);
+  --tw-prose-th-borders: var(--border);
+  --tw-prose-td-borders: var(--border);
+  font-family: var(--font-serif);
+}
+
+/* Headings stay in the UI sans even inside the serif article. */
+.prose-article :is(h1, h2, h3, h4) {
+  font-family: var(--font-sans);
+  letter-spacing: -0.01em;
+}
+
+/* Code uses the mono font on a subtle surface. */
+.prose-article :is(code, pre) {
+  font-family: var(--font-mono);
+}
+.prose-article :not(pre) > code {
+  background: var(--surface);
+  padding: 0.15em 0.35em;
+  border-radius: 0.3rem;
+  font-weight: 500;
+}
+.prose-article :not(pre) > code::before,
+.prose-article :not(pre) > code::after {
+  content: none; /* drop the typography plugin's backtick quotes */
+}
+.prose-article pre {
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+
+/* Reading measure (~68ch) for text, left-aligned so the body shares a left
+   edge with the (full-width) page title; media/code/tables bleed to the full
+   column width. Re-imposes a measure that `max-w-none` removes. */
+.prose-article > * {
+  max-width: 68ch;
+}
+.prose-article > :is(img, figure, pre, table, hr) {
+  max-width: 100%;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,29 @@
 import type { Metadata } from "next";
+import { Inter, Source_Serif_4, JetBrains_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import { NavHeader } from "@/components/NavHeader";
+import { Footer } from "@/components/Footer";
 import { ClientProviders } from "@/components/ClientProviders";
 import { EnsureYoyo } from "@/components/EnsureYoyo";
 import "./globals.css";
+
+// Self-hosted via next/font (no runtime Google CDN calls). Exposed as CSS
+// variables consumed by the `--font-*` tokens in globals.css.
+const fontSans = Inter({
+  subsets: ["latin"],
+  variable: "--font-sans-next",
+  display: "swap",
+});
+const fontSerif = Source_Serif_4({
+  subsets: ["latin"],
+  variable: "--font-serif-next",
+  display: "swap",
+});
+const fontMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono-next",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "yopedia",
@@ -32,11 +52,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${fontSans.variable} ${fontSerif.variable} ${fontMono.variable}`}
+    >
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
-      <body className="min-h-screen antialiased">
+      <body className="min-h-screen antialiased flex flex-col">
         <ClerkProvider>
           <ClientProviders>
             <EnsureYoyo />
@@ -44,7 +68,10 @@ export default function RootLayout({
               Skip to main content
             </a>
             <NavHeader />
-            <main id="main-content">{children}</main>
+            <main id="main-content" className="flex-1">
+              {children}
+            </main>
+            <Footer />
           </ClientProviders>
         </ClerkProvider>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,10 +44,10 @@ export default async function Home() {
     <div className="mx-auto max-w-5xl px-6 py-12">
       {/* Hero */}
       <section className="max-w-3xl">
-        <p className="text-sm font-medium text-foreground/50">
+        <p className="text-sm font-medium text-accent">
           A wiki for the agent age.
         </p>
-        <h1 className="mt-2 text-4xl sm:text-5xl font-bold tracking-tight">
+        <h1 className="mt-2 text-5xl sm:text-6xl font-bold tracking-tight">
           yopedia
         </h1>
         <p className="mt-4 text-lg text-foreground/70 leading-relaxed">
@@ -64,7 +64,7 @@ export default async function Home() {
         <div className="mt-6 flex flex-wrap items-center gap-3">
           <Link
             href="/wiki"
-            className="rounded-lg bg-foreground px-5 py-2.5 text-sm font-medium text-background hover:opacity-90 transition-opacity"
+            className="rounded-lg bg-accent px-5 py-2.5 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-colors"
           >
             Browse the wiki
           </Link>

--- a/src/app/wiki/[slug]/page.tsx
+++ b/src/app/wiki/[slug]/page.tsx
@@ -454,18 +454,44 @@ interface TocItem {
 }
 
 /**
- * Parse h2/h3 ATX headings from a markdown body into TOC items. IDs use the
- * same `slugify` as the MarkdownRenderer heading anchors, so the links line
- * up. Light markdown emphasis is stripped from the displayed text.
+ * Reduce raw markdown heading text to the plain text the MarkdownRenderer
+ * actually renders: `[label](url)`/`![alt](src)` collapse to their label, and
+ * emphasis/code markers are dropped. Keeps TOC slugs in sync with the heading
+ * anchors (which slugify the rendered text).
+ */
+function headingDisplayText(raw: string): string {
+  return raw
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/[*_`~]/g, "")
+    .trim();
+}
+
+/**
+ * Parse h2/h3 ATX headings into TOC items with unique ids (GitHub-style
+ * `-2`, `-3` suffixes for repeats). Fenced code blocks are skipped so a
+ * `## x` inside code isn't mistaken for a heading — keeping this list aligned
+ * with what the renderer emits. The id array is handed to the renderer so the
+ * heading anchors match these by construction.
  */
 function buildToc(body: string): TocItem[] {
+  const prose = body
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/~~~[\s\S]*?~~~/g, "");
   const items: TocItem[] = [];
+  const seen = new Map<string, number>();
   const re = /^(#{2,3})\s+(.+?)\s*#*$/gm;
   let m: RegExpExecArray | null;
-  while ((m = re.exec(body)) !== null) {
-    const text = m[2].replace(/[*_`]/g, "").trim();
+  while ((m = re.exec(prose)) !== null) {
+    const text = headingDisplayText(m[2]);
     if (!text) continue;
-    items.push({ level: m[1].length === 2 ? 2 : 3, text, id: slugify(text) });
+    const base = slugify(text) || "section";
+    const n = (seen.get(base) ?? 0) + 1;
+    seen.set(base, n);
+    items.push({
+      level: m[1].length === 2 ? 2 : 3,
+      text,
+      id: n === 1 ? base : `${base}-${n}`,
+    });
   }
   return items;
 }
@@ -583,7 +609,11 @@ export default async function WikiPageView({ params }: WikiPageProps) {
               discussionStats={discussStats}
             />
             <div className="mt-8">
-              <MarkdownRenderer content={articleBody} className="prose-article" />
+              <MarkdownRenderer
+                content={articleBody}
+                className="prose-article"
+                headingIds={toc.map((t) => t.id)}
+              />
             </div>
           </article>
 

--- a/src/app/wiki/[slug]/page.tsx
+++ b/src/app/wiki/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { decodeSlug } from "@/lib/slugify";
+import { decodeSlug, slugify } from "@/lib/slugify";
 import { readWikiPageWithFrontmatter, findBacklinks, type Frontmatter } from "@/lib/wiki";
 import { parseSources } from "@/lib/sources";
 import type { SourceEntry } from "@/lib/types";
@@ -77,8 +77,7 @@ function sourceTypeBadge(type: SourceEntry["type"]): {
     case "text":
       return {
         label: "Text",
-        className:
-          "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+        className: "bg-surface text-muted",
       };
     case "x-mention":
       return {
@@ -101,8 +100,7 @@ function sourceTypeBadge(type: SourceEntry["type"]): {
     default:
       return {
         label: String(type),
-        className:
-          "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+        className: "bg-surface text-muted",
       };
   }
 }
@@ -137,8 +135,8 @@ function SourceProvenance({
   // Structured sources available — render the rich provenance section.
   if (sources.length > 0) {
     return (
-      <section className="mt-8 border-t border-foreground/10 pt-6">
-        <h2 className="text-sm font-medium text-foreground/50 uppercase tracking-wide mb-3">
+      <section className="mt-8 border-t border-border pt-6">
+        <h2 className="text-sm font-medium text-muted uppercase tracking-wide mb-3">
           Provenance
         </h2>
         <div className="space-y-2">
@@ -167,7 +165,7 @@ function SourceProvenance({
                     href={entry.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-blue-600 hover:underline dark:text-blue-400 truncate max-w-md"
+                    className="text-accent hover:underline truncate max-w-md"
                     title={entry.url}
                   >
                     {entry.url}
@@ -228,12 +226,19 @@ function SourceProvenance({
 }
 
 /**
- * Render a small muted metadata strip (date + source count + tag pills +
- * yopedia fields) built from a page's parsed frontmatter. Returns `null`
- * when no metadata fields are present, so legacy frontmatter-less pages
- * render nothing.
+ * Slim byline shown directly beneath the page title: the lightweight
+ * who/when/how-confident line plus authors and topic tags. The heavier
+ * reference fields (validity, aliases, supersedes) live in {@link PageInfo}.
+ * Returns `null` when nothing applies, so frontmatter-less pages render only
+ * the title.
  */
-function PageMetadata({ frontmatter, discussionStats }: { frontmatter: Frontmatter; discussionStats?: DiscussionStats }) {
+function PageByline({
+  frontmatter,
+  discussionStats,
+}: {
+  frontmatter: Frontmatter;
+  discussionStats?: DiscussionStats;
+}) {
   const updatedRaw = frontmatter.updated;
   const createdRaw = frontmatter.created;
   const dateLabel =
@@ -258,8 +263,6 @@ function PageMetadata({ frontmatter, discussionStats }: { frontmatter: Frontmatt
     ? frontmatter.tags.filter((t) => typeof t === "string" && t.length > 0)
     : [];
 
-  // --- Yopedia fields ---
-
   // Confidence badge: show only when confidence is a finite number.
   const confidenceRaw = frontmatter.confidence;
   const confidenceNum =
@@ -273,79 +276,33 @@ function PageMetadata({ frontmatter, discussionStats }: { frontmatter: Frontmatt
       ? confidenceDisplay(confidenceNum)
       : null;
 
-  // Expiry / staleness: show only when expiry is a non-empty string.
-  const expiryRaw = frontmatter.expiry;
-  const expiryStr =
-    typeof expiryRaw === "string" && expiryRaw.length >= 10
-      ? expiryRaw
-      : null;
-  const expiryDate = expiryStr ? new Date(expiryStr) : null;
-  const isExpired =
-    expiryDate !== null && !isNaN(expiryDate.getTime()) && expiryDate < new Date();
-
-  // Temporal validity: when the page's content was last verified as accurate.
-  const validFromRaw = frontmatter.valid_from;
-  const validFromStr =
-    typeof validFromRaw === "string" && validFromRaw.length >= 10
-      ? validFromRaw
-      : null;
-
-  // Authors
   const authors = Array.isArray(frontmatter.authors)
-    ? frontmatter.authors.filter(
-        (a) => typeof a === "string" && a.length > 0,
-      )
+    ? frontmatter.authors.filter((a) => typeof a === "string" && a.length > 0)
     : [];
-
-  // Contributors (only show extras not already in authors)
   const contributors = Array.isArray(frontmatter.contributors)
     ? frontmatter.contributors.filter(
-        (c) =>
-          typeof c === "string" && c.length > 0 && !authors.includes(c),
+        (c) => typeof c === "string" && c.length > 0 && !authors.includes(c),
       )
     : [];
 
-  // Disputed badge
   const disputed = frontmatter.disputed === true;
-
-  // Aliases
-  const aliases = Array.isArray(frontmatter.aliases)
-    ? frontmatter.aliases.filter(
-        (a) => typeof a === "string" && a.length > 0,
-      )
-    : [];
-
-  // Supersedes
-  const supersedes =
-    typeof frontmatter.supersedes === "string" &&
-    frontmatter.supersedes.length > 0
-      ? frontmatter.supersedes
-      : null;
-
-  // Discussion stats
   const hasOpenDiscussions = (discussionStats?.open ?? 0) > 0;
 
-  const hasDateLine = dateLabel !== null || sourceLabel !== null;
-  const hasTags = tags.length > 0;
-  const hasYopedia =
+  const hasMetaLine =
+    dateLabel !== null ||
+    sourceLabel !== null ||
     confidence !== null ||
-    expiryStr !== null ||
-    validFromStr !== null ||
-    authors.length > 0 ||
     disputed ||
-    aliases.length > 0 ||
-    supersedes !== null ||
     hasOpenDiscussions;
 
-  if (!hasDateLine && !hasTags && !hasYopedia) return null;
+  if (!hasMetaLine && authors.length === 0 && tags.length === 0) return null;
 
   return (
-    <div className="mb-6 space-y-2">
-      {/* Row 1: date · sources · confidence · disputed · discussions */}
-      {(hasDateLine || confidence || disputed || hasOpenDiscussions) && (
-        <div className="flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+    <div className="mt-3 space-y-2">
+      {hasMetaLine && (
+        <div className="flex flex-wrap items-center gap-2 text-sm text-muted">
           {dateLabel && <span>{dateLabel}</span>}
-          {dateLabel && sourceLabel && <span>·</span>}
+          {dateLabel && sourceLabel && <span aria-hidden>·</span>}
           {sourceLabel && <span>{sourceLabel}</span>}
           {confidence && (
             <span
@@ -361,82 +318,193 @@ function PageMetadata({ frontmatter, discussionStats }: { frontmatter: Frontmatt
           )}
           {hasOpenDiscussions && (
             <span className="inline-flex items-center gap-0.5 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
-              💬 {discussionStats!.open} open {discussionStats!.open === 1 ? "thread" : "threads"}
+              💬 {discussionStats!.open} open{" "}
+              {discussionStats!.open === 1 ? "thread" : "threads"}
             </span>
           )}
         </div>
       )}
 
-      {/* Row 2: tags */}
-      {hasTags && (
+      {authors.length > 0 && (
+        <AuthorBadges authors={authors} contributors={contributors} />
+      )}
+
+      {tags.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
           {tags.map((tag) => (
             <span
               key={tag}
-              className="inline-block rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+              className="inline-block rounded-full bg-surface px-2 py-0.5 text-xs text-muted"
             >
               {tag}
             </span>
           ))}
         </div>
       )}
-
-      {/* Row 3: authors + contributors (with trust badges) */}
-      {authors.length > 0 && (
-        <AuthorBadges authors={authors} contributors={contributors} />
-      )}
-
-      {/* Row 4: temporal validity — verified date + expiry */}
-      {(validFromStr || (expiryStr && expiryDate && !isNaN(expiryDate.getTime()))) && (
-        <div className="text-sm">
-          {isExpired ? (
-            <span className="text-amber-600 dark:text-amber-400">
-              ⚠{validFromStr ? ` Verified ${formatMonthYear(validFromStr)} ·` : ""} Expired {formatDate(expiryStr!)} — may be outdated
-            </span>
-          ) : validFromStr && expiryStr ? (
-            <span className="text-gray-400 dark:text-gray-500">
-              Verified {formatMonthYear(validFromStr)} · Review by {formatMonthYear(expiryStr)}
-            </span>
-          ) : validFromStr ? (
-            <span className="text-gray-400 dark:text-gray-500">
-              Verified {formatMonthYear(validFromStr)}
-            </span>
-          ) : (
-            <span className="text-gray-400 dark:text-gray-500">
-              Review by {formatMonthYear(expiryStr!)}
-            </span>
-          )}
-        </div>
-      )}
-
-      {/* Row 5: disputed explanation */}
-      {disputed && (
-        <div className="text-sm text-orange-600 dark:text-orange-400">
-          This page has unresolved contradictions
-        </div>
-      )}
-
-      {/* Row 6: aliases */}
-      {aliases.length > 0 && (
-        <div className="text-sm text-gray-400 dark:text-gray-500">
-          Also known as: {aliases.join(", ")}
-        </div>
-      )}
-
-      {/* Row 7: supersedes link */}
-      {supersedes && (
-        <div className="text-sm text-gray-400 dark:text-gray-500">
-          Replaces:{" "}
-          <Link
-            href={`/wiki/${supersedes}`}
-            className="text-blue-600 hover:underline dark:text-blue-400"
-          >
-            {supersedes}
-          </Link>
-        </div>
-      )}
     </div>
   );
+}
+
+/**
+ * Demoted reference details (temporal validity, dispute note, aliases, the
+ * superseded page). Rendered in the desktop sidebar rail and, on mobile,
+ * inline below the article. Returns `null` when there's nothing to show.
+ */
+function PageInfo({
+  frontmatter,
+  className,
+}: {
+  frontmatter: Frontmatter;
+  className?: string;
+}) {
+  const expiryRaw = frontmatter.expiry;
+  const expiryStr =
+    typeof expiryRaw === "string" && expiryRaw.length >= 10 ? expiryRaw : null;
+  const expiryDate = expiryStr ? new Date(expiryStr) : null;
+  const isExpired =
+    expiryDate !== null && !isNaN(expiryDate.getTime()) && expiryDate < new Date();
+
+  const validFromRaw = frontmatter.valid_from;
+  const validFromStr =
+    typeof validFromRaw === "string" && validFromRaw.length >= 10
+      ? validFromRaw
+      : null;
+
+  const disputed = frontmatter.disputed === true;
+
+  const aliases = Array.isArray(frontmatter.aliases)
+    ? frontmatter.aliases.filter((a) => typeof a === "string" && a.length > 0)
+    : [];
+
+  const supersedes =
+    typeof frontmatter.supersedes === "string" &&
+    frontmatter.supersedes.length > 0
+      ? frontmatter.supersedes
+      : null;
+
+  const hasValidity =
+    validFromStr !== null ||
+    (expiryStr !== null && expiryDate !== null && !isNaN(expiryDate.getTime()));
+
+  if (!hasValidity && !disputed && aliases.length === 0 && !supersedes) {
+    return null;
+  }
+
+  return (
+    <section className={className}>
+      <h2 className="text-xs font-medium text-muted uppercase tracking-wide mb-2">
+        Page info
+      </h2>
+      <div className="space-y-2 text-sm">
+        {hasValidity && (
+          <div>
+            {isExpired ? (
+              <span className="text-amber-600 dark:text-amber-400">
+                ⚠{validFromStr ? ` Verified ${formatMonthYear(validFromStr)} ·` : ""} Expired {formatDate(expiryStr!)} — may be outdated
+              </span>
+            ) : validFromStr && expiryStr ? (
+              <span className="text-muted">
+                Verified {formatMonthYear(validFromStr)} · Review by {formatMonthYear(expiryStr)}
+              </span>
+            ) : validFromStr ? (
+              <span className="text-muted">
+                Verified {formatMonthYear(validFromStr)}
+              </span>
+            ) : (
+              <span className="text-muted">
+                Review by {formatMonthYear(expiryStr!)}
+              </span>
+            )}
+          </div>
+        )}
+
+        {disputed && (
+          <div className="text-orange-600 dark:text-orange-400">
+            This page has unresolved contradictions
+          </div>
+        )}
+
+        {aliases.length > 0 && (
+          <div className="text-muted">
+            Also known as: {aliases.join(", ")}
+          </div>
+        )}
+
+        {supersedes && (
+          <div className="text-muted">
+            Replaces:{" "}
+            <Link
+              href={`/wiki/${supersedes}`}
+              className="text-accent hover:underline"
+            >
+              {supersedes}
+            </Link>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/** A single Table-of-Contents entry parsed from the markdown body. */
+interface TocItem {
+  level: 2 | 3;
+  text: string;
+  id: string;
+}
+
+/**
+ * Parse h2/h3 ATX headings from a markdown body into TOC items. IDs use the
+ * same `slugify` as the MarkdownRenderer heading anchors, so the links line
+ * up. Light markdown emphasis is stripped from the displayed text.
+ */
+function buildToc(body: string): TocItem[] {
+  const items: TocItem[] = [];
+  const re = /^(#{2,3})\s+(.+?)\s*#*$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    const text = m[2].replace(/[*_`]/g, "").trim();
+    if (!text) continue;
+    items.push({ level: m[1].length === 2 ? 2 : 3, text, id: slugify(text) });
+  }
+  return items;
+}
+
+/** In-page Table of Contents. Hidden when there are too few headings. */
+function TableOfContents({
+  items,
+  className,
+}: {
+  items: TocItem[];
+  className?: string;
+}) {
+  if (items.length < 3) return null;
+  return (
+    <nav aria-label="On this page" className={className}>
+      <h2 className="text-xs font-medium text-muted uppercase tracking-wide mb-2">
+        On this page
+      </h2>
+      <ul className="space-y-1.5 border-l border-border">
+        {items.map((it) => (
+          <li key={it.id}>
+            <a
+              href={`#${it.id}`}
+              className={`block border-l border-transparent -ml-px py-0.5 text-muted hover:border-accent hover:text-accent transition-colors ${
+                it.level === 3 ? "pl-6" : "pl-3"
+              }`}
+            >
+              {it.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+/** Remove the first H1 line so the promoted page title isn't duplicated. */
+function stripLeadingH1(body: string): string {
+  return body.replace(/^#\s+.+(?:\r?\n)?/m, "");
 }
 
 export default async function WikiPageView({ params }: WikiPageProps) {
@@ -491,60 +559,95 @@ export default async function WikiPageView({ params }: WikiPageProps) {
     Array.isArray(page.frontmatter.sharedWith) &&
     (page.frontmatter.sharedWith as string[]).includes(myYoyoId);
 
+  const toc = buildToc(page.body);
+  const articleBody = stripLeadingH1(page.body);
+
   return (
-    <main className="mx-auto max-w-3xl px-6 py-12">
+    <main className="mx-auto max-w-5xl px-6 py-12">
       <Link
         href="/wiki"
-        className="text-sm text-foreground/60 hover:text-foreground transition-colors"
+        className="text-sm text-muted hover:text-foreground transition-colors"
       >
         ← Back to index
       </Link>
-      <article className="mt-6">
-        <PageMetadata frontmatter={page.frontmatter} discussionStats={discussStats} />
-        <MarkdownRenderer content={page.content} />
-      </article>
-      <SourceProvenance frontmatter={page.frontmatter} />
-      {backlinks.length > 0 && (
-        <section className="mt-10 border-t border-foreground/10 pt-6">
-          <h2 className="text-sm font-medium text-foreground/50 uppercase tracking-wide">
-            What links here
-          </h2>
-          <ul className="mt-2 space-y-1">
-            {backlinks.map((bl) => (
-              <li key={bl.slug}>
-                <Link
-                  href={`/wiki/${bl.slug}`}
-                  className="text-sm text-blue-600 hover:underline dark:text-blue-400"
-                >
-                  {bl.title}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </section>
-      )}
-      <DiscussionPanel slug={slug} />
-      <RevisionHistory slug={slug} />
-      <div className="mt-12 border-t border-foreground/10 pt-6 flex flex-wrap items-center gap-3">
-        <Link
-          href={`/wiki/${slug}/edit`}
-          className="rounded-md border border-foreground/20 px-4 py-2 text-sm font-medium text-foreground hover:bg-foreground/5 transition-colors"
-        >
-          Edit page
-        </Link>
-        {hasRawSource && (
-          <Link
-            href={`/raw/${slug}`}
-            className="rounded-md border border-foreground/20 px-4 py-2 text-sm font-medium text-foreground hover:bg-foreground/5 transition-colors"
-          >
-            View source
-          </Link>
-        )}
-        {hasSourceUrl && <ReingestButton slug={slug} />}
-        {canShare && (
-          <ShareWithYoyoButton slug={slug} initiallyShared={alreadyShared} />
-        )}
-        <DeletePageButton slug={slug} />
+
+      <div className="mt-6 lg:grid lg:grid-cols-[minmax(0,1fr)_15rem] lg:gap-12">
+        {/* Reading column */}
+        <div className="min-w-0">
+          <article>
+            <h1 className="text-3xl sm:text-4xl font-bold tracking-tight">
+              {page.title}
+            </h1>
+            <PageByline
+              frontmatter={page.frontmatter}
+              discussionStats={discussStats}
+            />
+            <div className="mt-8">
+              <MarkdownRenderer content={articleBody} className="prose-article" />
+            </div>
+          </article>
+
+          <SourceProvenance frontmatter={page.frontmatter} />
+
+          {/* Page info — inline on mobile; the rail shows it on desktop. */}
+          <PageInfo
+            frontmatter={page.frontmatter}
+            className="mt-8 border-t border-border pt-6 lg:hidden"
+          />
+
+          {backlinks.length > 0 && (
+            <section className="mt-10 border-t border-border pt-6">
+              <h2 className="text-sm font-medium text-muted uppercase tracking-wide">
+                What links here
+              </h2>
+              <ul className="mt-2 space-y-1">
+                {backlinks.map((bl) => (
+                  <li key={bl.slug}>
+                    <Link
+                      href={`/wiki/${bl.slug}`}
+                      className="text-sm text-accent hover:underline"
+                    >
+                      {bl.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          <DiscussionPanel slug={slug} />
+          <RevisionHistory slug={slug} />
+
+          <div className="mt-12 border-t border-border pt-6 flex flex-wrap items-center gap-3">
+            <Link
+              href={`/wiki/${slug}/edit`}
+              className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-foreground/5 transition-colors"
+            >
+              Edit page
+            </Link>
+            {hasRawSource && (
+              <Link
+                href={`/raw/${slug}`}
+                className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-foreground/5 transition-colors"
+              >
+                View source
+              </Link>
+            )}
+            {hasSourceUrl && <ReingestButton slug={slug} />}
+            {canShare && (
+              <ShareWithYoyoButton slug={slug} initiallyShared={alreadyShared} />
+            )}
+            <DeletePageButton slug={slug} />
+          </div>
+        </div>
+
+        {/* Right rail — table of contents + page info (desktop only) */}
+        <aside className="hidden lg:block">
+          <div className="sticky top-20 space-y-8">
+            <TableOfContents items={toc} />
+            <PageInfo frontmatter={page.frontmatter} />
+          </div>
+        </aside>
       </div>
     </main>
   );

--- a/src/components/AuthorBadges.tsx
+++ b/src/components/AuthorBadges.tsx
@@ -56,7 +56,7 @@ export function AuthorBadges({ authors, contributors }: AuthorBadgesProps) {
   if (authors.length === 0) return null;
 
   return (
-    <div className="text-sm text-gray-500 dark:text-gray-400 flex flex-wrap items-center gap-x-1.5 gap-y-1">
+    <div className="text-sm text-muted flex flex-wrap items-center gap-x-1.5 gap-y-1">
       <span>By</span>
       {authors.map((author, i) => {
         const profile = profiles.get(author);
@@ -72,7 +72,7 @@ export function AuthorBadges({ authors, contributors }: AuthorBadgesProps) {
         );
       })}
       {contributors.length > 0 && (
-        <span className="ml-1 text-gray-400 dark:text-gray-500">
+        <span className="ml-1 text-muted">
           + {contributors.length}{" "}
           {contributors.length === 1 ? "contributor" : "contributors"}
         </span>

--- a/src/components/ContributorBadge.tsx
+++ b/src/components/ContributorBadge.tsx
@@ -75,7 +75,7 @@ export function ContributorBadge({
 
   return (
     <span
-      className="inline-flex items-center gap-1 text-sm text-gray-700 dark:text-gray-300"
+      className="inline-flex items-center gap-1 text-sm text-muted"
       title={titleText}
     >
       <span

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { ThemeToggle } from "./ThemeToggle";
+
+const FOOTER_LINKS = [
+  { href: "/wiki", label: "Browse" },
+  { href: "/query", label: "Ask" },
+  { href: "/ingest", label: "Ingest" },
+  { href: "/wiki/contributors", label: "Contributors" },
+];
+
+/**
+ * Site footer — a quiet anchor at the bottom of every page. Width-aligned
+ * with the nav and homepage container.
+ */
+export function Footer() {
+  return (
+    <footer className="mt-16 border-t border-border">
+      <div className="mx-auto flex max-w-5xl flex-col gap-4 px-6 py-8 text-sm sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-1">
+          <span className="font-bold tracking-tight text-foreground">
+            yopedia
+          </span>
+          <span className="text-xs text-muted">
+            A shared second brain for humans and agents — growing in public.
+          </span>
+        </div>
+        <nav className="flex items-center gap-4">
+          {FOOTER_LINKS.map((l) => (
+            <Link
+              key={l.href}
+              href={l.href}
+              className="text-muted hover:text-foreground transition-colors"
+            >
+              {l.label}
+            </Link>
+          ))}
+          <ThemeToggle />
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1,9 +1,35 @@
 import Link from "next/link";
+import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { slugify } from "@/lib/slugify";
 
 interface MarkdownRendererProps {
   content: string;
+  /**
+   * Extra classes appended to the prose wrapper. Pass `"prose-article"` for
+   * the long-form serif reading treatment (see globals.css); omit for the
+   * neutral sans look used by query answers.
+   */
+  className?: string;
+}
+
+/** Flatten ReactMarkdown heading children to plain text for anchor IDs. */
+function headingText(children: ReactNode): string {
+  if (typeof children === "string") return children;
+  if (typeof children === "number") return String(children);
+  if (Array.isArray(children)) return children.map(headingText).join("");
+  if (
+    children &&
+    typeof children === "object" &&
+    "props" in children &&
+    (children as { props?: { children?: ReactNode } }).props
+  ) {
+    return headingText(
+      (children as { props: { children?: ReactNode } }).props.children,
+    );
+  }
+  return "";
 }
 
 /**
@@ -40,13 +66,30 @@ function resolveImageSrc(src: string): string {
   return src;
 }
 
-export function MarkdownRenderer({ content }: MarkdownRendererProps) {
+export function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
   const body = stripFrontmatter(content);
   return (
-    <div className="prose prose-neutral dark:prose-invert max-w-none">
+    <div
+      className={`prose prose-neutral dark:prose-invert max-w-none${
+        className ? ` ${className}` : ""
+      }`}
+    >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
+          // Stable heading IDs so an in-page Table of Contents can anchor to
+          // them (the typography plugin emits no ids). Slugs match the TOC's
+          // because both use the same `slugify`.
+          h2: ({ children, ...props }) => (
+            <h2 id={slugify(headingText(children))} {...props}>
+              {children}
+            </h2>
+          ),
+          h3: ({ children, ...props }) => (
+            <h3 id={slugify(headingText(children))} {...props}>
+              {children}
+            </h3>
+          ),
           img: ({ src, alt, ...props }) => {
             if (typeof src !== "string") return null;
             return (

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -12,6 +12,13 @@ interface MarkdownRendererProps {
    * neutral sans look used by query answers.
    */
   className?: string;
+  /**
+   * Pre-computed heading ids (h2/h3, document order) from the page's
+   * `buildToc`. Consumed in order so the in-page Table of Contents anchors
+   * match the rendered heading ids exactly — including dedupe suffixes. When
+   * omitted (e.g. query answers), ids fall back to slugifying the heading text.
+   */
+  headingIds?: string[];
 }
 
 /** Flatten ReactMarkdown heading children to plain text for anchor IDs. */
@@ -66,8 +73,22 @@ function resolveImageSrc(src: string): string {
   return src;
 }
 
-export function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
+export function MarkdownRenderer({
+  content,
+  className,
+  headingIds,
+}: MarkdownRendererProps) {
   const body = stripFrontmatter(content);
+  // Headings render in document order; pull the next pre-computed id (which
+  // already carries dedupe suffixes), falling back to slugifying the rendered
+  // text when no list was supplied or it runs short.
+  let headingIndex = 0;
+  const nextHeadingId = (children: ReactNode): string => {
+    if (headingIds && headingIndex < headingIds.length) {
+      return headingIds[headingIndex++];
+    }
+    return slugify(headingText(children));
+  };
   return (
     <div
       className={`prose prose-neutral dark:prose-invert max-w-none${
@@ -78,15 +99,15 @@ export function MarkdownRenderer({ content, className }: MarkdownRendererProps) 
         remarkPlugins={[remarkGfm]}
         components={{
           // Stable heading IDs so an in-page Table of Contents can anchor to
-          // them (the typography plugin emits no ids). Slugs match the TOC's
-          // because both use the same `slugify`.
+          // them (the typography plugin emits no ids). IDs come from the page's
+          // buildToc (via headingIds) so anchors and TOC links match exactly.
           h2: ({ children, ...props }) => (
-            <h2 id={slugify(headingText(children))} {...props}>
+            <h2 id={nextHeadingId(children)} {...props}>
               {children}
             </h2>
           ),
           h3: ({ children, ...props }) => (
-            <h3 id={slugify(headingText(children))} {...props}>
+            <h3 id={nextHeadingId(children)} {...props}>
               {children}
             </h3>
           ),

--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -86,7 +86,7 @@ export function NavHeader() {
   }, [moreOpen]);
 
   return (
-    <header className="sticky top-0 z-50 bg-background border-b border-foreground/10 shadow-sm">
+    <header className="sticky top-0 z-50 bg-background border-b border-border shadow-sm">
       <nav aria-label="Main navigation" className="mx-auto flex h-14 max-w-5xl items-center justify-between px-6">
         <Link
           href="/"
@@ -105,7 +105,7 @@ export function NavHeader() {
                   href={href}
                   className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
                     isActive
-                      ? "text-foreground font-semibold bg-foreground/10"
+                      ? "text-accent font-semibold bg-accent/10"
                       : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
                   }`}
                 >
@@ -124,7 +124,7 @@ export function NavHeader() {
               aria-haspopup="menu"
               className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
                 moreActive
-                  ? "text-foreground font-semibold bg-foreground/10"
+                  ? "text-accent font-semibold bg-accent/10"
                   : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
               }`}
             >
@@ -145,7 +145,7 @@ export function NavHeader() {
                       onClick={() => setMoreOpen(false)}
                       className={`block px-4 py-1.5 text-sm transition-colors ${
                         isActive
-                          ? "text-foreground font-semibold bg-foreground/10"
+                          ? "text-accent font-semibold bg-accent/10"
                           : "text-foreground/70 hover:text-foreground hover:bg-foreground/5"
                       }`}
                     >
@@ -173,7 +173,7 @@ export function NavHeader() {
                   href={href}
                   className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
                     isActive
-                      ? "text-foreground font-semibold bg-foreground/10"
+                      ? "text-accent font-semibold bg-accent/10"
                       : "text-foreground/40 hover:text-foreground hover:bg-foreground/5"
                   }`}
                   title={label}
@@ -219,7 +219,7 @@ export function NavHeader() {
                 </button>
               </SignInButton>
               <SignUpButton mode="modal">
-                <button className="rounded-md bg-foreground px-3 py-1.5 text-sm font-medium text-background hover:opacity-90 transition-opacity">
+                <button className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-colors">
                   Sign up
                 </button>
               </SignUpButton>
@@ -290,7 +290,7 @@ export function NavHeader() {
                 onClick={() => setMobileOpen(false)}
                 className={`block px-6 py-2 text-sm transition-colors ${
                   isActive
-                    ? "text-foreground font-semibold bg-foreground/10"
+                    ? "text-accent font-semibold bg-accent/10"
                     : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
                 }`}
               >
@@ -310,7 +310,7 @@ export function NavHeader() {
                 onClick={() => setMobileOpen(false)}
                 className={`block px-6 py-2 text-sm transition-colors ${
                   isActive
-                    ? "text-foreground font-semibold bg-foreground/10"
+                    ? "text-accent font-semibold bg-accent/10"
                     : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
                 }`}
               >
@@ -330,7 +330,7 @@ export function NavHeader() {
                 onClick={() => setMobileOpen(false)}
                 className={`block px-6 py-2 text-sm transition-colors ${
                   isActive
-                    ? "text-foreground font-semibold bg-foreground/10"
+                    ? "text-accent font-semibold bg-accent/10"
                     : "text-foreground/40 hover:text-foreground hover:bg-foreground/5"
                 }`}
               >
@@ -350,7 +350,7 @@ export function NavHeader() {
                 <button className="text-foreground/60 hover:text-foreground">Sign in</button>
               </SignInButton>
               <SignUpButton mode="modal">
-                <button className="font-medium text-foreground">Sign up</button>
+                <button className="font-medium text-accent">Sign up</button>
               </SignUpButton>
             </Show>
             <Show when="signed-in">

--- a/src/components/TagChip.tsx
+++ b/src/components/TagChip.tsx
@@ -13,7 +13,7 @@ export function TagChip({
   return (
     <Link
       href={href}
-      className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 transition-colors"
+      className="inline-flex items-center gap-1.5 rounded-full bg-surface px-3 py-1 text-sm text-muted hover:bg-surface-strong hover:text-foreground transition-colors"
     >
       <span>#{tag}</span>
       {count !== undefined && (

--- a/src/components/WikiPageCard.tsx
+++ b/src/components/WikiPageCard.tsx
@@ -24,9 +24,9 @@ export function WikiPageCard({ page, discussionCount }: WikiPageCardProps) {
     <li>
       <Link
         href={`/wiki/${page.slug}`}
-        className="group block rounded-lg border border-foreground/10 p-4 hover:border-foreground/30 transition-colors"
+        className="group block rounded-lg border border-border p-4 hover:border-accent/40 transition-colors"
       >
-        <span className="font-medium group-hover:underline">
+        <span className="font-medium group-hover:text-accent transition-colors">
           {page.title}
         </span>
         <span className="mt-1 block text-sm text-foreground/60">
@@ -37,7 +37,7 @@ export function WikiPageCard({ page, discussionCount }: WikiPageCardProps) {
             {pageTags.map((tag) => (
               <span
                 key={tag}
-                className="inline-block rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+                className="inline-block rounded-full bg-surface px-2 py-0.5 text-xs text-muted"
               >
                 {tag}
               </span>


### PR DESCRIPTION
A 10-yr-designer craft pass on the yopedia UI. Keeps the minimal soul but gives it an **editorial identity** and fixes the core reading experience. Direction was chosen with the owner: *editorial refresh · sans UI + serif reading body · indigo accent.*

## What changed

### Foundation — type & color
- **Fonts via `next/font` (self-hosted):** Inter (UI/headings), **Source Serif 4** (article body), **JetBrains Mono** (code). Today the app was bare `system-ui` everywhere, code included.
- **Semantic tokens + indigo accent.** Killed the two parallel color systems (`foreground/X` opacity *and* ad-hoc `gray-100/gray-800`) in favor of `surface / surface-strong / border / muted` + `accent / accent-hover / accent-foreground`, all light & dark. Focus ring → accent.

### Reading experience
- New `.prose-article` treatment: serif body, sans headings, accent links, mono code on a subtle surface, **~68ch measure** (images/code/tables stay full-width). Scoped so `/query` answers & slides keep the neutral sans look.
- `MarkdownRenderer` gains an optional `className` and emits stable `h2`/`h3` `id`s for anchoring.

### Article view restructure (`src/app/wiki/[slug]`) — the big win
- **Title-first.** The page title is promoted *above* the metadata (it used to sit below a dense 7-row metadata block). The leading H1 is stripped from the body so it isn't duplicated.
- Metadata split into a **slim byline** (author · date · sources · confidence · tags) and a demoted **"Page info"** panel (validity, aliases, supersedes).
- **Two-column on desktop:** reading column + sticky rail with a **Table of Contents** (generated from headings, hidden when <3) and Page info. Single column on mobile (Page info inline).

### Chrome
- Accent active-nav + Sign-up button; accent homepage CTA + eyebrow, larger hero.
- New site **Footer** on every page (there was none).
- Consistency sweep across TagChip / WikiPageCard / ContributorBadge / AuthorBadges / source-type & provenance pills (semantic status colors retained).

## Verification
- `pnpm lint` clean; **2281 tests pass**; `next build` clean.
- Live smoke test (prod server): fonts self-hosted (no Google CDN); article renders **title-first** with serif body; **TOC anchors match heading ids**; byline + Page info populate from frontmatter; query answers stay sans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)