### PR TITLE
yoyo: tenant silos P1a — commons index machinery (behavior-preserving)

### DIFF
--- a/src/lib/__tests__/commons.test.ts
+++ b/src/lib/__tests__/commons.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  belongsInCommons,
+  getCommonsIndex,
+  upsertCommonsEntry,
+  syncCommonsForPage,
+  removeCommonsEntryBySlug,
+  rebuildCommonsIndex,
+} from "../commons";
+import { ensureDirectories, writeWikiPage } from "../wiki";
+import { _resetStorage } from "../storage";
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "commons-test-"));
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetStorage();
+});
+
+afterEach(async () => {
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("belongsInCommons", () => {
+  it("public non-agent pages belong; private + agent-scoped do not", () => {
+    expect(belongsInCommons({})).toBe(true);
+    expect(belongsInCommons({ visibility: "public" })).toBe(true);
+    expect(belongsInCommons({ visibility: "private" })).toBe(false);
+    expect(belongsInCommons({ type: "agent-knowledge" })).toBe(false);
+    expect(belongsInCommons({ type: "agent-identity" })).toBe(false);
+    expect(belongsInCommons({ type: "wiki" })).toBe(true);
+  });
+});
+
+describe("syncCommonsForPage", () => {
+  it("adds a public page keyed by its owner tenant", async () => {
+    await syncCommonsForPage("p", {
+      owner: "alice",
+      visibility: "public",
+      title: "P",
+      summary: "s",
+    });
+    const idx = await getCommonsIndex();
+    expect(idx).toHaveLength(1);
+    expect(idx[0]).toMatchObject({ tenant: "alice", slug: "p", title: "P" });
+  });
+
+  it("ownerless pages land in the system tenant", async () => {
+    await syncCommonsForPage("o", { title: "O", summary: "" });
+    const idx = await getCommonsIndex();
+    expect(idx[0]).toMatchObject({ tenant: "system", slug: "o" });
+  });
+
+  it("private pages are excluded (and removed if previously public)", async () => {
+    await syncCommonsForPage("x", { owner: "alice", visibility: "public", title: "X", summary: "" });
+    expect(await getCommonsIndex()).toHaveLength(1);
+    await syncCommonsForPage("x", { owner: "alice", visibility: "private", title: "X", summary: "" });
+    expect(await getCommonsIndex()).toHaveLength(0);
+  });
+
+  it("upsert updates in place (no duplicate)", async () => {
+    await syncCommonsForPage("p", { owner: "alice", title: "P", summary: "a" });
+    await syncCommonsForPage("p", { owner: "alice", title: "P2", summary: "b" });
+    const idx = await getCommonsIndex();
+    expect(idx).toHaveLength(1);
+    expect(idx[0].title).toBe("P2");
+  });
+});
+
+describe("entry keying is (tenant, slug)", () => {
+  it("the same slug under two tenants is two distinct rows", async () => {
+    await upsertCommonsEntry({ tenant: "alice", slug: "p", title: "A", summary: "" });
+    await upsertCommonsEntry({ tenant: "bob", slug: "p", title: "B", summary: "" });
+    const idx = await getCommonsIndex();
+    expect(idx).toHaveLength(2);
+    expect(idx.map((e) => e.tenant).sort()).toEqual(["alice", "bob"]);
+  });
+});
+
+describe("removeCommonsEntryBySlug", () => {
+  it("removes an entry regardless of which tenant owns it", async () => {
+    // caller doesn't know the tenant; the entry belongs to bob
+    await upsertCommonsEntry({ tenant: "bob", slug: "p", title: "P", summary: "" });
+    await removeCommonsEntryBySlug("p");
+    expect(await getCommonsIndex()).toHaveLength(0);
+    // no-op when absent
+    await removeCommonsEntryBySlug("nope");
+  });
+});
+
+describe("rebuildCommonsIndex", () => {
+  async function createPage(slug: string, frontmatter: string, title: string) {
+    await ensureDirectories();
+    await writeWikiPage(slug, `---\n${frontmatter}\n---\n\n# ${title}\n\nBody.`);
+    const indexPath = path.join(process.env.WIKI_DIR!, "index.md");
+    let existing = "";
+    try {
+      existing = await fs.readFile(indexPath, "utf-8");
+    } catch {
+      /* none */
+    }
+    const line = `- [${title}](${slug}.md) — ${title}`;
+    await fs.writeFile(
+      indexPath,
+      existing ? `${existing.trimEnd()}\n${line}\n` : `# Wiki Index\n\n${line}\n`,
+      "utf-8",
+    );
+  }
+
+  it("indexes public pages only (excludes private + agent)", async () => {
+    await createPage("pub", "owner: alice\nvisibility: public", "Public");
+    await createPage("priv", "owner: alice\nvisibility: private", "Private");
+    await createPage("ag", "owner: alice--yoyo\ntype: agent-knowledge", "Agent");
+
+    const count = await rebuildCommonsIndex();
+    const idx = await getCommonsIndex();
+    const slugs = idx.map((e) => e.slug).sort();
+    expect(count).toBe(1);
+    expect(slugs).toEqual(["pub"]);
+    expect(idx[0].tenant).toBe("alice");
+  });
+});

--- a/src/lib/commons.ts
+++ b/src/lib/commons.ts
@@ -1,0 +1,153 @@
+/**
+ * The public **commons** — a derived index of every PUBLIC page across all
+ * tenants (tenant-silos groundwork; see yopedia-concept.md). In the per-tenant
+ * model each page lives in its owner's silo and the commons is *not* separate
+ * storage but this persisted index over the public ones.
+ *
+ * Phase-1a: the index is *maintained* on the write/delete path but not yet read
+ * by any surface (reads still use the flat wiki index) — additive and
+ * behavior-preserving. A later phase switches the commons read surfaces over.
+ */
+
+import { getStorage } from "./storage";
+import { withFileLock } from "./lock";
+import { listWikiPages, isAgentScopedType, DEFAULT_TENANT } from "./wiki";
+
+/** KV/derived-index key (resolves to `_idx:commons` on R2, a JSON file on fs). */
+const COMMONS_KEY = "commons";
+/** Single global lock — commons writes are cross-tenant. */
+const COMMONS_LOCK = "commons-index";
+
+/** One public page in the commons, addressed by `(tenant, slug)`. */
+export interface CommonsEntry {
+  tenant: string;
+  slug: string;
+  title: string;
+  summary: string;
+  tags?: string[];
+  updated?: string;
+  sourceCount?: number;
+  confidence?: number;
+  type?: string;
+}
+
+/** A page belongs in the commons iff it's public and not agent-scoped. */
+export function belongsInCommons(meta: {
+  visibility?: string;
+  type?: string;
+}): boolean {
+  return meta.visibility !== "private" && !isAgentScopedType(meta.type);
+}
+
+/** Read the full commons index (empty array when absent). */
+export async function getCommonsIndex(): Promise<CommonsEntry[]> {
+  const idx = await getStorage().getIndex<CommonsEntry[]>(COMMONS_KEY);
+  return Array.isArray(idx) ? idx : [];
+}
+
+async function putCommonsIndex(entries: CommonsEntry[]): Promise<void> {
+  await getStorage().putIndex(COMMONS_KEY, entries);
+}
+
+/** Insert or update a commons entry, keyed by `(tenant, slug)`. */
+export async function upsertCommonsEntry(entry: CommonsEntry): Promise<void> {
+  await withFileLock(COMMONS_LOCK, async () => {
+    const entries = await getCommonsIndex();
+    const i = entries.findIndex(
+      (e) => e.tenant === entry.tenant && e.slug === entry.slug,
+    );
+    if (i === -1) entries.push(entry);
+    else entries[i] = entry;
+    await putCommonsIndex(entries);
+  });
+}
+
+/** Remove a commons entry (no-op if absent). */
+export async function removeCommonsEntry(
+  tenant: string,
+  slug: string,
+): Promise<void> {
+  await withFileLock(COMMONS_LOCK, async () => {
+    const entries = await getCommonsIndex();
+    const next = entries.filter(
+      (e) => !(e.tenant === tenant && e.slug === slug),
+    );
+    if (next.length !== entries.length) await putCommonsIndex(next);
+  });
+}
+
+/**
+ * Remove any commons entry for a slug regardless of tenant. Safe while slugs
+ * are globally unique (pre-migration); used by the delete path where the
+ * owner may not be readily available.
+ */
+export async function removeCommonsEntryBySlug(slug: string): Promise<void> {
+  await withFileLock(COMMONS_LOCK, async () => {
+    const entries = await getCommonsIndex();
+    const next = entries.filter((e) => e.slug !== slug);
+    if (next.length !== entries.length) await putCommonsIndex(next);
+  });
+}
+
+/**
+ * Sync one page into/out of the commons after a write. Fail-soft: a commons
+ * error must never break the underlying page write. `tenant` defaults to the
+ * page owner (or {@link DEFAULT_TENANT} when ownerless).
+ */
+export async function syncCommonsForPage(
+  slug: string,
+  meta: {
+    owner?: string;
+    visibility?: string;
+    type?: string;
+    title: string;
+    summary: string;
+    tags?: string[];
+    updated?: string;
+    sourceCount?: number;
+    confidence?: number;
+  },
+): Promise<void> {
+  const tenant = meta.owner?.trim() || DEFAULT_TENANT;
+  if (belongsInCommons(meta)) {
+    await upsertCommonsEntry({
+      tenant,
+      slug,
+      title: meta.title,
+      summary: meta.summary,
+      tags: meta.tags,
+      updated: meta.updated,
+      sourceCount: meta.sourceCount,
+      confidence: meta.confidence,
+      type: meta.type,
+    });
+  } else {
+    await removeCommonsEntry(tenant, slug);
+  }
+}
+
+/**
+ * Rebuild the entire commons index from the current (flat) wiki index. Used by
+ * the migration and as a repair tool. Scans every page, keeps the public,
+ * non-agent ones, and replaces the stored index in one write.
+ */
+export async function rebuildCommonsIndex(): Promise<number> {
+  const pages = await listWikiPages();
+  const entries: CommonsEntry[] = pages
+    .filter((p) => belongsInCommons(p))
+    .map((p) => ({
+      tenant: p.owner?.trim() || DEFAULT_TENANT,
+      slug: p.slug,
+      title: p.title,
+      summary: p.summary,
+      tags: p.tags,
+      updated: p.updated,
+      sourceCount: p.sourceCount,
+      confidence: p.confidence,
+      type: p.type,
+    }));
+  await withFileLock(COMMONS_LOCK, async () => {
+    await putCommonsIndex(entries);
+  });
+  return entries.length;
+}

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -19,6 +19,7 @@ import { escapeRegex } from "./links";
 import { getErrorMessage } from "./errors";
 import { removeAliasForPage, updateAliasIndexForPage } from "./alias-index";
 import { removeSourceForPage } from "./source-index";
+import { syncCommonsForPage, removeCommonsEntryBySlug } from "./commons";
 import { parseFrontmatter } from "./frontmatter";
 import type { LogOperation } from "./wiki";
 import { logger } from "./logger";
@@ -305,6 +306,50 @@ async function runPageLifecycleOp(
     }
     await updateIndexUnsafe(postIndexEntries);
   });
