### PR TITLE
yoyo: tenant silos P0 — tenant-aware path helpers (groundwork)

### DIFF
--- a/src/lib/__tests__/tenant-paths.test.ts
+++ b/src/lib/__tests__/tenant-paths.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  wikiRelPath,
+  rawRelPath,
+  tenantWikiRelPath,
+  tenantRawRelPath,
+  validateTenant,
+  DEFAULT_TENANT,
+} from "../wiki";
+
+// Pin DATA_DIR and clear WIKI_DIR/RAW_DIR overrides so the relative-path math
+// is deterministic.
+const ENV_KEYS = ["DATA_DIR", "WIKI_DIR", "RAW_DIR"] as const;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  process.env.DATA_DIR = "/data";
+  delete process.env.WIKI_DIR;
+  delete process.env.RAW_DIR;
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("legacy path helpers are unchanged (behavior-preserving)", () => {
+  it("wikiRelPath / rawRelPath still resolve to the flat layout", () => {
+    expect(wikiRelPath("hello.md")).toBe("wiki/hello.md");
+    expect(wikiRelPath("index.md")).toBe("wiki/index.md");
+    expect(rawRelPath("hello.md")).toBe("raw/hello.md");
+  });
+});
+
+describe("tenant path helpers", () => {
+  it("DEFAULT_TENANT is 'system'", () => {
+    expect(DEFAULT_TENANT).toBe("system");
+  });
+
+  it("build storage-relative keys under tenants/<tenant>/…", () => {
+    expect(tenantWikiRelPath("yuanhao", "hello.md")).toBe(
+      "tenants/yuanhao/wiki/hello.md",
+    );
+    expect(tenantWikiRelPath("system", "index.md")).toBe(
+      "tenants/system/wiki/index.md",
+    );
+    expect(tenantRawRelPath("yuanhao", "hello.md")).toBe(
+      "tenants/yuanhao/raw/hello.md",
+    );
+  });
+
+  it("supports nested filenames (e.g. revisions)", () => {
+    expect(tenantWikiRelPath("alice", ".revisions/p/123.md")).toBe(
+      "tenants/alice/wiki/.revisions/p/123.md",
+    );
+  });
+});
+
+describe("validateTenant — traversal guard", () => {
+  it("accepts plausible handles", () => {
+    for (const t of ["yuanhao", "system", "yopedia", "a-b", "user123"]) {
+      expect(() => validateTenant(t)).not.toThrow();
+    }
+  });
+
+  it("rejects traversal / separators / empties", () => {
+    for (const bad of ["", "  ", "..", "../x", "a/b", "a\\b", "a\0b"]) {
+      expect(() => validateTenant(bad)).toThrow(/Invalid tenant/);
+    }
+  });
+
+  it("the tenant path helpers reject traversal", () => {
+    expect(() => tenantWikiRelPath("../escape", "x.md")).toThrow(/Invalid tenant/);
+    expect(() => tenantRawRelPath("a/b", "x.md")).toThrow(/Invalid tenant/);
+  });
+});

--- a/src/lib/__tests__/tenant-paths.test.ts
+++ b/src/lib/__tests__/tenant-paths.test.ts
@@ -66,8 +66,19 @@ describe("validateTenant — traversal guard", () => {
     }
   });
 
