### PR TITLE
yoyo: tenant silos P1b — copy migration + admin route (additive, reversible)

### DIFF
--- a/src/app/api/admin/migrate/route.ts
+++ b/src/app/api/admin/migrate/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getServicePrincipal, getPrincipal } from "@/lib/auth";
+import { isOwnerHandle } from "@/lib/owner";
+import { migrateToTenants } from "@/lib/migrate-to-tenants";
+import { getErrorMessage } from "@/lib/errors";
+import { logger } from "@/lib/logger";
+
+/**
+ * POST /api/admin/migrate
+ *
+ * Run (or dry-run) the per-tenant silo migration. Gated to the service token
+ * OR the site owner's session — everyone else gets 403 (the route is exempt
+ * from the blanket write-gate; it authenticates itself).
+ *
+ * Body: `{ "dry": boolean }`. Defaults to a DRY RUN — you must explicitly pass
+ * `{ "dry": false }` to perform the (additive, copy-only) live migration.
+ */
+export async function POST(req: Request) {
+  const service = getServicePrincipal(req);
+  const principal = service ?? (await getPrincipal());
+  if (!service && !isOwnerHandle(principal?.handle)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const body = (await req.json().catch(() => ({}))) as { dry?: unknown };
+    // Fail safe: anything other than an explicit `false` is a dry run.
+    const dryRun = body?.dry !== false;
+    logger.info(
+      "migrate",
+      `migration requested by ${principal?.handle ?? "service"} (dryRun=${dryRun})`,
+    );
+    const result = await migrateToTenants({ dryRun });
+    return NextResponse.json(result);
+  } catch (err) {
+    logger.error("migrate", "migration failed", err);
+    return NextResponse.json({ error: getErrorMessage(err) }, { status: 500 });
+  }
+}