+
+  // 3b. Mirror into the commons index (tenant-silos groundwork). Maintained
+  //     alongside the flat index; not yet read by any surface. Fail-soft — a
+  //     commons error must never break the page write/delete.
+  try {
+    if (op.kind === "delete") {
+      await removeCommonsEntryBySlug(slug);
+    } else {
+      const fm = parseFrontmatter(op.content).data;
+      const str = (v: unknown) => (typeof v === "string" ? v : undefined);
+      const num = (v: unknown) =>
+        typeof v === "number" && Number.isFinite(v) ? v : undefined;
+      // source_count is persisted as a string (see ingest.ts).
+      const sc = fm.source_count;
+      const sourceCount =
+        typeof sc === "number"
+          ? sc
+          : typeof sc === "string" && /^\d+$/.test(sc.trim())
+            ? Number.parseInt(sc, 10)
+            : undefined;
+      // confidence may be a number or a numeric string (mirror listWikiPages).
+      const cf = fm.confidence;
+      const confidence =
+        num(cf) ??
+        (typeof cf === "string" && /^-?\d+(\.\d+)?$/.test(cf.trim())
+          ? Number.parseFloat(cf)
+          : undefined);
+      await syncCommonsForPage(slug, {
+        owner: str(fm.owner),
+        visibility: str(fm.visibility),
+        type: str(fm.type),
+        title: op.title,
+        summary: op.summary,
+        tags: Array.isArray(fm.tags)
+          ? (fm.tags as unknown[]).filter((t): t is string => typeof t === "string")
+          : undefined,
+        updated: str(fm.updated),
+        sourceCount,
+        confidence,
+      });
+    }
+  } catch (err) {
+    logger.warn("commons", `commons sync skipped for "${slug}":`, err);
+  }
 
   // 4. Cross-reference other pages.
   //    - write: discover related pages and add backlinks TO this slug.