-  it("rejects traversal / separators / empties", () => {
-    for (const bad of ["", "  ", "..", "../x", "a/b", "a\\b", "a\0b"]) {
+  it("rejects traversal / separators / dots / whitespace / control chars", () => {
+    for (const bad of [
+      "",
+      "  ",
+      ".", // bare dot collapses the path segment under path.join
+      "..",
+      "../x",
+      "a/b",
+      "a\\b",
+      "a\0b",
+      "a b", // internal whitespace
+      "a\tb",
+    ]) {
       expect(() => validateTenant(bad)).toThrow(/Invalid tenant/);
     }
   });

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -17,3 +17,25 @@ export function getWikiDir(): string {
 export function getRawDir(): string {
   return process.env.RAW_DIR ?? `${getDataDir()}/raw`;
 }
+
+// ---------------------------------------------------------------------------
+// Per-tenant directories (tenant-silos groundwork — see yopedia-concept.md).
+// Every tenant's content will live under `tenants/<tenant>/…`. These helpers
+// are additive: nothing reads/writes these paths yet (later phases do). The
+// tenant is the owner handle.
+// ---------------------------------------------------------------------------
+
+/** Root holding every tenant silo: `<dataDir>/tenants`. */
+export function getTenantsDir(): string {
+  return `${getDataDir()}/tenants`;
+}
+
+/** A tenant's wiki directory: `<dataDir>/tenants/<tenant>/wiki`. */
+export function getTenantWikiDir(tenant: string): string {
+  return `${getTenantsDir()}/${tenant}/wiki`;
+}
+
+/** A tenant's raw-sources directory: `<dataDir>/tenants/<tenant>/raw`. */
+export function getTenantRawDir(tenant: string): string {
+  return `${getTenantsDir()}/${tenant}/raw`;
+}

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -10,6 +10,7 @@ import {
   getRawDir as _getRawDir,
   getDataDir,
 } from "./config";
+import { getTenantWikiDir, getTenantRawDir } from "./paths";
 
 // ---------------------------------------------------------------------------
 // Configurable base directories — delegated to the config layer
@@ -57,6 +58,54 @@ export function isAgentScopedType(type: string | undefined): boolean {
  */
 export function rawRelPath(filename: string): string {
   return path.relative(getDataDir(), path.join(getRawDir(), filename));
+}
+
+// ---------------------------------------------------------------------------
+// Per-tenant path helpers (tenant-silos groundwork — see yopedia-concept.md).
+//
+// Additive and behavior-preserving: the legacy `wikiRelPath`/`rawRelPath`
+// above are unchanged, and nothing yet routes through these. Later phases
+// thread a `tenant` (the owner handle) through reads/writes and the migration
+// relocates existing content under `tenants/<tenant>/…`.
+// ---------------------------------------------------------------------------
+
+/** Catch-all tenant for ownerless / seed / system content. */
+export const DEFAULT_TENANT = "system";
+
+/**
+ * Guard a tenant name against path traversal before using it to build a key.
+ * Deliberately lighter than {@link validateSlug} (owner handles need not match
+ * the strict slug pattern) — it only blocks traversal and separators.
+ */
+export function validateTenant(tenant: string): void {
+  if (
+    typeof tenant !== "string" ||
+    tenant.trim().length === 0 ||
+    tenant.includes("\0") ||
+    tenant.includes("/") ||
+    tenant.includes("\\") ||
+    tenant.includes("..")
+  ) {
+    throw new Error(`Invalid tenant: ${JSON.stringify(tenant)}`);
+  }
+}
+
+/** Storage-relative path for a file in a tenant's wiki tree. */
+export function tenantWikiRelPath(tenant: string, filename: string): string {
+  validateTenant(tenant);
+  return path.relative(
+    getDataDir(),
+    path.join(getTenantWikiDir(tenant), filename),
+  );
+}
+
+/** Storage-relative path for a file in a tenant's raw-sources tree. */
+export function tenantRawRelPath(tenant: string, filename: string): string {
+  validateTenant(tenant);
+  return path.relative(
+    getDataDir(),
+    path.join(getTenantRawDir(tenant), filename),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -80,15 +80,21 @@ export const DEFAULT_TENANT = "system";
 export function validateTenant(tenant: string): void {
   if (
     typeof tenant !== "string" ||
-    tenant.trim().length === 0 ||
-    tenant.includes("\0") ||
+    tenant.length === 0 ||
+    tenant === "." || // a bare dot collapses the segment under path.join
+    tenant.includes("..") ||
     tenant.includes("/") ||
     tenant.includes("\\") ||
-    tenant.includes("..")
+    // any whitespace or control char would make a malformed/ambiguous key
+    /[\s\x00-\x1f]/.test(tenant)
   ) {
     throw new Error(`Invalid tenant: ${JSON.stringify(tenant)}`);
   }
 }
+// NOTE (P1): tenant is case-sensitive here while owner checks are
+// case-insensitive (owner.ts). When P1 derives the tenant from a handle,
+// normalize (e.g. lowercase) at that boundary so one owner can't split across
+// "Alice"/"alice" silos.
 
 /** Storage-relative path for a file in a tenant's wiki tree. */
 export function tenantWikiRelPath(tenant: string, filename: string): string {

--- a/yopedia-concept.md
+++ b/yopedia-concept.md
@@ -74,7 +74,9 @@ Two separate ideas: **`owner`** (who's accountable) and **actor `authors`/`contr
 - **`authors` / `contributors[]`** — the acting identities only. The **user** when they
   ingest manually; **yoyo** when mediated. The owner is not double-listed.
 - **`sources[].triggered_by`** — always traces back to the triggering user.
-- **`visibility`** — `public` by default. (Private is future.)
+- **`visibility`** — `public` by default. `private` is **read-enforced, owner-only**
+  (live; `canReadPage` on every read path) and gated on a **paid plan** (billing +
+  toggle UI pending). See *Tenant model & privacy* below.
 
 | Case | `owner` | actor `authors` | `triggered_by` |
 |------|---------|-----------------|----------------|
@@ -85,11 +87,53 @@ Two separate ideas: **`owner`** (who's accountable) and **actor `authors`/`contr
 
 ## The personal lens (live)
 
-Everything is public. On top of the public commons, logged-in users get a soft
-**Mine \| All** *view filter* (like GitHub "Your repositories" vs "Explore") — **not**
-access control. "Mine" = pages where `owner == me` **or** I'm a contributor. Public
-profiles live at **`/u/<handle>`** and show a user's owned/contributed pages. Search
-and query accept an `owner:`/`mine` scope. Anyone (guests included) can still view All.
+On top of the public commons, logged-in users get a soft **Mine \| All** *view filter*
+(like GitHub "Your repositories" vs "Explore") over **public** content — "Mine" = pages
+where `owner == me` **or** I'm a contributor. Public profiles live at **`/u/<handle>`**
+and show a user's owned/contributed pages. Search and query accept an `owner:`/`mine`
+scope. Guests can still view All.
+
+Separately — and unlike the Mine\|All *view* filter — **`visibility: private` is real
+access control** now (live): a private page is readable by the **owner only** (for an
+agent-owned page `<user>--yoyo`, the human `<user>`), enforced on **every** read surface
+(`canReadPage`: list, page, raw, revisions, discuss, query/search/graph context, trail,
+profiles, export). Defaults stay public, so the commons is unchanged. See *Tenant model
+& privacy* below.
+
+---
+
+## Tenant model & privacy (decided direction — logical layer live, physical pending)
+
+The next foundation: move from one shared namespace to **per-tenant silos**.
+
+- **Per-tenant isolation.** Each user gets their own namespace (`tenants/<handle>/…`) —
+  strong *physical* isolation, per-tenant scoped query/graph, and clean data management
+  (export / delete / quota one tenant without scanning others). Slugs become
+  **per-tenant**, so two users never collide on a title (no more one-page-per-slug
+  commons forcing a single owner).
+- **Free → public, paid → private.** Content a **free** user creates is **public** and
+  joins the **collective public commons** — the shared knowledge base of *all* users. A
+  **paid** plan unlocks **private** pages, sealed in the owner's silo, owner-only.
+  *Private is the paywall; the public commons is the collective KB.*
+- **The commons survives.** It's the **union of everyone's public pages** — what the
+  public homepage, graph, and global query show. Private content never enters it.
+- **Two layers of defense.** `canReadPage` is the **logical** access check (live);
+  per-tenant folders add the **physical** layer (a missed check can't cross a prefix).
+  Defense in depth for the paid-private tier.
+- **All content lives in tenant folders;** the commons is a **derived view** (a
+  lightweight public-pages index for fast listing/graph), not a separate shared folder.
+- **Homes for shared things.** The canonical base `yopedia/yoyo` agent and the
+  seed/karpathy commons live in a **`system`/`yopedia` tenant**; per-user yoyos fork into
+  the user's own tenant.
+
+**"Growing in public" is about the *product*, not user data** — yoyo building the
+yopedia repo autonomously (commits, journal, issues). It is orthogonal to whether a
+user's *knowledge* is public or private.
+
+**Status.** The **logical** layer is **live** (read-enforcement above; setting private
+gated on `canSetPrivate` → Clerk `publicMetadata.plan`). **Pending:** the **physical**
+per-tenant folder layout + **migration** of existing content, the commons index,
+per-tenant ingest/slug scoping, **Clerk Billing** checkout, and the private toggle UI.
 
 ---
 
@@ -131,7 +175,8 @@ with yoyo as the first agent.
 - **Profiles (live).** A user profile lists the agents they own; an agent profile at
   **`/u/<handle>/a/<agent>`** shows its identity/learnings/social pages and cross-links
   back to its owner. *(A user-content ↔ agent-content graph is future.)*
-- **Today:** all agent content is **public-readable** (private is future).
+- **Today:** agent content is **public by default** (joins the commons); a paid owner
+  can mark it **private** (owner-only, read-enforced) — see *Tenant model & privacy*.
 
 *Built so far:* the `AgentProfile` registry, `agent:<id>` scoped search, the
 agent-context endpoint, agent **`owner`** + owner-only mutation, the nested
@@ -150,7 +195,7 @@ Every page is markdown with frontmatter. The fields actually used today:
 
 ```yaml
 owner: alice                 # accountable principal (from the session)
-visibility: public           # public | private (private = future)
+visibility: public           # public | private — private is read-enforced (owner-only), paid
 authors: [yoyo]              # acting identities only
 contributors: [yoyo]
 sources: [{ type, url, fetched, triggered_by }]
@@ -171,8 +216,10 @@ where this differs.
 
 ## Roadmap (future)
 
-- **Private content + billing.** `visibility: private` gated on a paid plan (Clerk
-  billing); read/search enforcement so private pages never leak.
+- **Per-tenant silos + private billing.** See *Tenant model & privacy*. Read/search
+  enforcement so private pages never leak is **done** (`canReadPage`, live); **pending**
+  = the per-tenant folder layout + content migration, the commons index, per-tenant
+  ingest/slug scoping, Clerk Billing checkout, and the private toggle UI.
 - **Service / scheduled tokens.** A non-human write credential so yoyo (and scheduled
   jobs) can write without a human session — unblocks the base-yoyo seed and the
   **`@yoyoevolve` X-mention loop** (tweet a URL → yoyo ingests *for you*, only if your


### PR DESCRIPTION
**Phase 0** of the per-tenant silos re-architecture (full plan in `yopedia-concept.md` → *Tenant model & privacy*). This is the deliberately tiny, **behavior-preserving** foundation that later phases build on — no storage change, no call site rewired.

## What's here
- **`paths.ts`** — `getTenantsDir` / `getTenantWikiDir(tenant)` / `getTenantRawDir(tenant)` → `tenants/<tenant>/{wiki,raw}`.
- **`wiki.ts`** — `DEFAULT_TENANT = "system"`; `validateTenant` (a traversal guard, intentionally lighter than `validateSlug` since owner handles needn't be strict slugs); `tenantWikiRelPath` / `tenantRawRelPath`. **The legacy `wikiRelPath` / `rawRelPath` are unchanged**, and nothing routes through the new helpers yet.
- **`yopedia-concept.md`** — documents the decided direction: per-tenant silos, free → public collective commons, paid → private silo, and "growing in public" = the *product/repo* built by yoyo (not user data). Also corrects now-stale "private is future" notes (read-enforcement shipped in #341).

## Why so small
The migration is risky, so the storage layer is parameterized first as a no-op shim. Subsequent PRs: **P1** migration + per-tenant indexes + commons index (dual-read), **P2** owner-qualified URLs + link/graph model, **P3** commons-vs-silo UI split, **P4** private-by-default-for-paid + billing, **P5** per-tenant ops.

## Verification
- New `tenant-paths.test.ts`: legacy helpers still resolve to the flat layout (`wiki/x.md`); tenant helpers produce `tenants/<tenant>/…`; `validateTenant` rejects traversal.
- **Zero regression**: full suite green (2355), lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)