--- a/src/lib/__tests__/migrate-to-tenants.test.ts
+++ b/src/lib/__tests__/migrate-to-tenants.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { migrateToTenants, getRedirectMap } from "../migrate-to-tenants";
+import { getCommonsIndex } from "../commons";
+import { ensureDirectories, writeWikiPage } from "../wiki";
+import { _resetStorage } from "../storage";
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-test-"));
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetStorage();
+});
+
+afterEach(async () => {
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function createPage(slug: string, frontmatter: string, title: string) {
+  await ensureDirectories();
+  await writeWikiPage(slug, `---\n${frontmatter}\n---\n\n# ${title}\n\nBody of ${title}.`);
+  const indexPath = path.join(process.env.WIKI_DIR!, "index.md");
+  let existing = "";
+  try {
+    existing = await fs.readFile(indexPath, "utf-8");
+  } catch {
+    /* none */
+  }
+  const line = `- [${title}](${slug}.md) — ${title}`;
+  await fs.writeFile(
+    indexPath,
+    existing ? `${existing.trimEnd()}\n${line}\n` : `# Wiki Index\n\n${line}\n`,
+    "utf-8",
+  );
+}
+
+const exists = async (rel: string) =>
+  fs.access(path.join(tmpDir, rel)).then(() => true).catch(() => false);
+
+async function seedThreePages() {
+  await createPage("pub", "owner: alice\nvisibility: public", "Public");
+  await createPage("priv", "owner: bob\nvisibility: private", "Private");
+  await createPage("seed", "# no owner here", "Seed"); // ownerless
+}
+
+describe("migrateToTenants — dry run", () => {
+  it("reports the plan without writing anything", async () => {
+    await seedThreePages();
+    const r = await migrateToTenants({ dryRun: true });
+
+    expect(r.dryRun).toBe(true);
+    expect(r.totalPages).toBe(3);
+    expect(r.tenants).toEqual({ alice: 1, bob: 1, system: 1 });
+    expect(r.redirectCount).toBe(3);
+    expect(r.artifactsCopied).toBe(0);
+    expect(r.errors).toEqual([]);
+
+    // Nothing written to tenant folders, no redirect map persisted.
+    expect(await exists("tenants/alice/wiki/pub.md")).toBe(false);
+    expect(await getRedirectMap()).toEqual([]);
+  });
+
+  it("dry run is the default (must opt in to write)", async () => {
+    await seedThreePages();
+    const r = await migrateToTenants();
+    expect(r.dryRun).toBe(true);
+    expect(await exists("tenants/alice/wiki/pub.md")).toBe(false);
+  });
+});
+
+describe("migrateToTenants — live", () => {
+  it("copies pages into tenant silos, builds per-tenant indexes + commons + redirect map", async () => {
+    await seedThreePages();
+    const r = await migrateToTenants({ dryRun: false });
+
+    expect(r.dryRun).toBe(false);
+    expect(r.totalPages).toBe(3);
+    expect(r.errors).toEqual([]);
+
+    // Pages copied into their owner's silo (ownerless → system).
+    expect(await exists("tenants/alice/wiki/pub.md")).toBe(true);
+    expect(await exists("tenants/bob/wiki/priv.md")).toBe(true);
+    expect(await exists("tenants/system/wiki/seed.md")).toBe(true);
+
+    // Flat originals are untouched (copy, not move).
+    expect(await exists("wiki/pub.md")).toBe(true);
+
+    // Per-tenant index.md written.
+    const aliceIndex = await fs.readFile(
+      path.join(tmpDir, "tenants/alice/wiki/index.md"),
+      "utf-8",
+    );
+    expect(aliceIndex).toContain("(pub.md)");
+
+    // Commons holds the public pages (pub + the ownerless seed); the private
+    // "priv" is excluded.
+    const commons = await getCommonsIndex();
+    expect(commons.map((e) => e.slug).sort()).toEqual(["pub", "seed"]);
+    expect(commons.find((e) => e.slug === "pub")?.tenant).toBe("alice");
+    expect(commons.find((e) => e.slug === "seed")?.tenant).toBe("system");
+
+    // Redirect map persisted, old → new.
+    const map = await getRedirectMap();
+    expect(map).toContainEqual({ from: "/wiki/pub", to: "/u/alice/pub" });
+    expect(map).toContainEqual({ from: "/wiki/seed", to: "/u/system/seed" });
+  });
+
+  it("is idempotent (re-running overwrites, same result)", async () => {
+    await seedThreePages();
+    await migrateToTenants({ dryRun: false });
+    const r2 = await migrateToTenants({ dryRun: false });
+    expect(r2.errors).toEqual([]);
+    expect(await exists("tenants/alice/wiki/pub.md")).toBe(true);
+  });
+
+  it("normalizes the tenant from the owner handle (case-insensitive)", async () => {
+    await createPage("p", "owner: Alice\nvisibility: public", "P");
+    const r = await migrateToTenants({ dryRun: false });
+    expect(r.tenants).toEqual({ alice: 1 });
+    expect(await exists("tenants/alice/wiki/p.md")).toBe(true);
+  });
+});

--- a/src/lib/__tests__/migrate-to-tenants.test.ts
+++ b/src/lib/__tests__/migrate-to-tenants.test.ts
@@ -4,8 +4,9 @@ import os from "os";
 import path from "path";
 import { migrateToTenants, getRedirectMap } from "../migrate-to-tenants";
 import { getCommonsIndex } from "../commons";
-import { ensureDirectories, writeWikiPage } from "../wiki";
-import { _resetStorage } from "../storage";
+import { ensureDirectories, writeWikiPage, rawRelPath } from "../wiki";
+import { createThread } from "../talk";
+import { getStorage, _resetStorage } from "../storage";
 
 let tmpDir: string;
 const saved: Record<string, string | undefined> = {};
@@ -130,5 +131,28 @@ describe("migrateToTenants — live", () => {
     const r = await migrateToTenants({ dryRun: false });
     expect(r.tenants).toEqual({ alice: 1 });
     expect(await exists("tenants/alice/wiki/p.md")).toBe(true);
+  });
+
+  it("copies every per-page artifact (revisions, discuss, assets) into the silo", async () => {
+    await createPage("doc", "owner: alice\nvisibility: public", "Doc");
+    // Second write snapshots the first as a revision.
+    await writeWikiPage("doc", "---\nowner: alice\nvisibility: public\n---\n\n# Doc\n\nv2.");
+    // A discussion thread + a binary asset.
+    await createThread("doc", "Re: Doc", "alice", "first comment");
+    await getStorage().writeAsset(
+      rawRelPath("assets/doc/img.png"),
+      new Uint8Array([1, 2, 3, 4]).buffer,
+    );
+
+    const r = await migrateToTenants({ dryRun: false });
+    expect(r.errors).toEqual([]);
+
+    // Revision snapshot, discuss thread, and asset all land in alice's silo.
+    const revs = await fs.readdir(
+      path.join(tmpDir, "tenants/alice/wiki/.revisions/doc"),
+    );
+    expect(revs.length).toBeGreaterThan(0);
+    expect(await exists("tenants/alice/discuss/doc.json")).toBe(true);
+    expect(await exists("tenants/alice/raw/assets/doc/img.png")).toBe(true);
   });
 });

