### PR TITLE
yopedia: tenant silos P3 — scoped query/graph + first-class silo views

### DIFF
--- a/src/app/api/query/stream/route.ts
+++ b/src/app/api/query/stream/route.ts
@@ -9,7 +9,7 @@ import {
   buildQuerySystemPrompt,
   type QueryFormat,
 } from "@/lib/query";
-import { resolveScope } from "@/lib/search";
+import { resolveScopeSlugs } from "@/lib/search";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 
@@ -51,27 +51,19 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Resolve scope to a set of slugs when provided
-    let scopeSlugs: string[] | undefined;
-    if (scope) {
-      const resolved = await resolveScope(scope);
-      if (!resolved) {
-        return NextResponse.json(
-          { error: `Invalid scope or agent not found: '${scope}'` },
-          { status: 400 },
-        );
-      }
-      scopeSlugs = resolved.slugs;
-      if (scopeSlugs.length === 0) {
-        return NextResponse.json(
-          { error: `No pages found for scope '${scope}'` },
-          { status: 400 },
-        );
-      }
-    }
-
     const trimmedQuestion = question.trim();
     const principal = await getPrincipal();
+
+    // Resolve scope to a set of slugs (handles the "mine" lens; empty "mine"
+    // falls back to the full commons).
+    const { scopeSlugs, error: scopeError } = await resolveScopeSlugs(
+      scope,
+      principal,
+    );
+    if (scopeError) {
+      return NextResponse.json({ error: scopeError }, { status: 400 });
+    }
+
     const entries = await listReadableWikiPages(principal);
 
     // Empty wiki — nothing to query

--- a/src/app/api/wiki/graph/route.ts
+++ b/src/app/api/wiki/graph/route.ts
@@ -1,7 +1,13 @@
-import { NextResponse } from "next/server";
-import { readWikiPageWithFrontmatter } from "@/lib/wiki";
+import { NextResponse, type NextRequest } from "next/server";
+import {
+  readWikiPageWithFrontmatter,
+  listReadableWikiPages,
+  isAgentScopedType,
+} from "@/lib/wiki";
 import { ownerToTenant } from "@/lib/links";
 import { listCommonsPages } from "@/lib/commons";
+import { expandMineScope, resolveScope } from "@/lib/search";
+import { getPrincipal } from "@/lib/auth";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 
@@ -19,10 +25,26 @@ interface GraphEdge {
   target: string;
 }
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
-    // The graph is the public commons graph (read from the commons index).
-    const pages = await listCommonsPages();
+    // Unscoped → the public commons graph. Scoped (`?scope=mine|owner:<h>`) →
+    // that silo's readable pages (incl. the viewer's own private pages). Unlike
+    // query, an empty "mine" shows an empty graph (your silo), not the commons.
+    const scopeParam =
+      new URL(req.url).searchParams.get("scope") || undefined;
+    const principal = await getPrincipal();
+    const expanded = expandMineScope(scopeParam, principal);
+
+    let pages;
+    if (expanded) {
+      const resolved = await resolveScope(expanded);
+      const scopeSet = new Set(resolved?.slugs ?? []);
+      pages = (await listReadableWikiPages(principal)).filter(
+        (p) => scopeSet.has(p.slug) && !isAgentScopedType(p.type),
+      );
+    } else {
+      pages = await listCommonsPages();
+    }
     const slugSet = new Set(pages.map((p) => p.slug));
 
     const nodes: GraphNode[] = [];

