### PR TITLE
yopedia: tenant silos P5a — live per-tenant silo mirror (vault folders)

### DIFF
--- a/src/lib/__tests__/lifecycle.test.ts
+++ b/src/lib/__tests__/lifecycle.test.ts
@@ -18,6 +18,7 @@ import { updateIndex } from "../wiki";
 import { listRevisions, saveRevision } from "../revisions";
 import { resolveAlias, buildAliasIndex, resetAliasIndex } from "../alias-index";
 import { serializeFrontmatter } from "../frontmatter";
+import { getStorage, _resetStorage } from "../storage";
 
 // ---------------------------------------------------------------------------
 // Temp directory setup — mirrors wiki.test.ts approach
@@ -26,13 +27,19 @@ import { serializeFrontmatter } from "../frontmatter";
 let tmpDir: string;
 let originalWikiDir: string | undefined;
 let originalRawDir: string | undefined;
+let originalDataDir: string | undefined;
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "lifecycle-test-"));
   originalWikiDir = process.env.WIKI_DIR;
   originalRawDir = process.env.RAW_DIR;
+  originalDataDir = process.env.DATA_DIR;
   process.env.WIKI_DIR = path.join(tmpDir, "wiki");
   process.env.RAW_DIR = path.join(tmpDir, "raw");
+  // Isolate DATA_DIR so the per-tenant silo mirror (tenants/…, relative to the
+  // data dir) and derived indexes land under tmp, not the repo cwd.
+  process.env.DATA_DIR = tmpDir;
+  _resetStorage();
   await ensureDirectories();
 });
 
@@ -47,6 +54,12 @@ afterEach(async () => {
   } else {
     process.env.RAW_DIR = originalRawDir;
   }
+  if (originalDataDir === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = originalDataDir;
+  }
+  _resetStorage();
   await fs.rm(tmpDir, { recursive: true, force: true });
   resetAliasIndex();
 });
