### PR TITLE
yoyo: redesign v2 — "the lab, running" (distinctive rebrand)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,53 +4,66 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  /* Warm paper + ink — a working lab notebook, not a white SaaS canvas. */
+  --background: #fafaf8;
+  --foreground: #1a1a17;
 
-  /* Neutral surfaces & borders — single source of truth for the muted
-     greys that were previously expressed ad-hoc as gray-100/gray-800 and
-     foreground/X opacity. */
-  --surface: #f5f5f4;
-  --surface-strong: #e7e5e4;
-  --border: #e5e5e5;
-  --muted: #6b6b6b;
+  /* Neutral surfaces & hairline rules. */
+  --surface: #f2f1ec;
+  --surface-strong: #e7e5de;
+  --border: #e2e0d8;
+  --rule: #e5e3db;
+  --muted: #6b6862;
 
-  /* Brand accent — indigo. Used for primary actions, links, active nav,
-     and focus rings. */
+  /* Primary accent — indigo (human / primary actions, links, focus). */
   --accent: #4f46e5;
   --accent-hover: #4338ca;
   --accent-foreground: #ffffff;
+
+  /* Signal accent — teal. Marks agent / system contributions, set apart
+     from human (indigo). Amber stays reserved for staleness / disputes. */
+  --agent: #0d9488;
+  --agent-foreground: #ffffff;
 }
 
 .dark {
-  --background: #0a0a0a;
+  --background: #0a0a0b;
   --foreground: #ededed;
 
-  --surface: #1c1c1c;
-  --surface-strong: #2a2a2a;
-  --border: #2a2a2a;
-  --muted: #a3a3a3;
+  --surface: #161618;
+  --surface-strong: #232325;
+  --border: #26262a;
+  --rule: #1f1f22;
+  --muted: #a1a1aa;
 
-  /* Brighter indigo + dark text so fills keep AA contrast on near-black. */
+  /* Brighter indigo + dark text so fills keep AA contrast on near-ink. */
   --accent: #818cf8;
   --accent-hover: #a5b4fc;
-  --accent-foreground: #0a0a0a;
+  --accent-foreground: #0a0a0b;
+
+  /* Brighter teal for agent marks on ink. */
+  --agent: #2dd4bf;
+  --agent-foreground: #0a0a0b;
 }
 
 /* Fallback for when JS hasn't loaded yet */
 @media (prefers-color-scheme: dark) {
   :root:not(.light) {
-    --background: #0a0a0a;
+    --background: #0a0a0b;
     --foreground: #ededed;
 
-    --surface: #1c1c1c;
-    --surface-strong: #2a2a2a;
-    --border: #2a2a2a;
-    --muted: #a3a3a3;
+    --surface: #161618;
+    --surface-strong: #232325;
+    --border: #26262a;
+    --rule: #1f1f22;
+    --muted: #a1a1aa;
 
     --accent: #818cf8;
     --accent-hover: #a5b4fc;
-    --accent-foreground: #0a0a0a;
+    --accent-foreground: #0a0a0b;
+
+    --agent: #2dd4bf;
+    --agent-foreground: #0a0a0b;
   }
 }
 
@@ -60,10 +73,13 @@
   --color-surface: var(--surface);
   --color-surface-strong: var(--surface-strong);
   --color-border: var(--border);
+  --color-rule: var(--rule);
   --color-muted: var(--muted);
   --color-accent: var(--accent);
   --color-accent-hover: var(--accent-hover);
   --color-accent-foreground: var(--accent-foreground);
+  --color-agent: var(--agent);
+  --color-agent-foreground: var(--agent-foreground);
 
   /* Fonts — wired to the next/font CSS variables set in layout.tsx, with
      graceful fallbacks before the web fonts load. */
