### PR TITLE
yopedia: P3b — last link surfaces off the 308 shim (canonical)

### DIFF
--- a/src/app/api/wiki/routes/route.ts
+++ b/src/app/api/wiki/routes/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { listReadableWikiPages, ownerToTenant } from "@/lib/wiki";
+import { getPrincipal } from "@/lib/auth";
+
+/**
+ * slug → canonical tenant, over the caller's READABLE pages. Lets client
+ * components (search, query sources, lint, batch, ingest) build canonical
+ * `/u/<tenant>/<slug>` links without threading `owner` through every payload.
+ * Readability-gated: a private page only appears in its owner's map, so this
+ * never leaks another user's private slugs. Unknown slugs fall back to the
+ * legacy `/wiki/<slug>` route (which 308-redirects) on the client.
+ */
+export async function GET() {
+  const pages = await listReadableWikiPages(await getPrincipal());
+  const map: Record<string, string> = {};
+  for (const p of pages) map[p.slug] = ownerToTenant(p.owner);
+  return NextResponse.json(map);
+}

--- a/src/app/lint/LintClient.tsx
+++ b/src/app/lint/LintClient.tsx
@@ -4,8 +4,10 @@ import Link from "next/link";
 import { LintFilterControls } from "@/components/LintFilterControls";
 import { LintIssueCard } from "@/components/LintIssueCard";
 import { useLint } from "@/hooks/useLint";
+import { useSlugTenants } from "@/hooks/useSlugTenants";
 
 export function LintClient() {
+  const { hrefForSlug } = useSlugTenants();
   const {
     result,
     loading,
@@ -94,6 +96,7 @@ export function LintClient() {
                     isFixing={fixingSet.has(key)}
                     fixMessage={fixMessages.get(key) ?? null}
                     onFix={handleFix}
+                    hrefForSlug={hrefForSlug}
                   />
                 );
               })}

--- a/src/components/BatchIngestForm.tsx
+++ b/src/components/BatchIngestForm.tsx
@@ -7,8 +7,10 @@ import { Alert } from "@/components/Alert";
 import { BatchItemRow } from "@/components/BatchItemRow";
 import { BatchProgressBar } from "@/components/BatchProgressBar";
 import type { BatchItem } from "@/components/BatchItemRow";