@@ -667,5 +680,65 @@ describe("lifecycle write triggers alias index update", () => {
 
     const result = await resolveAlias("Svelte");
     expect(result).toBe("svelte");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-tenant silo mirror (P5a) — every write/delete mirrors the page into
+// tenants/<tenant>/, keeping each silo a live vault.
+// ---------------------------------------------------------------------------
+describe("per-tenant silo mirror", () => {
+  it("mirrors a written page into its owner's silo (tenants/<tenant>/wiki)", async () => {
+    await writeWikiPageWithSideEffects({
+      slug: "alpha",
+      title: "Alpha",
+      content: serializeFrontmatter(
+        { owner: "Alice", visibility: "public" },
+        "# Alpha\n\nBody.",
+      ),
+      summary: "first",
+      logOp: "ingest",
+      crossRefSource: null,
+    });
+
+    // Owner "Alice" → tenant "alice" (lowercased).
+    const mirrored = await getStorage().readFile(
+      "tenants/alice/wiki/alpha.md",
+    );
+    expect(mirrored).toContain("# Alpha");
+    expect(mirrored).toContain("owner: Alice");
+  });
+
+  it("ownerless pages mirror into the yopedia silo", async () => {
+    await writeWikiPageWithSideEffects({
+      slug: "seed",
+      title: "Seed",
+      content: "# Seed\n\nNo owner.",
+      summary: "seed",
+      logOp: "ingest",
+      crossRefSource: null,
+    });
+    expect(
+      await getStorage().fileExists("tenants/yopedia/wiki/seed.md"),
+    ).toBe(true);
+  });
+
+  it("deleting a page removes it from its silo", async () => {
+    await writeWikiPageWithSideEffects({
+      slug: "doomed",
+      title: "Doomed",
+      content: serializeFrontmatter({ owner: "bob" }, "# Doomed\n\nBye."),
+      summary: "x",
+      logOp: "ingest",
+      crossRefSource: null,
+    });
+    expect(
+      await getStorage().fileExists("tenants/bob/wiki/doomed.md"),
+    ).toBe(true);
+
+    await deleteWikiPage("doomed");
+    expect(
+      await getStorage().fileExists("tenants/bob/wiki/doomed.md"),
+    ).toBe(false);
   });
 });

--- a/src/lib/__tests__/links.test.ts
+++ b/src/lib/__tests__/links.test.ts
@@ -119,6 +119,19 @@ describe("ownerToTenant", () => {
     expect(ownerToTenant("")).toBe("yopedia");
     expect(ownerToTenant("   ")).toBe("yopedia");
   });
+
+  it("normalizes path-unsafe chars so the tenant is always a valid URL/folder", () => {
+    // whitespace / separators / dots → dash; result must be validateTenant-safe.
+    expect(ownerToTenant("Jean Luc")).toBe("jean-luc");
+    expect(ownerToTenant("bob/admin")).toBe("bob-admin");
+    expect(ownerToTenant("a.b")).toBe("a-b");
+    expect(ownerToTenant("..")).toBe("yopedia"); // ".." → trimmed empty → default
+  });
+
+  it("preserves the `--` in agent-style ids and unicode handles", () => {
+    expect(ownerToTenant("alice--yoyo")).toBe("alice--yoyo");
+    expect(ownerToTenant("检索增强")).toBe("检索增强");
+  });
 });
 
 describe("canonical URL builders", () => {

--- a/src/lib/__tests__/silo.test.ts
+++ b/src/lib/__tests__/silo.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { syncSiloForPage, removeSiloForPage } from "../silo";
+import { writeWikiPage, ensureDirectories } from "../wiki";
+import { getStorage, _resetStorage } from "../storage";
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "silo-test-"));
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetStorage();
+  await ensureDirectories();
+});
+
+afterEach(async () => {
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("syncSiloForPage", () => {
+  it("mirrors the page md into tenants/<tenant>/wiki", async () => {
+    await writeWikiPage("alpha", "# Alpha\n\nBody.");
+    const n = await syncSiloForPage("alpha", "alice");
+    expect(n).toBe(1); // just the wiki md (no raw/revisions/discuss/assets)
+    expect(await getStorage().readFile("tenants/alice/wiki/alpha.md")).toContain(
+      "# Alpha",
+    );
+  });
+
+  it("re-copies the mutable md but SKIPS already-mirrored immutable revisions", async () => {
+    await writeWikiPage("beta", "# Beta\n\nv1");
+    // Plant two immutable revision files (as saveRevision would).
+    await getStorage().writeFile("wiki/.revisions/beta/1.md", "# Beta\n\nv0");
+    await getStorage().writeFile(
+      "wiki/.revisions/beta/1.meta.json",
+      '{"author":"a"}',
+    );
+
+    // First sync copies md + both revision files.
+    expect(await syncSiloForPage("beta", "bob")).toBe(3);
+
+    // Second sync (no new revisions) copies ONLY the mutable md again — the two
+    // already-mirrored revisions are skipped (the O(N) re-copy fix).
+    expect(await syncSiloForPage("beta", "bob")).toBe(1);
+
+    // A newly-added revision IS picked up next sync.
+    await getStorage().writeFile("wiki/.revisions/beta/2.md", "# Beta\n\nv1");
+    expect(await syncSiloForPage("beta", "bob")).toBe(2); // md + the new revision
+  });
+
+  it("removeSiloForPage clears the page from its silo", async () => {
+    await writeWikiPage("gamma", "# Gamma");
+    await syncSiloForPage("gamma", "alice");
+    expect(await getStorage().fileExists("tenants/alice/wiki/gamma.md")).toBe(
+      true,
+    );
+    await removeSiloForPage("gamma", "alice");
+    expect(await getStorage().fileExists("tenants/alice/wiki/gamma.md")).toBe(
+      false,
+    );
+  });
+});

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -6,13 +6,16 @@ import {
   validateSlug,
   writeWikiPage,
   readWikiPage,
+  readWikiPageWithFrontmatter,
   listWikiPages,
   updateIndexUnsafe,
   findRelatedPages,
   updateRelatedPages,
   appendToLog,
   wikiRelPath,
+  tenantForOwner,
 } from "./wiki";
+import { syncSiloForPage, removeSiloForPage } from "./silo";
 import { getStorage } from "./storage";
 import { withFileLock } from "./lock";
 import { escapeRegex } from "./links";
@@ -208,10 +211,23 @@ async function runPageLifecycleOp(
   //    fast before any filesystem mutation happens.
   validateSlug(slug);
 
+  // Capture the deleted page's owner BEFORE removing it, so step 3c knows which
+  // tenant silo to mirror the removal into (the flat file is gone afterward).
+  let deletedOwner: string | undefined;
+
   // 2. Mutate the page file.
   if (op.kind === "write") {
     await writeWikiPage(slug, op.content, op.author);
   } else {
+    try {
+      const pre = await readWikiPageWithFrontmatter(slug);
+      deletedOwner =
+        typeof pre?.frontmatter.owner === "string"
+          ? pre.frontmatter.owner
+          : undefined;
+    } catch {
+      // Owner unknown → falls back to the default tenant in step 3c.
+    }
     try {
       await getStorage().deleteFile(wikiRelPath(`${slug}.md`));
     } catch (err: unknown) {
@@ -349,6 +365,22 @@ async function runPageLifecycleOp(
     }
   } catch (err) {
     logger.warn("commons", `commons sync skipped for "${slug}":`, err);
+  }
+
+  // 3c. Mirror the page into its per-tenant silo — a live, self-contained vault
+  //     (`tenants/<tenant>/…`, Obsidian-servable). A derived per-page mirror of
+  //     flat (the write primary); fail-soft so a silo error never breaks the
+  //     write/delete. Reads from flat, so this runs AFTER the flat mutation.
+  try {
+    if (op.kind === "delete") {
+      await removeSiloForPage(slug, tenantForOwner(deletedOwner));
+    } else {
+      const o = parseFrontmatter(op.content).data.owner;
+      const owner = typeof o === "string" ? o : undefined;
+      await syncSiloForPage(slug, tenantForOwner(owner));
+    }
+  } catch (err) {
+    logger.warn("silo", `silo mirror skipped for "${slug}":`, err);
   }
 
   // 4. Cross-reference other pages.

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -67,10 +67,23 @@ export const DEFAULT_TENANT = "yopedia";
  * The canonical tenant for an owner handle: lowercased (owner checks are
  * case-insensitive, so one owner never splits across "Alice"/"alice" silos),
  * falling back to {@link DEFAULT_TENANT} for ownerless/seed content. The SINGLE
- * place tenant-from-owner is derived.
+ * place tenant-from-owner is derived — used for the `/u/<tenant>/` URL, the
+ * commons key, AND the physical silo folder, so all three stay identical.
+ *
+ * Normalizes the path-unsafe characters a tenant key/URL/folder can't contain
+ * (whitespace, control chars, `/`, `\`, `.`) to `-`, so a free-form owner (e.g.
+ * an API/MCP-supplied `"Jean Luc"`) still yields a valid, routable tenant rather
+ * than a broken URL or a silo write that throws. Unicode (e.g. CJK handles) is
+ * preserved — only the unsafe set is touched. Normal handles (Clerk usernames,
+ * `alice--yoyo`) pass through unchanged apart from lowercasing.
  */
 export function ownerToTenant(owner?: string | null): string {
-  const t = typeof owner === "string" ? owner.trim().toLowerCase() : "";
+  if (typeof owner !== "string") return DEFAULT_TENANT;
+  const t = owner
+    .trim()
+    .toLowerCase()
+    .replace(/[\s\u0000-\u001f/\\.]+/g, "-")
+    .replace(/^-+|-+$/g, ""); // trim leading/trailing dashes
   return t.length > 0 ? t : DEFAULT_TENANT;
 }
 

--- a/src/lib/migrate-to-tenants.ts
+++ b/src/lib/migrate-to-tenants.ts
@@ -24,18 +24,15 @@
  */
 
 import { getStorage } from "./storage";
-import { isEnoent } from "./errors";
 import { logger } from "./logger";
 import type { IndexEntry } from "./types";
 import {
   listWikiPages,
-  wikiRelPath,
-  rawRelPath,
   tenantWikiRelPath,
-  tenantRawRelPath,
   tenantForOwner,
 } from "./wiki";
 import { rebuildCommonsIndex } from "./commons";
+import { syncSiloForPage } from "./silo";
 
 /** The index + log are infrastructure, not pages — never migrated as pages. */
 const SKIP_SLUGS = new Set(["index", "log"]);
@@ -55,77 +52,6 @@ export interface MigrationResult {
   commonsCount: number;
   redirectCount: number;
   errors: string[];
-}
-
-async function copyText(src: string, dst: string): Promise<boolean> {
-  const storage = getStorage();
-  let content: string;
-  try {
-    content = await storage.readFile(src);
-  } catch (e) {
-    if (isEnoent(e)) return false;
-    throw e;
-  }
-  await storage.writeFile(dst, content);
-  return true;
-}
-
-async function copyAsset(src: string, dst: string): Promise<boolean> {
-  const storage = getStorage();
-  let data: ArrayBuffer;
-  try {
-    data = await storage.readAsset(src);
-  } catch (e) {
-    if (isEnoent(e)) return false;
-    throw e;
-  }
-  await storage.writeAsset(dst, data);
-  return true;
-}
-
-async function listSafe(prefix: string) {
-  try {
-    return await getStorage().listFiles(prefix);
-  } catch (e) {
-    if (isEnoent(e)) return [];
-    throw e;
-  }
-}
-
-/** Copy every per-page artifact for one slug into its tenant. */
-async function copyPageArtifacts(slug: string, tenant: string): Promise<number> {
-  let n = 0;
-  // wiki page + raw source
-  if (await copyText(wikiRelPath(`${slug}.md`), tenantWikiRelPath(tenant, `${slug}.md`))) n++;
-  if (await copyText(rawRelPath(`${slug}.md`), tenantRawRelPath(tenant, `${slug}.md`))) n++;
-
-  // revision history: wiki/.revisions/<slug>/{<ts>.md,<ts>.meta.json}
-  for (const f of await listSafe(wikiRelPath(`.revisions/${slug}`))) {
-    if (f.isDirectory) continue;
-    if (
-      await copyText(
-        wikiRelPath(`.revisions/${slug}/${f.name}`),
-        tenantWikiRelPath(tenant, `.revisions/${slug}/${f.name}`),
-      )
-    )
-      n++;
-  }
-
-  // discussion threads: discuss/<slug>.json
-  if (await copyText(`discuss/${slug}.json`, `tenants/${tenant}/discuss/${slug}.json`)) n++;
-
-  // binary assets: raw/assets/<slug>/<file>
-  for (const f of await listSafe(rawRelPath(`assets/${slug}`))) {
-    if (f.isDirectory) continue;
-    if (
-      await copyAsset(
-        rawRelPath(`assets/${slug}/${f.name}`),
-        tenantRawRelPath(tenant, `assets/${slug}/${f.name}`),
-      )
-    )
-      n++;
-  }
-  return n;
 }
 
 /** Migrate (copy) all flat content into per-tenant silos. Dry-run by default. */
@@ -152,7 +78,7 @@ export async function migrateToTenants(
 
     if (dryRun) continue;
     try {
-      artifactsCopied += await copyPageArtifacts(page.slug, tenant);
+      artifactsCopied += await syncSiloForPage(page.slug, tenant);
     } catch (e) {
       errors.push(`copy ${page.slug}: ${String(e)}`);
       logger.warn("migrate", `copy failed for "${page.slug}"`, e);

--- a/src/lib/silo.ts
+++ b/src/lib/silo.ts
@@ -1,0 +1,142 @@
+/**
+ * Per-tenant silo mirror (tenant-silos P5a).
+ *
+ * Each tenant's folder `tenants/<tenant>/…` is kept as a live, complete mirror
+ * of that owner's pages — a self-contained vault (Obsidian-servable). Flat
+ * storage stays the write/read primary; the silo is a DERIVED per-page mirror
+ * synced on every lifecycle write/delete (the same fail-soft pattern as the
+ * commons index). The one-shot migration backfills it; this module keeps it
+ * current going forward.
+ *
+ * Artifacts mirrored per page: wiki md, raw source, revision history, discussion
+ * threads, and binary assets. The embedding vector store is internal (not part
+ * of the vault) and stays global.
+ */
+
+import { getStorage } from "./storage";
+import { isEnoent } from "./errors";
+import {
+  wikiRelPath,
+  rawRelPath,
+  tenantWikiRelPath,
+  tenantRawRelPath,
+  validateTenant,
+} from "./wiki";
+
+async function copyText(src: string, dst: string): Promise<boolean> {
+  const storage = getStorage();
+  let content: string;
+  try {
+    content = await storage.readFile(src);
+  } catch (e) {
+    if (isEnoent(e)) return false;
+    throw e;
+  }
+  await storage.writeFile(dst, content);
+  return true;
+}
+
+async function copyAsset(src: string, dst: string): Promise<boolean> {
+  const storage = getStorage();
+  let data: ArrayBuffer;
+  try {
+    data = await storage.readAsset(src);
+  } catch (e) {
+    if (isEnoent(e)) return false;
+    throw e;
+  }
+  await storage.writeAsset(dst, data);
+  return true;
+}
+
+async function listSafe(prefix: string) {
+  try {
+    return await getStorage().listFiles(prefix);
+  } catch (e) {
+    if (isEnoent(e)) return [];
+    throw e;
+  }
+}
+
+async function deleteSafe(path: string): Promise<void> {
+  try {
+    await getStorage().deleteFile(path);
+  } catch (e) {
+    if (!isEnoent(e)) throw e;
+  }
+}
+
+async function deleteDirSafe(path: string): Promise<void> {
+  try {
+    await getStorage().deleteDirectory(path);
+  } catch (e) {
+    if (!isEnoent(e)) throw e;
+  }
+}
+
+/**
+ * Mirror every per-page artifact for one slug into its tenant silo (idempotent
+ * — overwrites). Reads from flat (the write primary), so call AFTER the flat
+ * write completes. Returns the count of artifacts copied.
+ */
+export async function syncSiloForPage(
+  slug: string,
+  tenant: string,
+): Promise<number> {
+  validateTenant(tenant);
+  let n = 0;
+  // wiki page + raw source
+  if (await copyText(wikiRelPath(`${slug}.md`), tenantWikiRelPath(tenant, `${slug}.md`)))
+    n++;
+  if (await copyText(rawRelPath(`${slug}.md`), tenantRawRelPath(tenant, `${slug}.md`)))
+    n++;
+
+  // revision history: wiki/.revisions/<slug>/{<ts>.md,<ts>.meta.json}
+  for (const f of await listSafe(wikiRelPath(`.revisions/${slug}`))) {
+    if (f.isDirectory) continue;
+    if (
+      await copyText(
+        wikiRelPath(`.revisions/${slug}/${f.name}`),
+        tenantWikiRelPath(tenant, `.revisions/${slug}/${f.name}`),
+      )
+    )
+      n++;
+  }
+
+  // discussion threads: discuss/<slug>.json
+  if (
+    await copyText(
+      `discuss/${slug}.json`,
+      `tenants/${tenant}/discuss/${slug}.json`,
+    )
+  )
+    n++;
+
+  // binary assets: raw/assets/<slug>/<file>
+  for (const f of await listSafe(rawRelPath(`assets/${slug}`))) {
+    if (f.isDirectory) continue;
+    if (
+      await copyAsset(
+        rawRelPath(`assets/${slug}/${f.name}`),
+        tenantRawRelPath(tenant, `assets/${slug}/${f.name}`),
+      )
+    )
+      n++;
+  }
+  return n;
+}
+
+/** Remove every per-page artifact for one slug from its tenant silo. */
+export async function removeSiloForPage(
+  slug: string,
+  tenant: string,
+): Promise<void> {
+  validateTenant(tenant);
+  await Promise.all([
+    deleteSafe(tenantWikiRelPath(tenant, `${slug}.md`)),
+    deleteSafe(tenantRawRelPath(tenant, `${slug}.md`)),
+    deleteSafe(`tenants/${tenant}/discuss/${slug}.json`),
+    deleteDirSafe(tenantWikiRelPath(tenant, `.revisions/${slug}`)),
+    deleteDirSafe(tenantRawRelPath(tenant, `assets/${slug}`)),
+  ]);
+}

--- a/src/lib/silo.ts
+++ b/src/lib/silo.ts
@@ -91,19 +91,29 @@ export async function syncSiloForPage(
   if (await copyText(rawRelPath(`${slug}.md`), tenantRawRelPath(tenant, `${slug}.md`)))
     n++;
 
+  // Revision history + assets are IMMUTABLE (append-only, never rewritten), so
+  // copy only the ones not already mirrored. This bounds a per-write sync to the
+  // new files instead of re-copying the whole (unbounded) history each time —
+  // critical on the Workers runtime (subrequest budget). One list of the silo
+  // side does the diff; the migration's first run (empty silo) still copies all.
+
   // revision history: wiki/.revisions/<slug>/{<ts>.md,<ts>.meta.json}
-  for (const f of await listSafe(wikiRelPath(`.revisions/${slug}`))) {
-    if (f.isDirectory) continue;
+  const revRel = `.revisions/${slug}`;
+  const mirroredRevs = new Set(
+    (await listSafe(tenantWikiRelPath(tenant, revRel))).map((f) => f.name),
+  );
+  for (const f of await listSafe(wikiRelPath(revRel))) {
+    if (f.isDirectory || mirroredRevs.has(f.name)) continue;
     if (
       await copyText(
-        wikiRelPath(`.revisions/${slug}/${f.name}`),
-        tenantWikiRelPath(tenant, `.revisions/${slug}/${f.name}`),
+        wikiRelPath(`${revRel}/${f.name}`),
+        tenantWikiRelPath(tenant, `${revRel}/${f.name}`),
       )
     )
       n++;
   }
 
-  // discussion threads: discuss/<slug>.json
+  // discussion threads: discuss/<slug>.json (mutable — always overwrite)
   if (
     await copyText(
       `discuss/${slug}.json`,
@@ -112,13 +122,17 @@ export async function syncSiloForPage(
   )
     n++;
 
-  // binary assets: raw/assets/<slug>/<file>
-  for (const f of await listSafe(rawRelPath(`assets/${slug}`))) {
-    if (f.isDirectory) continue;
+  // binary assets: raw/assets/<slug>/<file> (immutable — copy only new)
+  const assetRel = `assets/${slug}`;
+  const mirroredAssets = new Set(
+    (await listSafe(tenantRawRelPath(tenant, assetRel))).map((f) => f.name),
+  );
+  for (const f of await listSafe(rawRelPath(assetRel))) {
+    if (f.isDirectory || mirroredAssets.has(f.name)) continue;
     if (
       await copyAsset(
-        rawRelPath(`assets/${slug}/${f.name}`),
-        tenantRawRelPath(tenant, `assets/${slug}/${f.name}`),
+        rawRelPath(`${assetRel}/${f.name}`),
+        tenantRawRelPath(tenant, `${assetRel}/${f.name}`),
       )
     )
       n++;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/__tests__/**/*.test.ts"],
+    setupFiles: ["./vitest.setup.ts"],
   },
   resolve: {
     alias: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,11 @@
+import os from "os";
+import path from "path";
+import { mkdtempSync } from "fs";
+
+// Isolate the storage data root to a temp dir by default, so ANY test that
+// writes a page — which now also writes the commons index, per-tenant silos
+// (tenants/<tenant>/…), and .indexes — never touches the repo cwd. Tests that
+// set their own DATA_DIR/WIKI_DIR/RAW_DIR in beforeEach still override this.
+if (!process.env.DATA_DIR) {
+  process.env.DATA_DIR = mkdtempSync(path.join(os.tmpdir(), "yopedia-test-"));
+}


### PR DESCRIPTION
## Phase 5a — live silo mirror (the folder isolation)

Makes each `tenants/<handle>/…` folder a **live, self-contained vault** (Obsidian-servable): every page write/delete mirrors that page's full artifact set into the owner's silo. This delivers the folder-isolation the concept calls for **without** switching the app's reads off flat storage yet — so it's behavior-preserving and reversible.

### How
- **`src/lib/silo.ts`** — `syncSiloForPage(slug, tenant)` / `removeSiloForPage` mirror/remove a page's **md + raw + revisions + discuss + assets**. Extracted from the migration's `copyPageArtifacts` (now shared) so the one-shot backfill and the live mirror use identical logic.
- **`lifecycle.ts` step 3c** — after the flat write/delete (+ commons sync), sync the page into its tenant silo. Derived per-page mirror, **fail-soft** (a silo error never breaks the write). Owner→tenant via `tenantForOwner`; the delete path captures the owner before removing the flat file.
- Embedding vectors stay global (internal, not vault content).

### Why this shape
Folder isolation needs each silo to **exist and stay current** — not for the app to read from it. So a live mirror (same pattern as the commons index) gives you the exportable per-tenant vault now, at low risk; reading from silos becomes an optional later step (P5d), not a prerequisite.

### Test isolation (bonus)
Writing a page now also writes the silo, so a non-isolated test would litter the repo. Added a global **`vitest.setup.ts`** defaulting `DATA_DIR` to a temp dir — fixes this leak class for good (also covers the older commons/`.indexes` litter). +3 silo-mirror tests. Full suite green (2402), **zero repo litter**.

### Known follow-ups (acceptable for a derived mirror)
Cross-ref backlink edits and discuss-only updates to *other* pages lag in the silo until that page's next direct write — reconciled by a backfill re-run.

### After merge
Re-run the migration once to backfill the stale silos to current state; the mirror keeps them current thereafter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)