--- a/src/lib/commons.ts
+++ b/src/lib/commons.ts
@@ -11,7 +11,7 @@
 
 import { getStorage } from "./storage";
 import { withFileLock } from "./lock";
-import { listWikiPages, isAgentScopedType, DEFAULT_TENANT } from "./wiki";
+import { listWikiPages, isAgentScopedType, tenantForOwner } from "./wiki";
 
 /** KV/derived-index key (resolves to `_idx:commons` on R2, a JSON file on fs). */
 const COMMONS_KEY = "commons";
@@ -108,7 +108,7 @@ export async function syncCommonsForPage(
     confidence?: number;
   },
 ): Promise<void> {
-  const tenant = meta.owner?.trim() || DEFAULT_TENANT;
+  const tenant = tenantForOwner(meta.owner);
   if (belongsInCommons(meta)) {
     await upsertCommonsEntry({
       tenant,
@@ -136,7 +136,7 @@ export async function rebuildCommonsIndex(): Promise<number> {
   const entries: CommonsEntry[] = pages
     .filter((p) => belongsInCommons(p))
     .map((p) => ({
-      tenant: p.owner?.trim() || DEFAULT_TENANT,
+      tenant: tenantForOwner(p.owner),
       slug: p.slug,
       title: p.title,
       summary: p.summary,

--- a/src/lib/migrate-to-tenants.ts
+++ b/src/lib/migrate-to-tenants.ts
@@ -1,0 +1,194 @@
+/**
+ * One-shot migration to per-tenant silos (tenant-silos P1b).
+ *
+ * COPIES every page's artifacts into `tenants/<tenant>/…` (it does NOT delete
+ * the flat originals), builds per-tenant `index.md` files + the commons index,
+ * and persists an old→new redirect map. Because it only copies, the existing
+ * flat read paths keep working unchanged — so running this is additive and
+ * reversible (delete the `tenants/` prefix to undo). A later sub-phase switches
+ * reads to the tenant/commons layout, then a cleanup removes the flat copies.
+ *
+ * Idempotent + resumable: re-running overwrites the same destinations. Run with
+ * `{ dryRun: true }` first to see the per-tenant plan + redirect map with no
+ * writes.
+ */
+
+import { getStorage } from "./storage";
+import { isEnoent } from "./errors";
+import { logger } from "./logger";
+import type { IndexEntry } from "./types";
+import {
+  listWikiPages,
+  wikiRelPath,
+  rawRelPath,
+  tenantWikiRelPath,
+  tenantRawRelPath,
+  tenantForOwner,
+} from "./wiki";
+import { rebuildCommonsIndex } from "./commons";
+
+/** The index + log are infrastructure, not pages — never migrated as pages. */
+const SKIP_SLUGS = new Set(["index", "log"]);
+const REDIRECT_MAP_KEY = "redirect-map";
+
+export interface RedirectEntry {
+  from: string;
+  to: string;
+}
+
+export interface MigrationResult {
+  dryRun: boolean;
+  totalPages: number;
+  /** pages per tenant */
+  tenants: Record<string, number>;
+  artifactsCopied: number;
+  commonsCount: number;
+  redirectCount: number;
+  errors: string[];
+}
+
+async function copyText(src: string, dst: string): Promise<boolean> {
+  const storage = getStorage();
+  let content: string;
+  try {
+    content = await storage.readFile(src);
+  } catch (e) {
+    if (isEnoent(e)) return false;
+    throw e;
+  }
+  await storage.writeFile(dst, content);
+  return true;
+}
+
+async function copyAsset(src: string, dst: string): Promise<boolean> {
+  const storage = getStorage();
+  let data: ArrayBuffer;
+  try {
+    data = await storage.readAsset(src);
+  } catch (e) {
+    if (isEnoent(e)) return false;
+    throw e;
+  }
+  await storage.writeAsset(dst, data);
+  return true;
+}
+
+async function listSafe(prefix: string) {
+  try {
+    return await getStorage().listFiles(prefix);
+  } catch (e) {
+    if (isEnoent(e)) return [];
+    throw e;
+  }
+}
+
+/** Copy every per-page artifact for one slug into its tenant. */
+async function copyPageArtifacts(slug: string, tenant: string): Promise<number> {
+  let n = 0;
+  // wiki page + raw source
+  if (await copyText(wikiRelPath(`${slug}.md`), tenantWikiRelPath(tenant, `${slug}.md`))) n++;
+  if (await copyText(rawRelPath(`${slug}.md`), tenantRawRelPath(tenant, `${slug}.md`))) n++;
+
+  // revision history: wiki/.revisions/<slug>/{<ts>.md,<ts>.meta.json}
+  for (const f of await listSafe(wikiRelPath(`.revisions/${slug}`))) {
+    if (f.isDirectory) continue;
+    if (
+      await copyText(
+        wikiRelPath(`.revisions/${slug}/${f.name}`),
+        tenantWikiRelPath(tenant, `.revisions/${slug}/${f.name}`),
+      )
+    )
+      n++;
+  }
+
+  // discussion threads: discuss/<slug>.json
+  if (await copyText(`discuss/${slug}.json`, `tenants/${tenant}/discuss/${slug}.json`)) n++;
+
+  // binary assets: raw/assets/<slug>/<file>
+  for (const f of await listSafe(rawRelPath(`assets/${slug}`))) {
+    if (f.isDirectory) continue;
+    if (
+      await copyAsset(
+        rawRelPath(`assets/${slug}/${f.name}`),
+        tenantRawRelPath(tenant, `assets/${slug}/${f.name}`),
+      )
+    )
+      n++;
+  }
+  return n;
+}
+
+/** Migrate (copy) all flat content into per-tenant silos. Dry-run by default. */
+export async function migrateToTenants(
+  opts: { dryRun?: boolean } = {},
+): Promise<MigrationResult> {
+  const dryRun = opts.dryRun ?? true;
+  const storage = getStorage();
+  const pages = (await listWikiPages()).filter((p) => !SKIP_SLUGS.has(p.slug));
+
+  const tenants: Record<string, number> = {};
+  const byTenant = new Map<string, IndexEntry[]>();
+  const redirectMap: RedirectEntry[] = [];
+  const errors: string[] = [];
+  let artifactsCopied = 0;
+
+  for (const page of pages) {
+    const tenant = tenantForOwner(page.owner);
+    tenants[tenant] = (tenants[tenant] ?? 0) + 1;
+    const list = byTenant.get(tenant) ?? [];
+    list.push(page);
+    byTenant.set(tenant, list);
+    redirectMap.push({ from: `/wiki/${page.slug}`, to: `/u/${tenant}/${page.slug}` });
+
+    if (dryRun) continue;
+    try {
+      artifactsCopied += await copyPageArtifacts(page.slug, tenant);
+    } catch (e) {
+      errors.push(`copy ${page.slug}: ${String(e)}`);
+      logger.warn("migrate", `copy failed for "${page.slug}"`, e);
+    }
+  }
+
+  let commonsCount = 0;
+  if (!dryRun) {
+    // Per-tenant index.md (same `- [Title](slug.md) — summary` format).
+    for (const [tenant, entries] of byTenant) {
+      const lines = entries.map(
+        (e) => `- [${e.title}](${e.slug}.md) — ${e.summary}`,
+      );
+      const content = `# Wiki Index\n\n${lines.join("\n")}\n`;
+      try {
+        await storage.writeFile(tenantWikiRelPath(tenant, "index.md"), content);
+      } catch (e) {
+        errors.push(`index ${tenant}: ${String(e)}`);
+      }
+    }
+    // Derived commons index + the old→new redirect map.
+    try {
+      commonsCount = await rebuildCommonsIndex();
+    } catch (e) {
+      errors.push(`commons: ${String(e)}`);
+    }
+    try {
+      await storage.putIndex(REDIRECT_MAP_KEY, redirectMap);
+    } catch (e) {
+      errors.push(`redirect-map: ${String(e)}`);
+    }
+  }
+
+  return {
+    dryRun,
+    totalPages: pages.length,
+    tenants,
+    artifactsCopied,
+    commonsCount,
+    redirectCount: redirectMap.length,
+    errors,
+  };
+}
+
+/** Read the persisted old→new redirect map (empty until a live migration runs). */
+export async function getRedirectMap(): Promise<RedirectEntry[]> {
+  const m = await getStorage().getIndex<RedirectEntry[]>(REDIRECT_MAP_KEY);
+  return Array.isArray(m) ? m : [];
+}

--- a/src/lib/migrate-to-tenants.ts
+++ b/src/lib/migrate-to-tenants.ts
@@ -11,6 +11,16 @@
  * Idempotent + resumable: re-running overwrites the same destinations. Run with
  * `{ dryRun: true }` first to see the per-tenant plan + redirect map with no
  * writes.
+ *
+ * READ-SWITCH PRECONDITIONS (the later phase that flips reads must honor these):
+ *  - Only switch when a live run returns `errors.length === 0`. On partial
+ *    failure a tenant's `index.md`/commons can list a page whose silo file
+ *    failed to copy — re-run until clean before switching.
+ *  - This only ADDS; a page deleted/renamed between runs leaves a stale orphan
+ *    file in the silo (absent from the rebuilt index, but directly reachable).
+ *    The read-switch should reconcile/clean orphans.
+ *  - Raw sources are assumed to be `<slug>.md` (always true today). If a
+ *    non-`.md` raw source ever exists, copy by stripped-extension match.
  */
 
 import { getStorage } from "./storage";

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -91,10 +91,18 @@ export function validateTenant(tenant: string): void {
     throw new Error(`Invalid tenant: ${JSON.stringify(tenant)}`);
   }
 }
-// NOTE (P1): tenant is case-sensitive here while owner checks are
-// case-insensitive (owner.ts). When P1 derives the tenant from a handle,
-// normalize (e.g. lowercase) at that boundary so one owner can't split across
-// "Alice"/"alice" silos.
+
+/**
+ * The canonical tenant for a page owner. Lowercased (owner checks are
+ * case-insensitive — see owner.ts — so one owner must not split across
+ * "Alice"/"alice" silos), falling back to {@link DEFAULT_TENANT} for
+ * ownerless/seed content. This is the SINGLE place tenant-from-owner is
+ * derived; commons and the migration both use it so they stay consistent.
+ */
+export function tenantForOwner(owner: string | undefined | null): string {
+  const t = typeof owner === "string" ? owner.trim().toLowerCase() : "";
+  return t.length > 0 ? t : DEFAULT_TENANT;
+}
 
 /** Storage-relative path for a file in a tenant's wiki tree. */
 export function tenantWikiRelPath(tenant: string, filename: string): string {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,6 +23,9 @@ const IN_ROUTE_AUTH_PATHS = new Set([
   "/api/agents/seed",
   "/api/ingest",
   "/api/ingest/x-mention",
+  // Admin migration: authenticated in-route by the service token OR the site
+  // owner's session (it rejects everyone else with 403).
+  "/api/admin/migrate",
 ]);
 const AGENT_INGEST_RE = /^\/api\/agents\/[^/]+\/ingest$/;
 


### PR DESCRIPTION
**Phase 1b.** Migration tooling that **COPIES** flat content into `tenants/<tenant>/…` — it does **not** delete originals, so flat reads keep working and it's fully reversible (drop the `tenants/` prefix to undo). Builds per-tenant `index.md` + the commons index and persists an old→new redirect map. Reads are **not** switched yet.

## What's here
- **`tenantForOwner(owner)`** (`wiki.ts`) — the single canonical tenant derivation, **lowercased** (fixes the P0 case-split note). `commons.ts` now uses it.
- **`migrate-to-tenants.ts`** — `migrateToTenants({dryRun})` (**dry-run by default**), `getRedirectMap()`. Copies per page: wiki md, raw md, revisions, discuss, binary assets (ENOENT-soft). Builds per-tenant indexes, `rebuildCommonsIndex()`, persists the redirect map. Idempotent/resumable.
- **`POST /api/admin/migrate`** — gated to the **service token OR the site owner**; `{dry}` defaults to a dry run (only literal `false` runs live). Added to the middleware in-route-auth set.

## Reviewed — "Run it. Safe, reversible, auth-gated, fail-safe, complete."
No blockers. The reviewer's Important items are all **read-switch preconditions** (now documented in code): switch only when `errors.length === 0`; reconcile orphans on delete/rename; the `<slug>.md` raw assumption. Added an artifact-completeness test (revision + discuss + asset land in the silo).

## How it's run (not automatic)
The live migration is a deliberate admin trigger. Plan: **dry-run against prod first** (`POST /api/admin/migrate {"dry":true}`) to validate the per-tenant plan + redirect map, then `{"dry":false}` to copy. Merging this PR changes nothing — it only adds the capability.

## Verification
6 migration tests (dry-run-writes-nothing, live copy, idempotency, ownerless→system, case-normalization, artifact-completeness) + commons tests; full suite green (2380); lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)