### PR TITLE
yopedia: tenant silos P5b — per-tenant vault export (download my vault)

### DIFF
--- a/src/app/api/wiki/export/route.ts
+++ b/src/app/api/wiki/export/route.ts
@@ -1,44 +1,77 @@
 import { zipSync, strToU8 } from "fflate";
-import { listReadableWikiPages, readWikiPage } from "@/lib/wiki";
+import type { NextRequest } from "next/server";
+import { listReadableWikiPages, readWikiPage, rawRelPath } from "@/lib/wiki";
+import { getStorage } from "@/lib/storage";
+import { isEnoent } from "@/lib/errors";
 import { getPrincipal } from "@/lib/auth";
-import { convertToObsidianLinks } from "@/lib/export";
+import { expandMineScope, resolveScope } from "@/lib/search";
+import { convertToObsidianLinks, normalizeVaultAssetPaths } from "@/lib/export";
 
 /**
- * GET /api/wiki/export
+ * GET /api/wiki/export[?scope=mine|owner:<handle>]
  *
- * Returns the entire wiki as an Obsidian-compatible zip vault.
- * Each page is exported as a markdown file with internal links converted to
- * Obsidian wikilink syntax (`[[slug|Title]]`). YAML frontmatter is preserved
- * as-is since Obsidian reads it natively.
+ * Returns an Obsidian-compatible **vault zip**. Unscoped → every readable page;
+ * scoped → just that silo's pages ("download my vault" from a /u/<handle>).
+ * Each page is a markdown file with internal links converted to wikilinks
+ * (`[[slug|Title]]`); YAML frontmatter is preserved (Obsidian reads it). Binary
+ * **assets** (images) are included under `assets/<slug>/…` and image paths are
+ * normalized so they resolve in the vault. Scoped reads are readability-gated:
+ * the scope only narrows the already-readable set, so it can't export another
+ * user's private pages.
  *
- * Uses fflate (pure JS) instead of archiver so this route can run in
- * Cloudflare Workers as well as Node.js.
+ * Uses fflate (pure JS) so this runs on Cloudflare Workers as well as Node.
  */
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
     const principal = await getPrincipal();
-    const pages = await listReadableWikiPages(principal);
+    const scopeParam = new URL(req.url).searchParams.get("scope") || undefined;
+    const expanded = expandMineScope(scopeParam, principal);
 