@@ -165,4 +181,31 @@ textarea:focus-visible,
 }
 .prose-article > :is(img, figure, pre, table, hr) {
   max-width: 100%;
+}
+
+/* ---------------------------------------------------------------------------
+   Lab-instrument signature: mono section labels + mono "receipts" (data).
+   "Data is mono, prose is not." Used across the homepage, trail, and page
+   provenance to read like a working instrument rather than a magazine.
+   --------------------------------------------------------------------------- */
+
+/* Small-caps mono section label, e.g. `// THE TRAIL`. */
+.label {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem; /* 11px */
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.label::before {
+  content: "// ";
+  color: var(--accent);
+}
+
+/* Receipts: counts, dates, confidence, slugs, source types, ids. */
+.receipt {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
 }

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,14 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="7" fill="#0a0a0b"/>
+  <g stroke="#d4d4d8" stroke-width="2" stroke-linecap="round" opacity="0.5">
+    <line x1="9" y1="13" x2="16" y2="9"/>
+    <line x1="16" y1="9" x2="24" y2="14"/>
+    <line x1="16" y1="9" x2="17" y2="23"/>
+    <line x1="9" y1="13" x2="17" y2="23"/>
+    <line x1="17" y1="23" x2="24" y2="14"/>
+  </g>
+  <circle cx="9" cy="13" r="2.4" fill="#e4e4e7"/>
+  <circle cx="24" cy="14" r="2.4" fill="#e4e4e7"/>
+  <circle cx="17" cy="23" r="2.4" fill="#e4e4e7"/>
+  <circle cx="16" cy="9" r="3.2" fill="#818cf8"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,10 +25,27 @@ const fontMono = JetBrains_Mono({
   display: "swap",
 });
 
+const SITE_DESCRIPTION =
+  "A second brain for humans and agents. Not RAG — it accumulates: sources become cited pages, contradictions reconcile, and lineage stays visible.";
+
 export const metadata: Metadata = {
-  title: "yopedia",
-  description:
-    "A shared second brain for humans and agents — ingest sources, query your wiki, and browse interlinked pages.",
+  metadataBase: new URL("https://yopedia.yuanhao-li.workers.dev"),
+  title: {
+    default: "yopedia — a second brain for humans and agents",
+    template: "%s · yopedia",
+  },
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    title: "yopedia — a second brain for humans and agents",
+    description: SITE_DESCRIPTION,
+    siteName: "yopedia",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "yopedia — a second brain for humans and agents",
+    description: SITE_DESCRIPTION,
+  },
 };
 
 const themeScript = `

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,82 @@
+import { ImageResponse } from "next/og";
+
+// Rendered at build time and served as a static asset (no Workers runtime
+// dependency on next/og). Update copy here, not in a committed PNG.
+export const dynamic = "force-static";
+
+export const alt =
+  "yopedia — a second brain for humans and agents. Not RAG — it accumulates.";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// The node-constellation mark, inline so the OG image is self-contained.
+const MARK = `<svg width="120" height="120" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#d4d4d8" stroke-width="1.4" stroke-linecap="round" opacity="0.5">
+    <line x1="5" y1="8" x2="12" y2="5"/><line x1="12" y1="5" x2="19" y2="10"/>
+    <line x1="12" y1="5" x2="13" y2="18"/><line x1="5" y1="8" x2="13" y2="18"/>
+    <line x1="13" y1="18" x2="19" y2="10"/>
+  </g>
+  <circle cx="5" cy="8" r="2" fill="#e4e4e7"/><circle cx="19" cy="10" r="2" fill="#e4e4e7"/>
+  <circle cx="13" cy="18" r="2" fill="#e4e4e7"/><circle cx="12" cy="5" r="2.7" fill="#818cf8"/>
+</svg>`;
+const MARK_URI = `data:image/svg+xml,${encodeURIComponent(MARK)}`;
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: "#0a0a0b",
+          color: "#ededed",
+          padding: "72px 80px",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
+          <img src={MARK_URI} width={84} height={84} alt="" />
+          <div style={{ fontSize: 44, fontWeight: 700, letterSpacing: -1 }}>
+            yopedia
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              fontSize: 64,
+              fontWeight: 700,
+              letterSpacing: -1.5,
+              lineHeight: 1.1,
+            }}
+          >
+            <span>A second brain for</span>
+            <span>humans and agents.</span>
+          </div>
+          <div style={{ fontSize: 30, color: "#a1a1aa", lineHeight: 1.3, maxWidth: 900 }}>
+            Not RAG — it accumulates. Sources become cited pages; provenance and
+            lineage stay visible.
+          </div>
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: 16, fontSize: 24 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <div style={{ width: 14, height: 14, borderRadius: 7, background: "#818cf8" }} />
+            <span style={{ color: "#d4d4d8" }}>humans</span>
+          </div>
+          <span style={{ color: "#52525b" }}>+</span>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <div style={{ width: 14, height: 14, borderRadius: 7, background: "#2dd4bf" }} />
+            <span style={{ color: "#d4d4d8" }}>agents</span>
+          </div>
+          <span style={{ marginLeft: "auto", color: "#71717a" }}>growing in public</span>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,33 +3,32 @@ import { StatusBadge } from "@/components/StatusBadge";
 import { OnboardingWizard } from "@/components/OnboardingWizard";
 import { WikiPageCard } from "@/components/WikiPageCard";
 import { ContributorBadge } from "@/components/ContributorBadge";
-import { GlobalSearch } from "@/components/GlobalSearch";
-import { StatCard } from "@/components/StatCard";
 import { TagChip } from "@/components/TagChip";
+import { HomeAsk } from "@/components/HomeAsk";
+import { HomeGraph } from "@/components/HomeGraph";
+import { Trail } from "@/components/Trail";
 import { listWikiPages, isAgentScopedType } from "@/lib/wiki";
 import { listContributors } from "@/lib/contributors";
+import { getTrail } from "@/lib/trail";
 
 export default async function Home() {
-  const [allPages, contributors] = await Promise.all([
+  const [allPages, contributors, trail] = await Promise.all([
     listWikiPages(),
     listContributors(),
+    getTrail(10),
   ]);
 
-  // Match the public /wiki "all" view: hide all agent-scoped pages (identity +
-  // knowledge) so the stats, recent grid, and topics reflect the human-facing
-  // commons rather than an agent's private workspace.
+  // Public commons only — agent-scoped pages stay out of the stats/feeds.
   const pages = allPages.filter((p) => !isAgentScopedType(p.type));
 
   const pageCount = pages.length;
   const sourceCount = pages.reduce((n, p) => n + (p.sourceCount ?? 0), 0);
   const contributorCount = contributors.length;
 
-  // Recently updated (the content centerpiece).
   const recent = [...pages]
     .sort((a, b) => (b.updated ?? "").localeCompare(a.updated ?? ""))
     .slice(0, 6);
 
-  // Top topics by tag frequency.
   const tagFreq = new Map<string, number>();
   for (const p of pages) {
     for (const t of p.tags ?? []) tagFreq.set(t, (tagFreq.get(t) ?? 0) + 1);
@@ -43,78 +42,88 @@ export default async function Home() {
 
   return (
     <div className="mx-auto max-w-5xl px-6 py-12">
-      {/* Hero */}
+      {/* Hero — value prop + the live Ask box (the star) */}
       <section className="max-w-3xl">
-        <p className="text-sm font-medium text-accent">
-          A wiki for the agent age.
-        </p>
-        <h1 className="mt-2 text-5xl sm:text-6xl font-bold tracking-tight">
-          yopedia
+        <p className="label">a wiki for the agent age</p>
+        <h1 className="mt-3 text-4xl sm:text-5xl font-bold tracking-tight leading-[1.1]">
+          A second brain for humans and agents.
         </h1>
-        <p className="mt-4 text-lg text-foreground/70 leading-relaxed">
-          A shared second brain for humans and agents. Not RAG — it{" "}
-          <span className="font-medium text-foreground">accumulates</span>: new
-          sources update pages, contradictions reconcile, and lineage stays on
-          the page.
+        <p className="mt-4 text-lg text-muted leading-relaxed">
+          Not RAG — it{" "}
+          <span className="font-medium text-foreground">accumulates</span>:
+          sources become cited pages, contradictions reconcile, and lineage
+          stays visible.
         </p>
-        <div className="mt-4">
-          <StatusBadge />
-        </div>
-
-        {/* Primary actions + search */}
-        <div className="mt-6 flex flex-wrap items-center gap-3">
-          <Link
-            href="/wiki"
-            className="rounded-lg bg-accent px-5 py-2.5 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-colors"
-          >
-            Browse the wiki
-          </Link>
-          <Link
-            href="/query"
-            className="rounded-lg border border-foreground/20 px-5 py-2.5 text-sm font-medium hover:bg-foreground/5 transition-colors"
-          >
-            Ask a question
-          </Link>
-          <Link
-            href="/ingest"
-            className="rounded-lg border border-foreground/20 px-5 py-2.5 text-sm font-medium hover:bg-foreground/5 transition-colors"
-          >
-            Ingest a source
-          </Link>
-          <div className="ml-auto hidden sm:block">
-            <GlobalSearch />
-          </div>
-        </div>
-
-        {/* Live stats — proof of life */}
-        {pageCount > 0 && (
-          <div className="mt-8 flex flex-wrap items-end gap-8 border-t border-foreground/10 pt-6">
-            <StatCard value={pageCount} label={pageCount === 1 ? "page" : "pages"} />
-            <StatCard value={sourceCount} label={sourceCount === 1 ? "source" : "sources"} />
-            <StatCard
-              value={contributorCount}
-              label={contributorCount === 1 ? "contributor" : "contributors"}
-            />
-            <span className="text-xs text-foreground/40">growing in public</span>
-          </div>
-        )}
       </section>
 
+      <div className="mt-6 max-w-3xl">
+        <HomeAsk />
+      </div>
+
+      {/* Receipts — proof of life, in mono */}
+      {pageCount > 0 && (
+        <div className="receipt mt-6 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-muted">
+          <span>
+            <span className="font-semibold text-foreground">{pageCount}</span>{" "}
+            {pageCount === 1 ? "page" : "pages"}
+          </span>
+          <span aria-hidden className="text-border">·</span>
+          <span>
+            <span className="font-semibold text-foreground">{sourceCount}</span>{" "}
+            {sourceCount === 1 ? "source" : "sources"}
+          </span>
+          <span aria-hidden className="text-border">·</span>
+          <span>
+            <span className="font-semibold text-foreground">{contributorCount}</span>{" "}
+            {contributorCount === 1 ? "contributor" : "contributors"}
+          </span>
+          <span className="ml-auto">
+            <StatusBadge />
+          </span>
+        </div>
+      )}
+
       {pageCount === 0 ? (
-        <div className="mt-10">
+        <div className="mt-12">
           <OnboardingWizard pageCount={0} />
         </div>
       ) : (
         <>
-          {/* Recently updated — the centerpiece */}
-          <section className="mt-14">
+          {/* The lab running: live trail + the substrate */}
+          <section className="mt-16 grid gap-10 lg:grid-cols-5">
+            <div className="lg:col-span-3">
+              <h2 className="label">the trail</h2>
+              <p className="mt-1 text-sm text-muted">
+                Every ingest and edit, humans and agents alike.
+              </p>
+              <div className="mt-4">
+                {trail.length > 0 ? (
+                  <Trail events={trail} />
+                ) : (
+                  <p className="text-sm text-muted">
+                    Nothing yet — ingest a source to start the trail.
+                  </p>
+                )}
+              </div>
+            </div>
+            <div className="lg:col-span-2">
+              <h2 className="label">the substrate</h2>
+              <p className="mt-1 text-sm text-muted">Pages, interlinked.</p>
+              <div className="mt-4">
+                <HomeGraph />
+              </div>
+            </div>
+          </section>
+
+          {/* Recently accumulated */}
+          <section className="mt-16">
             <div className="flex items-baseline justify-between">
-              <h2 className="text-xl font-semibold">Recently updated</h2>
+              <h2 className="label">recently accumulated</h2>
               <Link
                 href="/wiki"
-                className="text-sm text-foreground/60 hover:text-foreground transition-colors"
+                className="receipt text-xs text-muted hover:text-foreground transition-colors"
               >
-                Browse all →
+                browse all →
               </Link>
             </div>
             <ul className="mt-4 grid gap-3 sm:grid-cols-2">
@@ -124,10 +133,10 @@ export default async function Home() {
             </ul>
           </section>
 
-          {/* Browse by topic — hidden when sparse */}
+          {/* Browse by topic */}
           {topTags.length >= 3 && (
             <section className="mt-12">
-              <h2 className="text-xl font-semibold">Browse by topic</h2>
+              <h2 className="label">browse by topic</h2>
               <div className="mt-4 flex flex-wrap gap-2">
                 {topTags.map(({ tag, count }) => (
                   <TagChip
@@ -141,16 +150,16 @@ export default async function Home() {
             </section>
           )}
 
-          {/* Contributors — social proof, hidden when sparse */}
+          {/* Contributors (humans; agents shown distinctly in the trail) */}
           {contributorCount >= 2 && (
             <section className="mt-12">
               <div className="flex items-baseline justify-between">
-                <h2 className="text-xl font-semibold">Contributors</h2>
+                <h2 className="label">contributors</h2>
                 <Link
                   href="/wiki/contributors"
-                  className="text-sm text-foreground/60 hover:text-foreground transition-colors"
+                  className="receipt text-xs text-muted hover:text-foreground transition-colors"
                 >
-                  See all →
+                  see all →
                 </Link>
               </div>
               <div className="mt-4 flex flex-wrap gap-3">
@@ -166,11 +175,13 @@ export default async function Home() {
             </section>
           )}
 
-          {/* How it works — slim, replaces the old feature tiles */}
-          <section className="mt-14 border-t border-foreground/10 pt-6 text-sm text-foreground/60 leading-relaxed">
-            <span className="font-medium text-foreground/80">How it works:</span>{" "}
-            Ingest a source → it updates pages, preserves lineage, and reconciles
-            contradictions → Ask and get cited answers.
+          {/* How it works — slim */}
+          <section className="mt-16 border-t border-rule pt-6 text-sm text-muted leading-relaxed">
+            <span className="label align-middle">how it works</span>{" "}
+            <span className="ml-1">
+              Ingest a source → it updates pages, preserves lineage, and
+              reconciles contradictions → ask, and get cited answers.
+            </span>
           </section>
         </>
       )}

--- a/src/app/wiki/[slug]/page.tsx
+++ b/src/app/wiki/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { ReactNode } from "react";
 import { decodeSlug, slugify } from "@/lib/slugify";
 import { readWikiPageWithFrontmatter, findBacklinks, type Frontmatter } from "@/lib/wiki";
 import { parseSources } from "@/lib/sources";
@@ -8,7 +9,9 @@ import { DeletePageButton } from "@/components/DeletePageButton";
 import { ReingestButton } from "@/components/ReingestButton";
 import { ShareWithYoyoButton } from "@/components/ShareWithYoyoButton";
 import { getPrincipal } from "@/lib/auth";
-import { agentIdFor, DEFAULT_AGENT_NAME } from "@/lib/agents";
+import { agentIdFor, DEFAULT_AGENT_NAME, isAgentHandle } from "@/lib/agents";
+import { listRevisions } from "@/lib/revisions";
+import { AgentBadge } from "@/components/AgentBadge";
 import { RevisionHistory } from "@/components/RevisionHistory";
 import { DiscussionPanel } from "@/components/DiscussionPanel";
 import { AuthorBadges } from "@/components/AuthorBadges";
@@ -183,10 +186,14 @@ function SourceProvenance({
                   </span>
                 )}
 
-                {/* Triggered by */}
+                {/* Triggered by — agents marked distinctly */}
                 {entry.triggered_by && entry.triggered_by !== "system" && (
-                  <span className="text-foreground/40 text-xs">
-                    via {entry.triggered_by}
+                  <span className="receipt inline-flex items-center gap-1 text-foreground/40 text-xs">
+                    via{" "}
+                    {isAgentHandle(entry.triggered_by)
+                      ? entry.triggered_by.split("--").pop()
+                      : entry.triggered_by}
+                    {isAgentHandle(entry.triggered_by) && <AgentBadge />}
                   </span>
                 )}
               </div>
@@ -533,6 +540,134 @@ function stripLeadingH1(body: string): string {
   return body.replace(/^#\s+.+(?:\r?\n)?/m, "");
 }
 
+/** One labelled stop in the lineage strip. */
+function Stop({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <span className="inline-flex items-baseline gap-1.5 whitespace-nowrap">
+      <span className="text-[10px] uppercase tracking-wide text-muted">
+        {label}
+      </span>
+      <span className="font-medium text-foreground">{value}</span>
+    </span>
+  );
+}
+
+/**
+ * "How this page accumulated" — a compact mono lineage strip under the title:
+ * created → sources (typed, human/agent) → revisions → confidence → status.
+ * Makes the differentiator (accumulation with receipts) legible at a glance.
+ * Returns null when there's nothing to show.
+ */
+function LineageStrip({
+  frontmatter,
+  sources,
+  revisions,
+}: {
+  frontmatter: Frontmatter;
+  sources: SourceEntry[];
+  revisions: { author?: string; date: string }[];
+}) {
+  const created =
+    typeof frontmatter.created === "string" && frontmatter.created
+      ? frontmatter.created
+      : revisions.length > 0
+        ? revisions[revisions.length - 1].date
+        : null;
+
+  if (!created && sources.length === 0 && revisions.length === 0) return null;
+
+  const sourceTypes = [...new Set(sources.map((s) => s.type))];
+  const ingestedByAgent = sources.some((s) => isAgentHandle(s.triggered_by));
+  const lastEditor = revisions[0]?.author;
+  const lastByAgent = isAgentHandle(lastEditor);
+
+  const confidenceRaw = frontmatter.confidence;
+  const confidence =
+    typeof confidenceRaw === "number" && Number.isFinite(confidenceRaw)
+      ? confidenceRaw
+      : typeof confidenceRaw === "string" && /^-?\d+(\.\d+)?$/.test(confidenceRaw)
+        ? Number(confidenceRaw)
+        : null;
+
+  const disputed = frontmatter.disputed === true;
+  const superseded =
+    typeof frontmatter.supersedes === "string" &&
+    frontmatter.supersedes.length > 0;
+
+  const stops: ReactNode[] = [];
+  if (created) {
+    stops.push(<Stop key="c" label="created" value={formatDate(created)} />);
+  }
+  if (sources.length > 0) {
+    stops.push(
+      <Stop
+        key="s"
+        label="sources"
+        value={
+          <span className="inline-flex items-center gap-1.5">
+            {sources.length}
+            <span className="font-normal text-muted">
+              {sourceTypes.slice(0, 3).join(" · ")}
+            </span>
+            {ingestedByAgent && <AgentBadge />}
+          </span>
+        }
+      />,
+    );
+  }
+  if (revisions.length > 0) {
+    stops.push(
+      <Stop
+        key="r"
+        label="revisions"
+        value={
+          <span className="inline-flex items-center gap-1.5">
+            {revisions.length}
+            {lastEditor && !lastByAgent && (
+              <span className="font-normal text-muted">· last {lastEditor}</span>
+            )}
+            {lastByAgent && <AgentBadge />}
+          </span>
+        }
+      />,
+    );
+  }
+  if (confidence !== null) {
+    stops.push(
+      <Stop key="cf" label="confidence" value={confidence.toFixed(2)} />,
+    );
+  }
+  stops.push(
+    <Stop
+      key="st"
+      label="status"
+      value={
+        disputed ? (
+          <span className="text-amber-600 dark:text-amber-400">disputed</span>
+        ) : superseded ? (
+          "superseded"
+        ) : (
+          "current"
+        )
+      }
+    />,
+  );
+
+  return (
+    <section className="mt-5">
+      <h2 className="label">how this page accumulated</h2>
+      <div className="receipt mt-2 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs">
+        {stops.map((s, i) => (
+          <span key={i} className="flex items-center gap-3">
+            {i > 0 && <span aria-hidden className="text-border">→</span>}
+            {s}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export default async function WikiPageView({ params }: WikiPageProps) {
   const { slug: encodedSlug } = await params;
   const slug = decodeSlug(encodedSlug);
@@ -585,6 +720,11 @@ export default async function WikiPageView({ params }: WikiPageProps) {
     Array.isArray(page.frontmatter.sharedWith) &&
     (page.frontmatter.sharedWith as string[]).includes(myYoyoId);
 
+  const revisions = await listRevisions(slug);
+  const lineageSources = parseSources(
+    page.frontmatter.sources as string | string[] | undefined,
+  );
+
   const toc = buildToc(page.body);
   const articleBody = stripLeadingH1(page.body);
 
@@ -607,6 +747,11 @@ export default async function WikiPageView({ params }: WikiPageProps) {
             <PageByline
               frontmatter={page.frontmatter}
               discussionStats={discussStats}
+            />
+            <LineageStrip
+              frontmatter={page.frontmatter}
+              sources={lineageSources}
+              revisions={revisions}
             />
             <div className="mt-8">
               <MarkdownRenderer

--- a/src/components/AgentBadge.tsx
+++ b/src/components/AgentBadge.tsx
@@ -1,0 +1,21 @@
+/**
+ * A small teal chip marking an *agent* actor, set apart from human
+ * contributors (indigo). Makes "humans AND agents" legible without folding
+ * agents into the human contributor list.
+ */
+export function AgentBadge({ className }: { className?: string }) {
+  return (
+    <span
+      className={`receipt inline-flex items-center gap-1 rounded-full border border-agent/30 bg-agent/10 px-1.5 py-px text-[10px] font-medium text-agent ${
+        className ?? ""
+      }`}
+      title="Autonomous agent contribution"
+    >
+      <span
+        aria-hidden
+        className="inline-block h-1.5 w-1.5 rounded-full bg-agent"
+      />
+      agent
+    </span>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ThemeToggle } from "./ThemeToggle";
+import { LogoMark } from "./Logo";
 
 const FOOTER_LINKS = [
   { href: "/wiki", label: "Browse" },
@@ -17,11 +18,14 @@ export function Footer() {
     <footer className="mt-16 border-t border-border">
       <div className="mx-auto flex max-w-5xl flex-col gap-4 px-6 py-8 text-sm sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-col gap-1">
-          <span className="font-bold tracking-tight text-foreground">
-            yopedia
+          <span className="inline-flex items-center gap-2">
+            <LogoMark size={18} className="text-foreground" />
+            <span className="font-bold tracking-tight text-foreground">
+              yopedia
+            </span>
           </span>
           <span className="text-xs text-muted">
-            A shared second brain for humans and agents — growing in public.
+            A second brain for humans and agents — growing in public.
           </span>
         </div>
         <nav className="flex items-center gap-4">

--- a/src/components/HomeAsk.tsx
+++ b/src/components/HomeAsk.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useUser, SignInButton } from "@clerk/nextjs";
+import { useStreamingQuery } from "@/hooks/useStreamingQuery";
+import { QueryResultPanel } from "./QueryResultPanel";
+import { Alert } from "./Alert";
+
+const EXAMPLES = [
+  "What is harness engineering?",
+  "How is yopedia different from RAG?",
+  "What are the agentic harness patterns?",
+];
+
+/**
+ * The homepage hero interaction: ask the accumulated wiki a question and get a
+ * cited answer streamed in place. Querying is signed-in-only (the API 401s
+ * anonymous POSTs), so signed-out visitors see the box with example prompts and
+ * a "Sign in to ask" CTA — no LLM call until they're authenticated.
+ */
+export function HomeAsk() {
+  const { isSignedIn } = useUser();
+  const { question, setQuestion, result, streaming, error, submit, isProcessing } =
+    useStreamingQuery();
+
+  return (
+    <div>
+      <form onSubmit={isSignedIn ? submit : (e) => e.preventDefault()}>
+        <div className="rounded-xl border border-border bg-surface/40 focus-within:border-accent/50 transition-colors">
+          <textarea
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            placeholder="Ask the accumulated brain a question…"
+            rows={2}
+            disabled={!isSignedIn || isProcessing}
+            className="w-full resize-none bg-transparent px-4 py-3.5 text-base outline-none placeholder:text-muted disabled:opacity-70"
+          />
+          <div className="flex flex-wrap items-center justify-between gap-3 border-t border-rule px-3 py-2.5">
+            <div className="flex flex-wrap gap-1.5">
+              {EXAMPLES.map((q) => (
+                <button
+                  type="button"
+                  key={q}
+                  onClick={() => isSignedIn && setQuestion(q)}
+                  className="receipt rounded-full border border-border px-2.5 py-1 text-[11px] text-muted hover:border-accent/40 hover:text-foreground transition-colors"
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
+            {isSignedIn ? (
+              <button
+                type="submit"
+                disabled={isProcessing || !question.trim()}
+                className="shrink-0 rounded-lg bg-accent px-5 py-2 text-sm font-medium text-accent-foreground hover:bg-accent-hover disabled:opacity-50 transition-colors"
+              >
+                {isProcessing ? "Thinking…" : "Ask →"}
+              </button>
+            ) : (
+              <SignInButton mode="modal">
+                <button className="shrink-0 rounded-lg bg-accent px-5 py-2 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-colors">
+                  Sign in to ask
+                </button>
+              </SignInButton>
+            )}
+          </div>
+        </div>
+      </form>
+
+      {!isSignedIn && (
+        <p className="mt-2 text-xs text-muted">
+          Answers query the wiki live and cite their sources — sign in to ask.
+        </p>
+      )}
+
+      {error && (
+        <div className="mt-4">
+          <Alert variant="error">{error}</Alert>
+        </div>
+      )}
+
+      {result && (
+        <div className="mt-6">
+          <QueryResultPanel
+            result={result}
+            streaming={streaming}
+            question={question}
+            currentHistoryId={null}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/HomeGraph.tsx
+++ b/src/components/HomeGraph.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRef } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useGraphSimulation } from "@/hooks/useGraphSimulation";
+
+/**
+ * Ambient knowledge-graph visual for the homepage — "a second brain you can
+ * see." Reuses the full graph simulation (the content is small enough that the
+ * whole graph is the preview); clicking a node opens its page. Silently absent
+ * when there's nothing to show, so it never breaks the page.
+ */
+export function HomeGraph({ height = 340 }: { height?: number }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const router = useRouter();
+  const {
+    loading,
+    empty,
+    fetchError,
+    canvasBg,
+    handleMouseMove,
+    handleMouseLeave,
+    handleClick,
+  } = useGraphSimulation(canvasRef, router);
+
+  if (fetchError || empty) return null;
+
+  return (
+    <div className="relative overflow-hidden rounded-xl border border-border">
+      <canvas
+        ref={canvasRef}
+        onClick={handleClick}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+        className="block w-full"
+        style={{ height, backgroundColor: canvasBg }}
+        role="img"
+        aria-label="Knowledge graph of interlinked wiki pages. Visit the wiki index for a text list."
+        tabIndex={0}
+      >
+        Knowledge graph — see the wiki index for an accessible page listing.
+      </canvas>
+      <Link
+        href="/wiki/graph"
+        className="receipt absolute right-2 top-2 rounded border border-border bg-background/70 px-2 py-1 text-[11px] text-muted backdrop-blur hover:text-foreground transition-colors"
+      >
+        open graph →
+      </Link>
+      {loading && (
+        <div className="receipt pointer-events-none absolute inset-0 flex items-center justify-center text-xs text-muted">
+          mapping the substrate…
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,61 @@
+/**
+ * yopedia logomark — a small node-constellation glyph that ties the brand to
+ * the knowledge graph / substrate. Monoline edges in `currentColor`, nodes
+ * filled, with the hub node in the indigo accent. Crisp at 16px.
+ */
+
+interface LogoMarkProps {
+  className?: string;
+  /** Pixel size of the square glyph. */
+  size?: number;
+}
+
+export function LogoMark({ className, size = 24 }: LogoMarkProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+    >
+      {/* edges */}
+      <g stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" opacity={0.45}>
+        <line x1="5" y1="8" x2="12" y2="5" />
+        <line x1="12" y1="5" x2="19" y2="10" />
+        <line x1="12" y1="5" x2="13" y2="18" />
+        <line x1="5" y1="8" x2="13" y2="18" />
+        <line x1="13" y1="18" x2="19" y2="10" />
+      </g>
+      {/* nodes */}
+      <circle cx="5" cy="8" r="2" fill="currentColor" />
+      <circle cx="19" cy="10" r="2" fill="currentColor" />
+      <circle cx="13" cy="18" r="2" fill="currentColor" />
+      {/* hub */}
+      <circle cx="12" cy="5" r="2.7" fill="var(--accent)" />
+    </svg>
+  );
+}
+
+interface LogoProps {
+  className?: string;
+  /** Pixel size of the glyph (wordmark scales with text). */
+  size?: number;
+  /** Hide the "yopedia" wordmark, showing only the glyph. */
+  markOnly?: boolean;
+}
+
+/** Logomark + "yopedia" wordmark, for the nav and footer. */
+export function Logo({ className, size = 22, markOnly = false }: LogoProps) {
+  return (
+    <span className={`inline-flex items-center gap-2 ${className ?? ""}`}>
+      <LogoMark size={size} className="text-foreground" />
+      {!markOnly && (
+        <span className="text-lg font-bold tracking-tight text-foreground">
+          yopedia
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -12,6 +12,7 @@ import {
 } from "@clerk/nextjs";
 import { GlobalSearch } from "./GlobalSearch";
 import { ThemeToggle } from "./ThemeToggle";
+import { Logo } from "./Logo";
 import { isOwnerHandle } from "@/lib/owner";
 
 // Primary actions — shown to everyone, always in the bar.
@@ -88,11 +89,8 @@ export function NavHeader() {
   return (
     <header className="sticky top-0 z-50 bg-background border-b border-border shadow-sm">
       <nav aria-label="Main navigation" className="mx-auto flex h-14 max-w-5xl items-center justify-between px-6">
-        <Link
-          href="/"
-          className="text-lg font-bold text-foreground tracking-tight hover:opacity-90 transition-opacity"
-        >
-          yopedia
+        <Link href="/" className="hover:opacity-90 transition-opacity">
+          <Logo />
         </Link>
 
         {/* Desktop nav */}

--- a/src/components/Trail.tsx
+++ b/src/components/Trail.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import { formatRelativeTime } from "@/lib/format";
+import { AgentBadge } from "./AgentBadge";
+import type { TrailEvent } from "@/lib/trail";
+
+/** Short display name for an actor — agent ids collapse to their short name. */
+function actorName(actor: string, isAgent: boolean): string {
+  if (isAgent && actor.includes("--")) return actor.split("--").pop() || actor;
+  return actor;
+}
+
+/**
+ * The Trail — the lab's running log of recent ingests and edits, with humans
+ * (indigo) and agents (teal) marked distinctly. The "alive / receipts"
+ * centerpiece of the homepage.
+ */
+export function Trail({ events }: { events: TrailEvent[] }) {
+  if (events.length === 0) return null;
+  return (
+    <ul className="divide-y divide-rule border-t border-rule">
+      {events.map((e, i) => (
+        <li
+          key={`${e.slug}-${e.action}-${e.ts}-${i}`}
+          className="flex items-baseline gap-3 py-2"
+        >
+          <time
+            dateTime={e.when}
+            className="receipt w-20 shrink-0 text-xs text-muted"
+          >
+            {formatRelativeTime(e.when)}
+          </time>
+          <div className="min-w-0 text-sm leading-snug">
+            <span className="font-medium text-foreground">
+              {actorName(e.actor, e.isAgent)}
+            </span>
+            {e.isAgent && <AgentBadge className="ml-1.5 align-middle" />}
+            <span className="text-muted"> {e.action} </span>
+            {e.sourceType && (
+              <span className="receipt mr-1 rounded bg-surface px-1 py-px text-[10px] text-muted">
+                {e.sourceType}
+              </span>
+            )}
+            <Link
+              href={`/wiki/${e.slug}`}
+              className="text-accent hover:underline"
+            >
+              {e.title}
+            </Link>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -113,6 +113,22 @@ export function baseAgentId(): string {
 }
 
 /**
+ * True when an author/actor handle denotes an agent rather than a human.
+ * Agents appear as the composite id `<owner>--<name>` (e.g. `yuanhao--yoyo`)
+ * or, in some legacy attributions, as the bare agent name (`yoyo`). Used to
+ * mark agent contributions distinctly across the UI — never to fold agents
+ * into the human contributor list.
+ */
+export function isAgentHandle(handle: string | null | undefined): boolean {
+  if (!handle) return false;
+  return (
+    handle.includes("--") ||
+    handle === DEFAULT_AGENT_NAME ||
+    handle.endsWith(`--${DEFAULT_AGENT_NAME}`)
+  );
+}
+
+/**
  * Recover an agent's short name from its composite id — the inverse of
  * {@link agentIdFor} for the clean `/u/<owner>/a/<name>` URL form. The id is
  * `slugify(owner)--slugify(name)`, so stripping the unambiguous `slugify(owner)--`

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -1,0 +1,104 @@
+import { listWikiPages, readWikiPageWithFrontmatter, isAgentScopedType } from "./wiki";
+import { listRevisions } from "./revisions";
+import { parseSources } from "./sources";
+import { isAgentHandle } from "./agents";
+import type { SourceEntry } from "./types";
+
+/** A single event in the public activity trail — the lab's running log. */
+export interface TrailEvent {
+  /** Sort key: epoch ms. */
+  ts: number;
+  /** ISO date string for display. */
+  when: string;
+  /** Who acted — a human handle, an agent id, or "system". */
+  actor: string;
+  /** True when the actor is an autonomous agent (e.g. `yoyo`). */
+  isAgent: boolean;
+  /** What happened. */
+  action: "ingested" | "edited";
+  /** For ingests, the kind of source. */
+  sourceType?: SourceEntry["type"];
+  slug: string;
+  title: string;
+}
+
+// Bound the work: only scan the most-recently-updated public pages.
+const MAX_PAGES_SCANNED = 60;
+
+/**
+ * Build the activity trail by merging recent ingests (from each page's
+ * `sources[]` provenance) and edits (from revision metadata) into one
+ * time-sorted feed. Agent-scoped pages are excluded; agent *actors* are kept
+ * and flagged via {@link isAgentHandle} so the UI can mark them distinctly.
+ */
+export async function getTrail(limit = 12): Promise<TrailEvent[]> {
+  const pages = (await listWikiPages())
+    .filter((p) => !isAgentScopedType(p.type))
+    .sort((a, b) => (b.updated ?? "").localeCompare(a.updated ?? ""))
+    .slice(0, MAX_PAGES_SCANNED);
+
+  const events: TrailEvent[] = [];
+
+  for (const page of pages) {
+    // Ingests — structured provenance entries.
+    try {
+      const full = await readWikiPageWithFrontmatter(page.slug);
+      const sources = parseSources(
+        full?.frontmatter.sources as string | string[] | undefined,
+      );
+      for (const s of sources) {
+        const ts = Date.parse(s.fetched);
+        if (Number.isNaN(ts)) continue;
+        const actor = s.triggered_by || "system";
+        events.push({
+          ts,
+          when: s.fetched,
+          actor,
+          isAgent: isAgentHandle(actor),
+          action: "ingested",
+          sourceType: s.type,
+          slug: page.slug,
+          title: page.title,
+        });
+      }
+    } catch {
+      // Page unreadable — skip its ingests.
+    }
+
+    // Edits — attributed revisions.
+    try {
+      const revisions = await listRevisions(page.slug);
+      for (const r of revisions) {
+        if (!r.author) continue;
+        events.push({
+          ts: r.timestamp,
+          when: r.date,
+          actor: r.author,
+          isAgent: isAgentHandle(r.author),
+          action: "edited",
+          slug: page.slug,
+          title: page.title,
+        });
+      }
+    } catch {
+      // No revisions — skip.
+    }
+  }
+
+  events.sort((a, b) => b.ts - a.ts);
+
+  // Collapse near-duplicate events (same actor+action+page within ~2 min).
+  const deduped: TrailEvent[] = [];
+  for (const e of events) {
+    const dup = deduped.find(
+      (d) =>
+        d.slug === e.slug &&
+        d.actor === e.actor &&
+        d.action === e.action &&
+        Math.abs(d.ts - e.ts) < 120_000,
+    );
+    if (!dup) deduped.push(e);
+  }
+
+  return deduped.slice(0, limit);
+}

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -37,54 +37,61 @@ export async function getTrail(limit = 12): Promise<TrailEvent[]> {
     .sort((a, b) => (b.updated ?? "").localeCompare(a.updated ?? ""))
     .slice(0, MAX_PAGES_SCANNED);
 
-  const events: TrailEvent[] = [];
+  // Gather each page's events concurrently — the per-page work is independent,
+  // so this avoids serializing the (bounded) page-read + revision-list I/O.
+  const perPage = await Promise.all(
+    pages.map(async (page): Promise<TrailEvent[]> => {
+      const evs: TrailEvent[] = [];
 
-  for (const page of pages) {
-    // Ingests — structured provenance entries.
-    try {
-      const full = await readWikiPageWithFrontmatter(page.slug);
-      const sources = parseSources(
-        full?.frontmatter.sources as string | string[] | undefined,
-      );
-      for (const s of sources) {
-        const ts = Date.parse(s.fetched);
-        if (Number.isNaN(ts)) continue;
-        const actor = s.triggered_by || "system";
-        events.push({
-          ts,
-          when: s.fetched,
-          actor,
-          isAgent: isAgentHandle(actor),
-          action: "ingested",
-          sourceType: s.type,
-          slug: page.slug,
-          title: page.title,
-        });
+      // Ingests — structured provenance entries.
+      try {
+        const full = await readWikiPageWithFrontmatter(page.slug);
+        const sources = parseSources(
+          full?.frontmatter.sources as string | string[] | undefined,
+        );
+        for (const s of sources) {
+          const ts = Date.parse(s.fetched);
+          if (Number.isNaN(ts)) continue;
+          const actor = s.triggered_by || "system";
+          evs.push({
+            ts,
+            when: s.fetched,
+            actor,
+            isAgent: isAgentHandle(actor),
+            action: "ingested",
+            sourceType: s.type,
+            slug: page.slug,
+            title: page.title,
+          });
+        }
+      } catch {
+        // Page unreadable — skip its ingests.
       }
-    } catch {
-      // Page unreadable — skip its ingests.
-    }
 
-    // Edits — attributed revisions.
-    try {
-      const revisions = await listRevisions(page.slug);
-      for (const r of revisions) {
-        if (!r.author) continue;
-        events.push({
-          ts: r.timestamp,
-          when: r.date,
-          actor: r.author,
-          isAgent: isAgentHandle(r.author),
-          action: "edited",
-          slug: page.slug,
-          title: page.title,
-        });
+      // Edits — attributed revisions.
+      try {
+        const revisions = await listRevisions(page.slug);
+        for (const r of revisions) {
+          if (!r.author) continue;
+          evs.push({
+            ts: r.timestamp,
+            when: r.date,
+            actor: r.author,
+            isAgent: isAgentHandle(r.author),
+            action: "edited",
+            slug: page.slug,
+            title: page.title,
+          });
+        }
+      } catch {
+        // No revisions — skip.
       }
-    } catch {
-      // No revisions — skip.
-    }
-  }
 
+      return evs;
+    }),
+  );
+
+  const events = perPage.flat();
   events.sort((a, b) => b.ts - a.ts);
 
   // Collapse near-duplicate events (same actor+action+page within ~2 min).


### PR DESCRIPTION
The editorial refresh made yopedia *prettier* but read as a **magazine** — which `PRODUCT.md` lists as an explicit anti-reference. This redesign stops polishing and **makes the machine visible**: a public research lab with receipts. Direction chosen with the owner: **distinctive rebrand · ask-first homepage (signed-in-only query) · agents shown as distinct collaborators**.

## Identity — "field station / lab notebook"
- **Logomark** — a node-constellation glyph (`Logo.tsx`) in nav + footer, tied to the knowledge graph.
- **Favicon** (`icon.svg`) + **build-time static OG image** (`opengraph-image.tsx`, `force-static` to dodge the Workers runtime) + full OpenGraph/Twitter metadata — shared links finally sell the product.
- **Tokens** — warm paper / ink background, a **teal `--agent`** signal color (set apart from indigo = human), hairline `--rule`. Signature `.label` (mono `// SECTION`) and `.receipt` (mono tabular-nums) — *"data is mono, prose is not."*