+import { useSlugTenants } from "@/hooks/useSlugTenants";
 
 export function BatchIngestForm() {
+  const { hrefForSlug } = useSlugTenants();
   const [input, setInput] = useState("");
   const [items, setItems] = useState<BatchItem[]>([]);
   const [running, setRunning] = useState(false);
@@ -230,7 +232,7 @@ export function BatchIngestForm() {
           {/* Item list */}
           <ul className="space-y-2">
             {items.map((item, i) => (
-              <BatchItemRow key={i} item={item} />
+              <BatchItemRow key={i} item={item} hrefForSlug={hrefForSlug} />
             ))}
           </ul>
 

--- a/src/components/BatchItemRow.tsx
+++ b/src/components/BatchItemRow.tsx
@@ -22,9 +22,11 @@ function statusIcon(status: BatchItem["status"]) {
 
 interface BatchItemRowProps {
   item: BatchItem;
+  /** Resolve a slug to its canonical `/u/<tenant>/<slug>` href (from useSlugTenants). */
+  hrefForSlug: (slug: string) => string;
 }
 
-export function BatchItemRow({ item }: BatchItemRowProps) {
+export function BatchItemRow({ item, hrefForSlug }: BatchItemRowProps) {
   return (
     <li className="flex items-start gap-3 rounded-lg border border-foreground/10 px-4 py-3 text-sm">
       <span className="shrink-0 text-base leading-5">
@@ -38,7 +40,7 @@ export function BatchItemRow({ item }: BatchItemRowProps) {
           <p className="mt-1">
             Created{" "}
             <Link
-              href={`/wiki/${item.slug}`}
+              href={hrefForSlug(item.slug)}
               className="font-medium text-foreground hover:underline"
             >
               {item.slug}

--- a/src/components/IngestSuccess.tsx
+++ b/src/components/IngestSuccess.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { useSlugTenants } from "@/hooks/useSlugTenants";
 
 interface IngestSuccessProps {
   slug: string;
@@ -7,13 +10,14 @@ interface IngestSuccessProps {
 }
 
 export function IngestSuccess({ slug, relatedUpdated, onReset }: IngestSuccessProps) {
+  const { hrefForSlug } = useSlugTenants();
   return (
     <main className="mx-auto max-w-3xl px-6 py-12">
       <div className="rounded-lg border border-foreground/10 p-8 text-center">
         <p className="text-2xl font-semibold">✓ Ingested as wiki page</p>
         <div className="mt-6 flex flex-col items-center gap-3">
           <Link
-            href={`/wiki/${slug}`}
+            href={hrefForSlug(slug)}
             className="inline-block rounded-lg bg-foreground px-6 py-3 text-sm font-medium text-background hover:opacity-90 transition-opacity"
           >
             View &ldquo;{slug}&rdquo; →
@@ -28,7 +32,7 @@ export function IngestSuccess({ slug, relatedUpdated, onReset }: IngestSuccessPr
                 {relatedUpdated.map((relatedSlug) => (
                   <li key={relatedSlug}>
                     <Link
-                      href={`/wiki/${relatedSlug}`}
+                      href={hrefForSlug(relatedSlug)}
                       className="text-sm text-foreground/70 hover:text-foreground hover:underline transition-colors"
                     >
                       {relatedSlug}

--- a/src/components/LintIssueCard.tsx
+++ b/src/components/LintIssueCard.tsx
@@ -51,6 +51,8 @@ export interface LintIssueCardProps {
   isFixing: boolean;
   fixMessage: string | null;
   onFix: (issue: LintIssue, targetSlug?: string) => void;
+  /** Resolve a slug to its canonical `/u/<tenant>/<slug>` href (from useSlugTenants). */
+  hrefForSlug: (slug: string) => string;
 }
 
 export function LintIssueCard({
@@ -58,6 +60,7 @@ export function LintIssueCard({
   isFixing,
   fixMessage,
   onFix,
+  hrefForSlug,
 }: LintIssueCardProps) {
   const styles = severityClasses[issue.severity];
   const targetSlug = issue.target ?? null;
@@ -84,7 +87,7 @@ export function LintIssueCard({
       </span>
       {issue.slug ? (
         <Link
-          href={`/wiki/${issue.slug}`}
+          href={hrefForSlug(issue.slug)}
           className="inline-block rounded-full border border-foreground/20 bg-foreground/5 px-2.5 py-0.5 text-xs font-medium text-foreground hover:bg-foreground/10 transition-colors"
         >
           {issue.slug}

--- a/src/components/QueryResultPanel.tsx
+++ b/src/components/QueryResultPanel.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { SlidePreview } from "@/components/SlidePreview";
 import { Alert } from "@/components/Alert";
+import { useSlugTenants } from "@/hooks/useSlugTenants";
 import { logger } from "@/lib/logger";
 
 interface SaveState {
@@ -28,6 +29,7 @@ export function QueryResultPanel({
   currentHistoryId,
   onHistorySaved,
 }: QueryResultPanelProps) {
+  const { hrefForSlug } = useSlugTenants();
   const [saveState, setSaveState] = useState<SaveState>({ status: "idle" });
   const [saveTitle, setSaveTitle] = useState("");
   const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
@@ -142,7 +144,7 @@ export function QueryResultPanel({
             {result.sources.map((slug) => (
               <li key={slug}>
                 <Link
-                  href={`/wiki/${slug}`}
+                  href={hrefForSlug(slug)}
                   className="inline-block rounded-md border border-foreground/20 px-3 py-1 text-sm hover:bg-foreground/5 transition-colors"
                 >
                   {slug}
@@ -220,7 +222,7 @@ export function QueryResultPanel({
             <Alert variant="success">
               Saved!{" "}
               <Link
-                href={`/wiki/${saveState.slug}`}
+                href={hrefForSlug(saveState.slug)}
                 className="underline font-medium hover:opacity-80"
               >
                 View wiki page →

--- a/src/components/WikiEditor.tsx
+++ b/src/components/WikiEditor.tsx
@@ -435,7 +435,7 @@ export function WikiEditor({
           {busy ? "Saving…" : "Save"}
         </button>
         <Link
-          href={`/wiki/${slug}`}
+          href={`/u/${tenant}/${slug}`}
           className="text-sm text-foreground/60 hover:text-foreground transition-colors"
         >
           Cancel

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { useSlugTenants } from "./useSlugTenants";
 
 export interface SearchNode {
   id: string;
@@ -38,6 +39,7 @@ export interface UseGlobalSearchReturn {
 
 export function useGlobalSearch(): UseGlobalSearchReturn {
   const router = useRouter();
+  const { hrefForSlug } = useSlugTenants();
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
   const [pages, setPages] = useState<SearchNode[]>([]);
@@ -192,7 +194,7 @@ export function useGlobalSearch(): UseGlobalSearchReturn {
     setOpen(false);
     setExpanded(false);
     setContentResults([]);
-    router.push(`/wiki/${slug}`);
+    router.push(hrefForSlug(slug));
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {

--- a/src/hooks/useSlugTenants.ts
+++ b/src/hooks/useSlugTenants.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { pagePath } from "@/lib/links";
+
+type SlugTenants = Record<string, string>;
+
+// Session-level cache so the slug→tenant map is fetched at most once across all
+// components that use it (search, query sources, lint, batch, ingest).
+let cache: SlugTenants | null = null;
+let inflight: Promise<SlugTenants> | null = null;
+
+function load(): Promise<SlugTenants> {
+  if (cache) return Promise.resolve(cache);
+  if (!inflight) {
+    inflight = fetch("/api/wiki/routes")
+      .then((r) => (r.ok ? r.json() : {}))
+      .then((m: SlugTenants) => {
+        cache = m;
+        return m;
+      })
+      .catch(() => ({}) as SlugTenants)
+      .finally(() => {
+        inflight = null;
+      });
+  }
+  return inflight;
+}
+
+/**
+ * Resolve a target slug to its canonical `/u/<tenant>/<slug>` href on the
+ * client. Falls back to the legacy `/wiki/<slug>` (which 308-redirects to
+ * canonical) while the map is loading or for an unknown slug — so links always
+ * work, just with one redirect hop in the fallback case.
+ */
+export function useSlugTenants() {
+  const [map, setMap] = useState<SlugTenants>(cache ?? {});
+  useEffect(() => {
+    let on = true;
+    load().then((m) => {
+      if (on) setMap(m);
+    });
+    return () => {
+      on = false;
+    };
+  }, []);
+  const hrefForSlug = (slug: string): string =>
+    map[slug] ? pagePath(map[slug], slug) : `/wiki/${slug}`;
+  return { hrefForSlug };
+}

--- a/src/lib/__tests__/wiki.test.ts
+++ b/src/lib/__tests__/wiki.test.ts
@@ -950,6 +950,41 @@ describe("/api/wiki/graph route", () => {
 });
 
 // ---------------------------------------------------------------------------
+// /api/wiki/routes — slug→tenant map for client canonical links (P3b)
+// ---------------------------------------------------------------------------
+describe("/api/wiki/routes route", () => {
+  it("maps readable slugs to their tenant and omits others' private pages", async () => {
+    await writeWikiPage(
+      "pub",
+      serializeFrontmatter(
+        { owner: "alice", visibility: "public" },
+        "# Pub\n\nbody",
+      ),
+    );
+    await writeWikiPage("seed", "# Seed\n\nbody"); // ownerless → yopedia
+    await writeWikiPage(
+      "bob-priv",
+      serializeFrontmatter(
+        { owner: "bob", visibility: "private" },
+        "# Priv\n\nsecret",
+      ),
+    );
+    await updateIndex([
+      { slug: "pub", title: "Pub", summary: "" },
+      { slug: "seed", title: "Seed", summary: "" },
+      { slug: "bob-priv", title: "Priv", summary: "" },
+    ]);
+
+    const { GET } = await import("../../app/api/wiki/routes/route");
+    const map = (await (await GET()).json()) as Record<string, string>;
+
+    // Owner→tenant (lowercased), ownerless→yopedia; another user's private page
+    // is absent (readability-gated) so its slug can't leak.
+    expect(map).toEqual({ pub: "alice", seed: "yopedia" });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // YAML frontmatter parser + serializer
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The 5 secondary link-builders deferred from P2/P3 (search nav, query sources, ingest-success, batch rows, lint cards) plus the editor's Cancel link still emitted `/wiki/<slug>` and rode the 308 redirect. They now link **canonically** to `/u/<tenant>/<slug>` — no hop.

### Approach — shared client resolver (DRY)
These surfaces only had a **slug**, so instead of threading `owner` through 5 different payloads:
- **`GET /api/wiki/routes`** → `slug → tenant` map over the caller's **readable** pages (private pages appear only for their owner — readability-gated; +test locks this in).
- **`useSlugTenants()`** → session-cached fetch (one request shared across all consumers), exposes `hrefForSlug(slug)` → `/u/<tenant>/<slug>`, falling back to `/wiki/<slug>` (still 308s) for unknown/loading slugs so links never break.

### No behavior change
Same destinations, minus the redirect hop. Purely consistency/polish.

Full suite green (2399; +1). Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)