### PR DESCRIPTION
**Phase 1a** of the per-tenant silos epic. Introduces the **commons index** — a derived index of every PUBLIC page across tenants — **maintained on the write/delete path but not yet read** by any surface. Additive and behavior-preserving (same pattern as P0).

## What's here
- **`src/lib/commons.ts`** — `CommonsEntry { tenant, slug, title, … }`; `belongsInCommons` (public && not agent-scoped); `getCommonsIndex` / `upsertCommonsEntry` / `removeCommonsEntry` / `removeCommonsEntryBySlug` (KV-backed via `getIndex/putIndex`, key `commons`, lock `commons-index`); `syncCommonsForPage` (upsert public / remove otherwise; `tenant = owner ?? "system"`); `rebuildCommonsIndex` (repair + migration tool).
- **`lifecycle.ts` step 3b** — fail-soft commons sync right after the flat-index update. A commons error can **never** break the page write/delete (the page is already on disk; steps 4–5 always run). String-tolerant `source_count`/`confidence` parse to stay coherent with `listWikiPages`.

## Why behavior-preserving
Nothing reads the commons index yet — the read surfaces still use the flat wiki index. This de-risks P1 by separating "build + maintain the commons" from "switch reads to it" (the P1b migration + read-switch).

## Reviewed
Code-reviewer verdict: solid, fail-soft, truly behavior-preserving. `(tenant, slug)` keying and cross-tenant `removeBySlug` pinned by tests. **P1b follow-up (flagged in code):** once slugs become per-tenant, the delete path must resolve the owner and use `removeCommonsEntry(tenant, slug)` instead of by-slug.

## Verification
- 8 new commons tests; full suite green (2374); lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)