## Homepage = the lab (ask-first, gated)
- **`HomeAsk`** — a real Ask box (`useStreamingQuery`). Signed-in → streams a cited answer in place; signed-out → example chips + **"Sign in to ask"**. Querying is signed-in-only (the middleware already 401s anonymous POSTs) → **zero anonymous LLM cost**.
- **`HomeGraph`** — the knowledge graph as an ambient hero visual (reuses the canvas sim), links to `/wiki/graph`.
- **The Trail** (`lib/trail.ts` + `Trail.tsx`) — a live feed of recent ingests + edits merged from `sources[]` and revisions, **humans and agents marked distinctly**.
- Mono "receipts" strip; section headers as `// labels`.

## Agents as distinct collaborators
- `isAgentHandle()` classifies agent actors; **`AgentBadge`** (teal) marks them in the trail, lineage strip, and page provenance — **never folded into the human Contributors list** (preserves #326).

## "How this page accumulated" (wiki page)
- **`LineageStrip`** — a compact mono timeline under the title: `created → sources (typed, human/agent) → revisions → confidence → status`. The accumulation differentiator, legible at a glance. Reuses `parseSources` + `listRevisions` + frontmatter; the title-first serif reading view is unchanged.

## Verification
- `pnpm lint` clean; **2311 tests pass**; `next build` clean (OG image prerendered static, `○ (Static)`).
- Live smoke: homepage `// labels`, ask-gate ("Sign in to ask", no anon LLM call), ambient graph, logomark, `icon.svg` (200), `opengraph-image` (200 image/png); wiki **lineage strip + agent badge** on a provenance page; CJK page — no regression.
- Nothing broken: `/query`, `/wiki/graph`, wiki page actions, contributors all intact.

Note: built on top of `main` (includes yoyo's in-flight YouTube module from #332/#334).

🤖 Generated with [Claude Code](https://claude.com/claude-code)