### PR TITLE
yoyo: fix CJK mojibake in query Sources (encode X-Wiki-Sources header)

### DIFF
--- a/src/app/api/query/stream/route.ts
+++ b/src/app/api/query/stream/route.ts
@@ -113,7 +113,10 @@ export async function POST(request: NextRequest) {
 
     return result.toTextStreamResponse({
       headers: {
-        "X-Wiki-Sources": JSON.stringify(loadedSlugs),
+        // Percent-encode so non-ASCII slugs (e.g. CJK titles) survive the
+        // header transport, which is Latin-1 on the wire. The client decodes
+        // with decodeURIComponent before JSON.parse.
+        "X-Wiki-Sources": encodeURIComponent(JSON.stringify(loadedSlugs)),
       },
     });
   } catch (error) {

--- a/src/hooks/useStreamingQuery.ts
+++ b/src/hooks/useStreamingQuery.ts
@@ -110,12 +110,14 @@ export function useStreamingQuery(
           return;
         }
 
-        // Parse sources from the custom header
+        // Parse sources from the custom header. The server percent-encodes the
+        // JSON so non-ASCII slugs (e.g. CJK titles) survive the Latin-1 header
+        // transport; decode before parsing.
         const sourcesHeader = res.headers.get("X-Wiki-Sources");
         let sources: string[] = [];
         if (sourcesHeader) {
           try {
-            sources = JSON.parse(sourcesHeader) as string[];
+            sources = JSON.parse(decodeURIComponent(sourcesHeader)) as string[];
           } catch {
             // Malformed header — fall back to empty array
             sources = [];


### PR DESCRIPTION
## Problem

On `/query`, the **Sources** list rendered Chinese page slugs as mojibake — e.g. `openclaw-è ½å¹²ä» ä¹ -ä¸ ä¸ªé åº¦ç ¨æ ·ç` instead of the real Chinese. Chinese renders fine everywhere else (wiki titles), so it was specific to the query Sources path.

## Root cause

The source slugs are sent from `/api/query/stream` to the client in a **custom HTTP header** `X-Wiki-Sources` as raw `JSON.stringify(...)` UTF-8. HTTP header values are Latin-1 on the wire, so multibyte UTF-8 (CJK = 3 bytes/char) gets reinterpreted as Latin-1 → mojibake.

The streamed **answer body** was already correct (it uses `TextDecoder({ stream: true })`) — only the header was broken.

## Fix

Percent-encode the header on the server, decode on the client:
- `src/app/api/query/stream/route.ts`: `encodeURIComponent(JSON.stringify(loadedSlugs))`
- `src/hooks/useStreamingQuery.ts`: `JSON.parse(decodeURIComponent(sourcesHeader))`

`encodeURIComponent` yields ASCII-only output, so it transits the header cleanly and round-trips losslessly. Portable across the Workers runtime and the browser (no `Buffer`).

## Verification
- Round-trip with the real CJK slug → ASCII-only header, exact round-trip (`openclaw-全干货-习-三个维度统一框架-10-个实用例解`).
- `pnpm lint` clean; query test suites pass (126 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)