--- a/src/app/query/page.tsx
+++ b/src/app/query/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import Link from "next/link";
+import { useUser } from "@clerk/nextjs";
 import { Alert } from "@/components/Alert";
 import {
   QueryHistorySidebar,
@@ -39,11 +40,18 @@ export default function QueryPage() {
     [],
   );
 
+  // Mine|All lens — querying requires sign-in (API write gate), so signed-in
+  // users default to "mine" (their own pages). A `?scope=owner:<h>` deep-link
+  // (from a /u/<handle> silo) takes precedence and pins the query to that silo.
+  const { isLoaded, isSignedIn } = useUser();
+
   const {
     question,
     setQuestion,
     format,
     setFormat,
+    scope,
+    setScope,
     result,
     setResult,
     loading,
@@ -58,6 +66,25 @@ export default function QueryPage() {
     onComplete: saveToHistory,
     onSubmitStart: () => setCurrentHistoryId(null),
   });
+
+  // Set the initial scope once, on first Clerk load: a `?scope=` deep-link wins;
+  // otherwise signed-in users default to "mine". Reads location directly (not
+  // useSearchParams) to avoid a client-side-rendering bailout of the page.
+  const didInitScope = useRef(false);
+  useEffect(() => {
+    if (didInitScope.current || !isLoaded) return;
+    didInitScope.current = true;
+    const deepLink =
+      new URLSearchParams(window.location.search).get("scope") || undefined;
+    if (deepLink) setScope(deepLink);
+    else if (isSignedIn) setScope("mine");
+  }, [isLoaded, isSignedIn, setScope]);
+
+  // A deep-linked owner:<handle> scope renders as a dismissible chip; otherwise
+  // the Mine|All toggle drives `scope` ("mine" vs undefined=All).
+  const scopedHandle = scope?.startsWith("owner:")
+    ? scope.slice("owner:".length)
+    : null;
 
   // Fetch history on mount
   useEffect(() => {
@@ -109,6 +136,64 @@ export default function QueryPage() {
       <p className="mt-2 text-foreground/60">
         Ask a question and get a cited answer drawn from your wiki pages.
       </p>
+
+      {/* Scope lens — pinned silo (deep-link) renders as a chip; otherwise a
+          Mine|All toggle. "Mine" is shown only when signed in. */}
+      <div className="mt-4">
+        {scopedHandle ? (
+          <div className="inline-flex items-center gap-2 rounded-lg border border-foreground/10 bg-foreground/5 px-3 py-1.5 text-sm">
+            <span className="text-foreground/70">
+              Answering from{" "}
+              <Link
+                href={`/u/${scopedHandle}`}
+                className="font-medium text-foreground hover:underline"
+              >
+                @{scopedHandle}
+              </Link>
+              ’s pages
+            </span>
+            <button
+              type="button"
+              onClick={() => setScope(undefined)}
+              className="text-foreground/50 hover:text-foreground"
+              aria-label="Clear scope and search all content"
+            >
+              ✕
+            </button>
+          </div>
+        ) : (
+          <div
+            role="group"
+            aria-label="Query scope"
+            className="inline-flex items-center gap-1 rounded-lg border border-foreground/10 p-1"
+          >
+            {isSignedIn && (
+              <button
+                type="button"
+                onClick={() => setScope("mine")}
+                className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
+                  scope === "mine"
+                    ? "bg-foreground/10 font-semibold text-foreground"
+                    : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
+                }`}
+              >
+                Mine
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => setScope(undefined)}
+              className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
+                scope === undefined
+                  ? "bg-foreground/10 font-semibold text-foreground"
+                  : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
+              }`}
+            >
+              All
+            </button>
+          </div>
+        )}
+      </div>
 
       <div className="mt-8 flex flex-col lg:flex-row gap-8">
         {/* Main query area */}

--- a/src/app/u/[handle]/page.tsx
+++ b/src/app/u/[handle]/page.tsx
@@ -36,6 +36,24 @@ export default async function UserPage({
         <p className="mt-1 text-foreground/60">
           Public pages owned or contributed by {handle}.
         </p>
+
+        {/* Silo actions — query/graph scoped to this handle's pages. */}
+        {pages.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Link
+              href={`/query?scope=owner:${encodeURIComponent(handle)}`}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-foreground/10 px-3 py-1.5 text-sm text-foreground/70 hover:border-foreground/30 hover:text-foreground transition-colors"
+            >
+              💬 Ask these pages
+            </Link>
+            <Link
+              href={`/wiki/graph?scope=owner:${encodeURIComponent(handle)}`}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-foreground/10 px-3 py-1.5 text-sm text-foreground/70 hover:border-foreground/30 hover:text-foreground transition-colors"
+            >
+              🕸 Graph this silo
+            </Link>
+          </div>
+        )}
       </div>
 
       {agents.length > 0 && (

--- a/src/app/wiki/graph/page.tsx
+++ b/src/app/wiki/graph/page.tsx
@@ -1,12 +1,36 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState, useEffect } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
 import { useGraphSimulation } from "@/hooks/useGraphSimulation";
 
 export default function GraphPage() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const router = useRouter();
+
+  // Mine|All lens (consistent with /wiki and /query). A `?scope=owner:<h>`
+  // deep-link (from a /u/<handle> silo) pins the graph to that silo.
+  const { isLoaded, isSignedIn } = useUser();
+  const [scope, setScope] = useState<string | undefined>(undefined);
+
+  // Initial scope once, on first Clerk load: a `?scope=` deep-link wins, else
+  // signed-in users default to "mine". Reads location directly (not
+  // useSearchParams) to avoid a client-side-rendering bailout of the page.
+  const didInit = useRef(false);
+  useEffect(() => {
+    if (didInit.current || !isLoaded) return;
+    didInit.current = true;
+    const deepLink =
+      new URLSearchParams(window.location.search).get("scope") || undefined;
+    if (deepLink) setScope(deepLink);
+    else if (isSignedIn) setScope("mine");
+  }, [isLoaded, isSignedIn]);
+
+  const scopedHandle = scope?.startsWith("owner:")
+    ? scope.slice("owner:".length)
+    : null;
 
   const {
     loading,
@@ -16,64 +40,107 @@ export default function GraphPage() {
     handleMouseMove,
     handleMouseLeave,
     handleClick,
-  } = useGraphSimulation(canvasRef, router);
+  } = useGraphSimulation(canvasRef, router, scope);
 
-  if (loading) {
-    return (
-      <main className="mx-auto max-w-5xl px-6 py-12">
-        <h1 className="text-3xl font-bold tracking-tight mb-6">Wiki Graph</h1>
-        <p className="text-foreground/60">Loading graph…</p>
-      </main>
-    );
-  }
-
-  if (fetchError) {
-    return (
-      <main className="mx-auto max-w-5xl px-6 py-12">
-        <h1 className="text-3xl font-bold tracking-tight mb-6">Wiki Graph</h1>
-        <p className="text-red-500">
-          Failed to load graph data: {fetchError}
-        </p>
-      </main>
-    );
-  }
-
-  if (empty) {
-    return (
-      <main className="mx-auto max-w-5xl px-6 py-12">
-        <h1 className="text-3xl font-bold tracking-tight mb-6">Wiki Graph</h1>
-        <p className="text-foreground/60">
-          No wiki pages yet. Ingest some content to see the graph!
-        </p>
-      </main>
-    );
-  }
+  const lens = scopedHandle ? (
+    <div className="inline-flex items-center gap-2 rounded-lg border border-foreground/10 bg-foreground/5 px-3 py-1.5 text-sm">
+      <span className="text-foreground/70">
+        Graphing{" "}
+        <Link
+          href={`/u/${scopedHandle}`}
+          className="font-medium text-foreground hover:underline"
+        >
+          @{scopedHandle}
+        </Link>
+        ’s pages
+      </span>
+      <button
+        type="button"
+        onClick={() => setScope(undefined)}
+        className="text-foreground/50 hover:text-foreground"
+        aria-label="Clear scope and show the full commons graph"
+      >
+        ✕
+      </button>
+    </div>
+  ) : (
+    <div
+      role="group"
+      aria-label="Graph scope"
+      className="inline-flex items-center gap-1 rounded-lg border border-foreground/10 p-1"
+    >
+      {isSignedIn && (
+        <button
+          type="button"
+          onClick={() => setScope("mine")}
+          className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
+            scope === "mine"
+              ? "bg-foreground/10 font-semibold text-foreground"
+              : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
+          }`}
+        >
+          Mine
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={() => setScope(undefined)}
+        className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
+          scope === undefined
+            ? "bg-foreground/10 font-semibold text-foreground"
+            : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
+        }`}
+      >
+        All
+      </button>
+    </div>
+  );
 
   return (
     <main className="mx-auto max-w-5xl px-6 py-12">
-      <h1 className="text-3xl font-bold tracking-tight mb-6">Wiki Graph</h1>
-      <p className="text-sm text-foreground/60 mb-4">
-        Click a node to open the page.
-      </p>
-      <div className="w-full overflow-hidden rounded-lg border border-foreground/10">
-        <canvas
-          ref={canvasRef}
-          onClick={handleClick}
-          onMouseMove={handleMouseMove}
-          onMouseLeave={handleMouseLeave}
-          className="block w-full"
-          style={{ height: 560, backgroundColor: canvasBg }}
-          role="img"
-          aria-label="Wiki page relationship graph. Visit the wiki index for a text-based list of all pages."
-          tabIndex={0}
-        >
-          Wiki relationship graph — see wiki index for accessible page listing.
-        </canvas>
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-3xl font-bold tracking-tight">Wiki Graph</h1>
+        {lens}
       </div>
-      <p className="text-xs text-foreground/40 mt-2">
-        Node size reflects connection count. Colors indicate detected
-        communities.
-      </p>
+
+      {loading ? (
+        <p className="text-foreground/60">Loading graph…</p>
+      ) : fetchError ? (
+        <p className="text-red-500">Failed to load graph data: {fetchError}</p>
+      ) : empty ? (
+        <p className="text-foreground/60">
+          {scopedHandle
+            ? `No pages in @${scopedHandle}’s silo yet.`
+            : scope === "mine"
+              ? "You haven’t added any pages yet."
+              : "No wiki pages yet. Ingest some content to see the graph!"}
+        </p>
+      ) : (
+        <>
+          <p className="text-sm text-foreground/60 mb-4">
+            Click a node to open the page.
+          </p>
+          <div className="w-full overflow-hidden rounded-lg border border-foreground/10">
+            <canvas
+              ref={canvasRef}
+              onClick={handleClick}
+              onMouseMove={handleMouseMove}
+              onMouseLeave={handleMouseLeave}
+              className="block w-full"
+              style={{ height: 560, backgroundColor: canvasBg }}
+              role="img"
+              aria-label="Wiki page relationship graph. Visit the wiki index for a text-based list of all pages."
+              tabIndex={0}
+            >
+              Wiki relationship graph — see wiki index for accessible page listing.
+            </canvas>
+          </div>
+          <p className="text-xs text-foreground/40 mt-2">
+            Node size reflects connection count. Colors indicate detected
+            communities.
+          </p>
+        </>
+      )}
     </main>
   );
 }

--- a/src/hooks/useGraphSimulation.ts
+++ b/src/hooks/useGraphSimulation.ts
@@ -87,8 +87,11 @@ export function useGraphSimulation(
     }
   }, [canvasRef]);
 
-  // Fetch graph data (re-fetches when the scope lens changes)
+  // Fetch graph data (re-fetches when the scope lens changes). A `cancelled`
+  // guard drops a stale in-flight response when the scope toggles again, so an
+  // older request can't overwrite a newer one's data.
   useEffect(() => {
+    let cancelled = false;
     setLoading(true);
     setEmpty(false);
     setFetchError(null);
@@ -108,6 +111,7 @@ export function useGraphSimulation(
           }[];
           edges: GraphEdge[];
         }) => {
+          if (cancelled) return;
           if (!raw.nodes || raw.nodes.length === 0) {
             setEmpty(true);
             setLoading(false);
@@ -147,9 +151,13 @@ export function useGraphSimulation(
         },
       )
       .catch((err) => {
+        if (cancelled) return;
         setFetchError(String(err));
         setLoading(false);
       });
+    return () => {
+      cancelled = true;
+    };
   }, [scope]);
 
   // Detect color scheme and listen for changes

--- a/src/hooks/useGraphSimulation.ts
+++ b/src/hooks/useGraphSimulation.ts
@@ -29,6 +29,8 @@ export interface UseGraphSimulationReturn {
 export function useGraphSimulation(
   canvasRef: RefObject<HTMLCanvasElement | null>,
   router: AppRouterInstance,
+  /** Optional scope ("mine"/"owner:<h>") → fetches that silo's graph; undefined = commons. */
+  scope?: string,
 ): UseGraphSimulationReturn {
   const dataRef = useRef<GraphData | null>(null);
   const animRef = useRef<number>(0);
@@ -85,9 +87,12 @@ export function useGraphSimulation(
     }
   }, [canvasRef]);
 
-  // Fetch graph data
+  // Fetch graph data (re-fetches when the scope lens changes)
   useEffect(() => {
-    fetch("/api/wiki/graph")
+    setLoading(true);
+    setEmpty(false);
+    setFetchError(null);
+    fetch(`/api/wiki/graph${scope ? `?scope=${encodeURIComponent(scope)}` : ""}`)
       .then((r) => {
         if (!r.ok) throw new Error(`Graph API error: ${r.status}`);
         return r.json();
@@ -145,7 +150,7 @@ export function useGraphSimulation(
         setFetchError(String(err));
         setLoading(false);
       });
-  }, []);
+  }, [scope]);
 
   // Detect color scheme and listen for changes
   useEffect(() => {

--- a/src/hooks/useStreamingQuery.ts
+++ b/src/hooks/useStreamingQuery.ts
@@ -14,6 +14,9 @@ export interface UseStreamingQueryReturn {
   setQuestion: (q: string) => void;
   format: "prose" | "table" | "slides";
   setFormat: (f: "prose" | "table" | "slides") => void;
+  /** Active scope sent with each query ("mine", "owner:<h>", or undefined=All). */
+  scope: string | undefined;
+  setScope: (s: string | undefined) => void;
   result: QueryResponse | null;
   setResult: (r: QueryResponse | null) => void;
   loading: boolean;
@@ -29,6 +32,8 @@ export interface UseStreamingQueryReturn {
 interface UseStreamingQueryOptions {
   onComplete?: (question: string, answer: string, sources: string[]) => void;
   onSubmitStart?: () => void;
+  /** Initial query scope (e.g. "mine" when signed in, or a deep-linked owner:<h>). */
+  initialScope?: string;
 }
 
 export function useStreamingQuery(
@@ -36,6 +41,7 @@ export function useStreamingQuery(
 ): UseStreamingQueryReturn {
   const [question, setQuestion] = useState("");
   const [format, setFormat] = useState<"prose" | "table" | "slides">("prose");
+  const [scope, setScope] = useState<string | undefined>(options.initialScope);
   const [result, setResult] = useState<QueryResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [streaming, setStreaming] = useState(false);
@@ -79,7 +85,7 @@ export function useStreamingQuery(
         const res = await fetch("/api/query/stream", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ question: trimmed, format }),
+          body: JSON.stringify({ question: trimmed, format, scope }),
           signal: controller.signal,
         });
 
@@ -92,7 +98,7 @@ export function useStreamingQuery(
           const fallbackRes = await fetch("/api/query", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ question: trimmed, format }),
+            body: JSON.stringify({ question: trimmed, format, scope }),
             signal: controller.signal,
           });
 
@@ -167,7 +173,7 @@ export function useStreamingQuery(
         setStreaming(false);
       }
     },
-    [question, format],
+    [question, format, scope],
   );
 
   const isProcessing = loading || streaming;
@@ -177,6 +183,8 @@ export function useStreamingQuery(
     setQuestion,
     format,
     setFormat,
+    scope,
+    setScope,
     result,
     setResult,
     loading,

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -24,8 +24,11 @@ import {
   levenshteinDistance,
   fuzzySearchWikiContent,
   resolveScope,
+  expandMineScope,
+  resolveScopeSlugs,
 } from "../search";
 import type { SearchScope } from "../search";
+import type { Principal } from "../auth";
 import { registerAgent, ensureAgentsDir } from "../agents";
 import { serializeFrontmatter } from "../frontmatter";
 import { isAgentScopedType } from "../wiki";
@@ -844,5 +847,64 @@ describe("resolveScope", () => {
     expect(result).not.toBeNull();
     expect(result!.agentId).toBe("yoyo");
     expect(result!.slugs).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expandMineScope + resolveScopeSlugs — the Mine|All lens plumbing (P3)
+// ---------------------------------------------------------------------------
+
+describe("expandMineScope", () => {
+  const alice = { handle: "alice" } as Principal;
+
+  it("expands 'mine' to owner:<handle> for a signed-in principal", () => {
+    expect(expandMineScope("mine", alice)).toBe("owner:alice");
+  });
+
+  it("'mine' for a signed-out caller falls through to unscoped (undefined)", () => {
+    expect(expandMineScope("mine", null)).toBeUndefined();
+  });
+
+  it("passes other scopes through unchanged; empty/undefined → undefined", () => {
+    expect(expandMineScope("owner:bob", alice)).toBe("owner:bob");
+    expect(expandMineScope("agent:yoyo", null)).toBe("agent:yoyo");
+    expect(expandMineScope(undefined, alice)).toBeUndefined();
+    expect(expandMineScope("", alice)).toBeUndefined();
+  });
+});
+
+describe("resolveScopeSlugs", () => {
+  const alice = { handle: "alice" } as Principal;
+
+  it("no scope → unscoped (no slugs, no error)", async () => {
+    expect(await resolveScopeSlugs(undefined, alice)).toEqual({});
+  });
+
+  it("'mine' resolves to the principal's own pages", async () => {
+    await writeWikiPage(
+      "alice-pg",
+      serializeFrontmatter({ owner: "alice" }, "# A\n\nbody"),
+    );
+    await writeWikiPage("index", "# Index\n\n- [A](alice-pg.md) — body");
+    const r = await resolveScopeSlugs("mine", alice);
+    expect(r.error).toBeUndefined();
+    expect(r.scopeSlugs).toEqual(["alice-pg"]);
+  });
+
+  it("'mine' with NO own pages falls back to the commons (unscoped), not an error", async () => {
+    await ensureDirectories();
+    const r = await resolveScopeSlugs("mine", { handle: "nobody" } as Principal);
+    expect(r).toEqual({});
+  });
+
+  it("explicit owner:<h> with no pages IS an error (not a silent fallback)", async () => {
+    await ensureDirectories();
+    const r = await resolveScopeSlugs("owner:ghost", alice);
+    expect(r.error).toMatch(/No pages found/);
+  });
+
+  it("an unresolvable scope → error", async () => {
+    const r = await resolveScopeSlugs("user:bogus", alice);
+    expect(r.error).toMatch(/Invalid scope/);
   });
 });

--- a/src/lib/__tests__/wiki.test.ts
+++ b/src/lib/__tests__/wiki.test.ts
@@ -915,6 +915,38 @@ describe("/api/wiki/graph route", () => {
 
     expect(data.edges).toHaveLength(0);
   });
+
+  it("a scoped graph excludes another owner's private page (readable ∩ scope)", async () => {
+    // bob has a public + a private page. An anonymous viewer (no principal in
+    // tests) scoping to owner:bob must see ONLY the public one — slugsForOwner
+    // is visibility-blind, but the readable-set intersection gates the private.
+    await writeWikiPage(
+      "bob-pub",
+      serializeFrontmatter(
+        { owner: "bob", visibility: "public" },
+        "# Bob Public\n\nShared.",
+      ),
+    );
+    await writeWikiPage(
+      "bob-priv",
+      serializeFrontmatter(
+        { owner: "bob", visibility: "private" },
+        "# Bob Private\n\nSecret.",
+      ),
+    );
+    await updateIndex([
+      { slug: "bob-pub", title: "Bob Public", summary: "shared" },
+      { slug: "bob-priv", title: "Bob Private", summary: "secret" },
+    ]);
+
+    const { GET } = await import("../../app/api/wiki/graph/route");
+    const res = await GET(
+      new Request("http://localhost/api/wiki/graph?scope=owner:bob") as never,
+    );
+    const data = (await res.json()) as { nodes: { id: string }[] };
+
+    expect(data.nodes.map((n) => n.id)).toEqual(["bob-pub"]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/__tests__/wiki.test.ts
+++ b/src/lib/__tests__/wiki.test.ts
@@ -867,7 +867,9 @@ describe("/api/wiki/graph route", () => {
     ]);
 
     const { GET } = await import("../../app/api/wiki/graph/route");
-    const res = await GET();
+    const res = await GET(
+      new Request("http://localhost/api/wiki/graph") as never,
+    );
     const data = (await res.json()) as {
       nodes: { id: string; label: string }[];
       edges: { source: string; target: string }[];
@@ -904,7 +906,9 @@ describe("/api/wiki/graph route", () => {
     ]);
 
     const { GET } = await import("../../app/api/wiki/graph/route");
-    const res = await GET();
+    const res = await GET(
+      new Request("http://localhost/api/wiki/graph") as never,
+    );
     const data = (await res.json()) as {
       edges: { source: string; target: string }[];
     };

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -24,7 +24,7 @@ import {
   buildContext,
 } from "./query-search";
 
-import { resolveScope } from "./search";
+import { resolveScopeSlugs } from "./search";
 
 // Re-export BM25 helpers so existing callers (and tests) that import them
 // from `./query` continue to work after the bm25 extraction.
@@ -178,23 +178,14 @@ export async function query(
   return withPageCache(async () => {
     let entries = readable;
 
-    // Resolve scope to a set of slugs when provided
-    let scopeSlugs: string[] | undefined;
-    if (scope) {
-      const resolved = await resolveScope(scope);
-      if (!resolved) {
-        return {
-          answer: `Invalid scope or agent not found: '${scope}'`,
-          sources: [],
-        };
-      }
-      scopeSlugs = resolved.slugs;
-      if (scopeSlugs.length === 0) {
-        return {
-          answer: `No pages found for scope '${scope}'`,
-          sources: [],
-        };
-      }
+    // Resolve scope to a set of slugs (handles the "mine" lens; empty "mine"
+    // falls back to the full commons). Errors surface as a friendly answer.
+    const { scopeSlugs, error: scopeError } = await resolveScopeSlugs(
+      scope,
+      principal,
+    );
+    if (scopeError) {
+      return { answer: scopeError, sources: [] };
     }
 
     // General (unscoped) query excludes agent-scoped pages — agent knowledge

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -13,6 +13,7 @@ import {
   withPageCache,
   wikiRelPath,
   isAgentScopedType,
+  tenantForOwner,
 } from "./wiki";
 import { canReadFrontmatter } from "./authz";
 import type { Principal } from "./auth";
@@ -546,6 +547,10 @@ export async function fuzzySearchWikiContent(
  * the handle appears in `contributors`. Scans frontmatter (O(n), small scale).
  */
 export async function slugsForOwner(handle: string): Promise<string[]> {
+  // Compare by TENANT, not raw handle: owner matching is case-insensitive and,
+  // crucially, ownerless/seed pages (no `owner` field → DEFAULT_TENANT) belong
+  // to the `yopedia` silo. So `/u/yopedia` and `owner:yopedia` include them.
+  const wantTenant = tenantForOwner(handle);
   const pages = await listWikiPages();
   const out: string[] = [];
   for (const entry of pages) {
@@ -557,11 +562,55 @@ export async function slugsForOwner(handle: string): Promise<string[]> {
     const contributors = Array.isArray(page.frontmatter.contributors)
       ? (page.frontmatter.contributors as string[])
       : [];
-    if (owner === handle || contributors.includes(handle)) {
-      out.push(entry.slug);
-    }
+    const matchesOwner = tenantForOwner(owner) === wantTenant;
+    const matchesContributor = contributors.some(
+      (c) => typeof c === "string" && tenantForOwner(c) === wantTenant,
+    );
+    if (matchesOwner || matchesContributor) out.push(entry.slug);
   }
   return out;
+}
+
+/**
+ * Expand the client-facing `"mine"` scope to the concrete `owner:<handle>` of
+ * the signed-in principal (the Mine|All lens — see [[yopedia-tenant-silos]]).
+ * Signed-out callers asking for "mine" fall through to the unscoped commons.
+ * Any other scope string passes through unchanged. Pure — called at the route
+ * boundary before `query()`/`fuzzySearchWikiContent`/the graph route.
+ */
+export function expandMineScope(
+  scope: string | undefined | null,
+  principal: Principal | null,
+): string | undefined {
+  if (scope === "mine") {
+    return principal ? `owner:${principal.handle}` : undefined;
+  }
+  return scope || undefined;
+}
+
+/**
+ * Resolve a request's raw scope (incl. the `"mine"` convenience) to a concrete
+ * slug set, or an error. One source of truth for query + stream. Semantics:
+ * - no scope (or signed-out "mine") → `{}` (unscoped = full commons)
+ * - `"mine"` for a signed-in user with NO own pages → `{}` (fall back to the
+ *   commons rather than erroring — good first-run UX)
+ * - explicit `owner:`/`agent:` with no pages, or an unresolvable scope → error
+ */
+export async function resolveScopeSlugs(
+  rawScope: string | undefined | null,
+  principal: Principal | null,
+): Promise<{ scopeSlugs?: string[]; error?: string }> {
+  const scope = expandMineScope(rawScope, principal);
+  if (!scope) return {};
+  const resolved = await resolveScope(scope);
+  if (!resolved) {
+    return { error: `Invalid scope or agent not found: '${rawScope}'` };
+  }
+  if (resolved.slugs.length === 0) {
+    if (rawScope === "mine") return {}; // no own pages yet → full commons
+    return { error: `No pages found for scope '${rawScope}'` };
+  }
+  return { scopeSlugs: resolved.slugs };
 }
 
 export async function resolveScope(


### PR DESCRIPTION
## Phase 3 — the Mine|All lens (your tenancy ask: "view/query/graph your own data by default")

A consistent **Mine | All** scope lens across `/wiki`, `/query`, and `/wiki/graph` — defaulting to **Mine** when signed in — and `/u/<handle>` becomes a place you *act on* a silo, not just a list.

### Query
- Mine|All toggle on the query page (Mine shown only when signed in), defaults to Mine. "Answer from *my* notes" vs "from the whole commons."
- Wires to the existing `scope=owner:<handle>` the API already understood; the client just sends `"mine"` and the server resolves it from the principal (no need to ship the handle to the client).
- A signed-in user with **no pages** querying Mine falls back to the commons (good first-run UX); an explicit `owner:`/`agent:` scope with no pages still errors.

### Graph
- `/api/wiki/graph?scope=mine|owner:<h>` → that silo's **readable** pages (incl. the viewer's own private). Same Mine|All toggle + a deep-link chip. Unlike query, an empty Mine shows an **empty silo graph** (not the commons).

### `/u/<handle>` silo
- New **"Ask these pages"** (→ `/query?scope=owner:<h>`) and **"Graph this silo"** (→ `/wiki/graph?scope=owner:<h>`) actions.
- `slugsForOwner` now compares by **tenant** (case-insensitive), so **ownerless/seed pages belong to the `yopedia` silo** — `/u/yopedia` and `owner:yopedia` now include them. (Also fixes owner case-sensitivity.)

### Privacy (the bar)
A scoped query/graph only ever draws from **readable ∩ scope**. `?scope=owner:<other>` cannot expose another user's private page — `slugsForOwner` is visibility-blind, but the `listReadableWikiPages` intersection gates it. New test locks this in.

### Notes
- Scope deep-links are read from `window.location` (not `useSearchParams`) to avoid a CSR bailout that was dropping SSR of the whole query page.
- Graph hook fetch is now stale-guarded (rapid toggles can't land an out-of-order response).
- **Deferred to a follow-up:** the 5 secondary link-builders still ride the 308 shim (search-nav, query sources, ingest-success, batch, lint).

### Tests
Full suite green (2398; +9). Build green. Reviewed (code-reviewer): privacy/scope-leak bar met; fixed the one Important issue (graph stale guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)