-    if (pages.length === 0) {
-      return new Response(JSON.stringify({ error: "No wiki pages to export" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
+    let pages = await listReadableWikiPages(principal);
+    let vaultName = "yopedia";
+    if (expanded) {
+      const resolved = await resolveScope(expanded);
+      const scopeSet = new Set(resolved?.slugs ?? []);
+      pages = pages.filter((p) => scopeSet.has(p.slug));
+      const ownerMatch = expanded.match(/^owner:(.+)$/);
+      if (ownerMatch) vaultName = ownerMatch[1].trim() || vaultName;
     }
 
-    // Build a map of filename → compressed Uint8Array content
+    if (pages.length === 0) {
+      return new Response(
+        JSON.stringify({ error: "No wiki pages to export" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const storage = getStorage();
     const files: Record<string, Uint8Array> = {};
 
     for (const entry of pages) {
       const page = await readWikiPage(entry.slug);
       if (!page) continue;
 
-      const obsidianContent = convertToObsidianLinks(page.content);
-      files[`${entry.slug}.md`] = strToU8(obsidianContent);
+      const md = normalizeVaultAssetPaths(convertToObsidianLinks(page.content));
+      files[`${entry.slug}.md`] = strToU8(md);
+
+      // Bundle the page's binary assets (images) so the vault is self-contained.
+      let assetFiles: Awaited<ReturnType<typeof storage.listFiles>> = [];
+      try {
+        assetFiles = await storage.listFiles(rawRelPath(`assets/${entry.slug}`));
+      } catch (e) {
+        if (!isEnoent(e)) throw e;
+      }
+      for (const f of assetFiles) {
+        if (f.isDirectory) continue;
+        const data = await storage.readAsset(
+          rawRelPath(`assets/${entry.slug}/${f.name}`),
+        );
+        files[`assets/${entry.slug}/${f.name}`] = new Uint8Array(data);
+      }
     }
 
-    // Rebuild index.md from the readable pages only — the raw index file lists
-    // every page (including private ones the caller can't read).
+    // Rebuild index.md from the exported pages only (never list pages the
+    // caller can't read or that fall outside the scope).
     const indexLines = pages.map(
       (p) => `- [${p.title}](${p.slug}.md) — ${p.summary}`,
     );
@@ -46,19 +79,18 @@ export async function GET() {
       convertToObsidianLinks(`# Wiki Index\n\n${indexLines.join("\n")}\n`),
     );
 
-    // Create the zip synchronously (pure JS, no Node.js streams)
     const zipped = zipSync(files, { level: 9 });
 
     return new Response(zipped.buffer as ArrayBuffer, {
       headers: {
         "Content-Type": "application/zip",
-        "Content-Disposition": 'attachment; filename="yopedia-vault.zip"',
+        "Content-Disposition": `attachment; filename="${vaultName}-vault.zip"`,
       },
     });
   } catch (err) {
     return Response.json(
       { error: "Export failed", details: String(err) },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/wiki/export/route.ts
+++ b/src/app/api/wiki/export/route.ts
@@ -63,10 +63,14 @@ export async function GET(req: NextRequest) {
       }
       for (const f of assetFiles) {
         if (f.isDirectory) continue;
-        const data = await storage.readAsset(
-          rawRelPath(`assets/${entry.slug}/${f.name}`),
-        );
-        files[`assets/${entry.slug}/${f.name}`] = new Uint8Array(data);
+        try {
+          const data = await storage.readAsset(
+            rawRelPath(`assets/${entry.slug}/${f.name}`),
+          );
+          files[`assets/${entry.slug}/${f.name}`] = new Uint8Array(data);
+        } catch {
+          // Skip a single unreadable asset rather than fail the whole vault.
+        }
       }
     }
 
@@ -81,10 +85,18 @@ export async function GET(req: NextRequest) {
 
     const zipped = zipSync(files, { level: 9 });
 
+    // `vaultName` derives from the handle (user-controlled via ?scope=), so
+    // NEVER interpolate it raw into the header — a `"` would break the quoted
+    // filename. Sanitize to an ASCII-safe token for `filename=` and add an
+    // RFC 5987 `filename*` (percent-encoded) so unicode handles still display.
+    const fileBase = `${vaultName}-vault.zip`;
+    const asciiName =
+      `${vaultName.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "")}` ||
+      "yopedia";
     return new Response(zipped.buffer as ArrayBuffer, {
       headers: {
         "Content-Type": "application/zip",
-        "Content-Disposition": `attachment; filename="${vaultName}-vault.zip"`,
+        "Content-Disposition": `attachment; filename="${asciiName}-vault.zip"; filename*=UTF-8''${encodeURIComponent(fileBase)}`,
       },
     });
   } catch (err) {

--- a/src/app/u/[handle]/page.tsx
+++ b/src/app/u/[handle]/page.tsx
@@ -52,6 +52,13 @@ export default async function UserPage({
             >
               🕸 Graph this silo
             </Link>
+            {/* Plain anchor — this is a file download, not a route. */}
+            <a
+              href={`/api/wiki/export?scope=owner:${encodeURIComponent(handle)}`}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-foreground/10 px-3 py-1.5 text-sm text-foreground/70 hover:border-foreground/30 hover:text-foreground transition-colors"
+            >
+              ⬇ Download vault
+            </a>
           </div>
         )}
       </div>

--- a/src/lib/__tests__/export.test.ts
+++ b/src/lib/__tests__/export.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from "vitest";
-import { convertToObsidianLinks } from "../export";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { strFromU8, unzipSync } from "fflate";
+import { convertToObsidianLinks, normalizeVaultAssetPaths } from "../export";
+import { writeWikiPage, updateIndex, ensureDirectories } from "../wiki";
+import { serializeFrontmatter } from "../frontmatter";
+import { _resetStorage } from "../storage";
 
 describe("convertToObsidianLinks", () => {
   it("converts a basic internal link", () => {
@@ -61,5 +68,93 @@ tags: [ai, ml]
 
 See [[related|Related]].`;
     expect(convertToObsidianLinks(input)).toBe(expected);
+  });
+});
+
+describe("normalizeVaultAssetPaths", () => {
+  it("rewrites raw/assets image refs to vault-relative assets/", () => {
+    expect(
+      normalizeVaultAssetPaths("![x](raw/assets/p/img.png)"),
+    ).toBe("![x](assets/p/img.png)");
+  });
+  it("leaves already-vault-relative and absolute refs untouched", () => {
+    expect(normalizeVaultAssetPaths("![x](assets/p/img.png)")).toBe(
+      "![x](assets/p/img.png)",
+    );
+    expect(normalizeVaultAssetPaths("![x](https://e.com/i.png)")).toBe(
+      "![x](https://e.com/i.png)",
+    );
+  });
+});
+
+describe("GET /api/wiki/export — scoped vault", () => {
+  let tmpDir: string;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "export-test-"));
+    for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+    process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+    process.env.RAW_DIR = path.join(tmpDir, "raw");
+    process.env.DATA_DIR = tmpDir;
+    _resetStorage();
+    await ensureDirectories();
+  });
+
+  afterEach(async () => {
+    for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    _resetStorage();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function exportZip(scope?: string): Promise<Record<string, string>> {
+    const { GET } = await import("../../app/api/wiki/export/route");
+    const url = `http://localhost/api/wiki/export${scope ? `?scope=${encodeURIComponent(scope)}` : ""}`;
+    const res = await GET(new Request(url) as never);
+    if (res.status !== 200) return {}; // e.g. 400 "no pages" — empty vault
+    const buf = new Uint8Array(await res.arrayBuffer());
+    const files = unzipSync(buf);
+    const out: Record<string, string> = {};
+    for (const [name, data] of Object.entries(files)) out[name] = strFromU8(data);
+    return out;
+  }
+
+  it("scopes the vault to one owner and excludes others' private pages", async () => {
+    await writeWikiPage(
+      "alice-pub",
+      serializeFrontmatter({ owner: "alice", visibility: "public" }, "# Alice Pub"),
+    );
+    await writeWikiPage(
+      "bob-priv",
+      serializeFrontmatter({ owner: "bob", visibility: "private" }, "# Bob Priv"),
+    );
+    await updateIndex([
+      { slug: "alice-pub", title: "Alice Pub", summary: "p" },
+      { slug: "bob-priv", title: "Bob Priv", summary: "s" },
+    ]);
+
+    const files = await exportZip("owner:alice");
+    expect(Object.keys(files).sort()).toEqual(["alice-pub.md", "index.md"]);
+    // An anonymous caller (tests have no principal) can never get bob's private
+    // page even by scoping to him.
+    const bobFiles = await exportZip("owner:bob");
+    expect(bobFiles["bob-priv.md"]).toBeUndefined();
+  });
+
+  it("converts internal links to wikilinks in the exported markdown", async () => {
+    await writeWikiPage(
+      "a",
+      serializeFrontmatter({ owner: "alice" }, "# A\n\nSee [B](b.md)."),
+    );
+    await writeWikiPage("b", serializeFrontmatter({ owner: "alice" }, "# B"));
+    await updateIndex([
+      { slug: "a", title: "A", summary: "" },
+      { slug: "b", title: "B", summary: "" },
+    ]);
+    const files = await exportZip("owner:alice");
+    expect(files["a.md"]).toContain("[[b|B]]");
   });
 });

--- a/src/lib/__tests__/export.test.ts
+++ b/src/lib/__tests__/export.test.ts
@@ -4,9 +4,9 @@ import os from "os";
 import path from "path";
 import { strFromU8, unzipSync } from "fflate";
 import { convertToObsidianLinks, normalizeVaultAssetPaths } from "../export";
-import { writeWikiPage, updateIndex, ensureDirectories } from "../wiki";
+import { writeWikiPage, updateIndex, ensureDirectories, rawRelPath } from "../wiki";
 import { serializeFrontmatter } from "../frontmatter";
-import { _resetStorage } from "../storage";
+import { getStorage, _resetStorage } from "../storage";
 
 describe("convertToObsidianLinks", () => {
   it("converts a basic internal link", () => {
@@ -156,5 +156,42 @@ describe("GET /api/wiki/export — scoped vault", () => {
     ]);
     const files = await exportZip("owner:alice");
     expect(files["a.md"]).toContain("[[b|B]]");
+  });
+
+  it("bundles a page's binary assets into the vault under assets/<slug>/", async () => {
+    await writeWikiPage(
+      "withimg",
+      serializeFrontmatter(
+        { owner: "alice" },
+        "# WithImg\n\n![pic](assets/withimg/pic.png)",
+      ),
+    );
+    await updateIndex([{ slug: "withimg", title: "WithImg", summary: "" }]);
+    await getStorage().writeAsset(
+      rawRelPath("assets/withimg/pic.png"),
+      new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer,
+    );
+
+    const files = await exportZip("owner:alice");
+    expect(Object.keys(files)).toContain("assets/withimg/pic.png");
+  });
+
+  it("sanitizes the handle in Content-Disposition (no header injection)", async () => {
+    // Owner with a quote: ownerToTenant keeps `"`, so the scope resolves — the
+    // filename must NOT contain the raw quote that would break the header.
+    await writeWikiPage(
+      "q",
+      serializeFrontmatter({ owner: 'alice"x' }, "# Q"),
+    );
+    await updateIndex([{ slug: "q", title: "Q", summary: "" }]);
+
+    const { GET } = await import("../../app/api/wiki/export/route");
+    const res = await GET(
+      new Request('http://localhost/api/wiki/export?scope=owner:alice"x') as never,
+    );
+    const cd = res.headers.get("content-disposition") ?? "";
+    expect(res.status).toBe(200);
+    expect(cd).toContain('filename="alice-x-vault.zip"'); // sanitized
+    expect(cd).not.toContain('alice"x-vault.zip'); // raw quote not injected
   });
 });

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -25,3 +25,14 @@ export function convertToObsidianLinks(content: string): string {
     (_match, title: string, slug: string) => `[[${slug}|${title}]]`,
   );
 }
+
+/**
+ * Rewrite a page's image references to vault-relative asset paths so images
+ * resolve in the exported vault. Stored sources are either `assets/<slug>/…`
+ * (already vault-relative) or `raw/assets/<slug>/…`; the latter is normalized to
+ * the former — where the export places the file. Absolute/`/api/assets` URLs are
+ * left untouched.
+ */
+export function normalizeVaultAssetPaths(content: string): string {
+  return content.replace(/\]\(raw\/assets\//g, "](assets/");
+}


### PR DESCRIPTION
## Phase 5b — "download my vault"

The folder-isolation payoff: each silo is now a **one-click, Obsidian-openable vault**.

- **`GET /api/wiki/export?scope=mine|owner:<handle>`** → just that silo's pages (unscoped still exports all readable). Reuses the P3 scope plumbing (`expandMineScope` + `resolveScope`); **readability-gated** so the scope only narrows the already-readable set — `?scope=owner:<other>` can't export another user's private pages. Zip named `<handle>-vault.zip`.
- **Assets included** — binary images bundled under `assets/<slug>/…` and image refs normalized (new pure `normalizeVaultAssetPaths`: `raw/assets/` → `assets/`) so they resolve in the vault. Pages keep Obsidian wikilinks; YAML frontmatter preserved (Obsidian reads it).
- **`/u/<handle>`** gets a **"⬇ Download vault"** action → `/api/wiki/export?scope=owner:<h>`.

### Tests
Scoped-export route tests (scoping + the privacy intersection + wikilink conversion) and `normalizeVaultAssetPaths`. Full suite green (2416). Smoke-tested: `yopedia-vault.zip` returns the scoped pages + `index.md`.

### Note
The export reads from flat (current source of truth), so the vault is always current regardless of silo sync state. After the P5a backfill, the on-disk `tenants/<handle>/` folder is an equivalent live mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)