### PR TITLE
yopedia: tenant silos P5c — delete-tenant (gated)

### DIFF
--- a/src/app/api/admin/tenant/[handle]/route.ts
+++ b/src/app/api/admin/tenant/[handle]/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { getServicePrincipal, getPrincipal } from "@/lib/auth";
+import { isOwnerHandle } from "@/lib/owner";
+import { tenantForOwner } from "@/lib/wiki";
+import { deleteTenant } from "@/lib/tenant-admin";
+import { decodeSlug } from "@/lib/slugify";
+import { getErrorMessage } from "@/lib/errors";
+import { logger } from "@/lib/logger";
+
+/**
+ * DELETE /api/admin/tenant/<handle>?confirm=<tenant>
+ *
+ * Hard-delete a tenant's entire content (see {@link deleteTenant}). Gated to:
+ *  - the service token (admin/ops),
+ *  - the site owner's session, OR
+ *  - the tenant's OWNER themselves (self-serve: deleting your own silo).
+ * Everyone else gets 403. The route authenticates itself, so it's exempt from
+ * the blanket write-gate (see middleware).
+ *
+ * Destructive + irreversible, so it requires an explicit `?confirm=<tenant>`
+ * matching the target tenant — otherwise 400, nothing deleted.
+ */
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ handle: string }> },
+) {
+  const { handle: encoded } = await params;
+  const handle = decodeSlug(encoded);
+  const tenant = tenantForOwner(handle);
+
+  const service = getServicePrincipal(req);
+  const principal = service ?? (await getPrincipal());
+  const isSelf = !!principal && tenantForOwner(principal.handle) === tenant;
+  if (!service && !isOwnerHandle(principal?.handle) && !isSelf) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const confirm = new URL(req.url).searchParams.get("confirm");
+  if (confirm !== tenant) {
+    return NextResponse.json(
+      {
+        error: `This permanently deletes tenant "${tenant}". Re-send with ?confirm=${tenant} to proceed.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    logger.warn(
+      "tenant-admin",
+      `deleteTenant "${tenant}" requested by ${principal?.handle ?? "service"}`,
+    );
+    const result = await deleteTenant(handle);
+    return NextResponse.json(result);
+  } catch (err) {
+    logger.error("tenant-admin", "deleteTenant failed", err);
+    return NextResponse.json({ error: getErrorMessage(err) }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/tenant/[handle]/route.ts
+++ b/src/app/api/admin/tenant/[handle]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getServicePrincipal, getPrincipal } from "@/lib/auth";
 import { isOwnerHandle } from "@/lib/owner";
-import { tenantForOwner } from "@/lib/wiki";
+import { tenantForOwner, DEFAULT_TENANT } from "@/lib/wiki";
 import { deleteTenant } from "@/lib/tenant-admin";
 import { decodeSlug } from "@/lib/slugify";
 import { getErrorMessage } from "@/lib/errors";
@@ -30,9 +30,21 @@ export async function DELETE(
 
   const service = getServicePrincipal(req);
   const principal = service ?? (await getPrincipal());
+  // "self" = same TENANT, not same handle — distinct handles that normalize to
+  // the same tenant (e.g. "a.b"/"a-b") share a silo and can self-delete it.
   const isSelf = !!principal && tenantForOwner(principal.handle) === tenant;
-  if (!service && !isOwnerHandle(principal?.handle) && !isSelf) {
+  const isAdmin = !!service || isOwnerHandle(principal?.handle);
+  if (!isAdmin && !isSelf) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // The platform tenant holds all seed/shared content — only admins (service
+  // token or site owner) may delete it, never a self-serve caller.
+  if (tenant === DEFAULT_TENANT && !isAdmin) {
+    return NextResponse.json(
+      { error: "Forbidden: the platform tenant can only be deleted by an admin." },
+      { status: 403 },
+    );
   }
 
   const confirm = new URL(req.url).searchParams.get("confirm");
@@ -51,7 +63,11 @@ export async function DELETE(
       `deleteTenant "${tenant}" requested by ${principal?.handle ?? "service"}`,
     );
     const result = await deleteTenant(handle);
-    return NextResponse.json(result);
+    // 200 = fully deleted; 207 = partial (some pages failed — see `errors`), so
+    // the caller doesn't read a clean 200 as complete success.
+    return NextResponse.json(result, {
+      status: result.errors.length > 0 ? 207 : 200,
+    });
   } catch (err) {
     logger.error("tenant-admin", "deleteTenant failed", err);
     return NextResponse.json({ error: getErrorMessage(err) }, { status: 500 });

--- a/src/lib/__tests__/tenant-admin.test.ts
+++ b/src/lib/__tests__/tenant-admin.test.ts
@@ -145,4 +145,15 @@ describe("DELETE /api/admin/tenant/[handle] — gating", () => {
     expect((await res.json()).deletedPages).toBe(1);
     expect(await readWikiPage("alice-1")).toBeNull();
   });
+
+  it("admins (service token) CAN delete the platform yopedia tenant", async () => {
+    process.env.YOPEDIA_SERVICE_TOKEN = "tok";
+    process.env.YOPEDIA_SERVICE_PRINCIPAL = "yopedia";
+    await write("seed", {}); // ownerless → yopedia
+
+    const res = await del("yopedia", { token: "tok", confirm: "yopedia" });
+    expect(res.status).toBe(200);
+    expect((await res.json()).deletedPages).toBe(1);
+    expect(await readWikiPage("seed")).toBeNull();
+  });
 });

--- a/src/lib/__tests__/tenant-admin.test.ts
+++ b/src/lib/__tests__/tenant-admin.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { deleteTenant } from "../tenant-admin";
+import { writeWikiPageWithSideEffects } from "../lifecycle";
+import { readWikiPage, ensureDirectories } from "../wiki";
+import { serializeFrontmatter } from "../frontmatter";
+import { getStorage, _resetStorage } from "../storage";
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  "WIKI_DIR",
+  "RAW_DIR",
+  "DATA_DIR",
+  "YOPEDIA_SERVICE_TOKEN",
+  "YOPEDIA_SERVICE_PRINCIPAL",
+];
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tenant-admin-test-"));
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  delete process.env.YOPEDIA_SERVICE_TOKEN;
+  delete process.env.YOPEDIA_SERVICE_PRINCIPAL;
+  _resetStorage();
+  await ensureDirectories();
+});
+
+afterEach(async () => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function write(
+  slug: string,
+  fm: Record<string, string | string[]>,
+  body = `# ${slug}`,
+) {
+  await writeWikiPageWithSideEffects({
+    slug,
+    title: slug,
+    content: serializeFrontmatter(fm, body),
+    summary: "s",
+    logOp: "ingest",
+    crossRefSource: null,
+  });
+}
+
+describe("deleteTenant", () => {
+  it("deletes only the tenant's OWNED pages (flat + silo) and its folder", async () => {
+    await write("alice-1", { owner: "alice" });
+    await write("alice-2", { owner: "alice" });
+    await write("bob-1", { owner: "bob" });
+    await write("seed", {}); // ownerless → yopedia
+
+    // Silo was mirrored on write (P5a).
+    expect(await getStorage().fileExists("tenants/alice/wiki/alice-1.md")).toBe(
+      true,
+    );
+
+    const result = await deleteTenant("alice");
+    expect(result.tenant).toBe("alice");
+    expect(result.deletedPages).toBe(2);
+    expect(result.errors).toEqual([]);
+
+    // alice's pages gone (flat + silo); others untouched.
+    expect(await readWikiPage("alice-1")).toBeNull();
+    expect(await readWikiPage("alice-2")).toBeNull();
+    expect(await readWikiPage("bob-1")).not.toBeNull();
+    expect(await readWikiPage("seed")).not.toBeNull();
+    expect(
+      await getStorage().fileExists("tenants/alice/wiki/alice-1.md"),
+    ).toBe(false);
+    expect(await getStorage().fileExists("tenants/bob/wiki/bob-1.md")).toBe(
+      true,
+    );
+  });
+
+  it("never deletes a page the handle only CONTRIBUTED to (owned by another)", async () => {
+    // Owned by bob, but alice is a contributor — deleting tenant alice must
+    // leave it intact (it belongs to bob's silo).
+    await write("bobs-page", { owner: "bob", contributors: ["alice"] });
+
+    const result = await deleteTenant("alice");
+    expect(result.deletedPages).toBe(0);
+    expect(await readWikiPage("bobs-page")).not.toBeNull();
+  });
+
+  it("ownerless/seed pages belong to the yopedia tenant", async () => {
+    await write("seed-a", {});
+    await write("seed-b", { owner: "yopedia" });
+    await write("alice-x", { owner: "alice" });
+
+    const result = await deleteTenant("yopedia");
+    expect(result.deletedPages).toBe(2); // both seed pages
+    expect(await readWikiPage("alice-x")).not.toBeNull();
+  });
+});
+
+describe("DELETE /api/admin/tenant/[handle] — gating", () => {
+  async function del(
+    handle: string,
+    opts: { confirm?: string; token?: string } = {},
+  ) {
+    const { DELETE } = await import(
+      "../../app/api/admin/tenant/[handle]/route"
+    );
+    const url = `http://localhost/api/admin/tenant/${handle}${opts.confirm ? `?confirm=${opts.confirm}` : ""}`;
+    const headers: Record<string, string> = {};
+    if (opts.token) headers.Authorization = `Bearer ${opts.token}`;
+    return DELETE(new Request(url, { method: "DELETE", headers }), {
+      params: Promise.resolve({ handle }),
+    });
+  }
+
+  it("403 for an unauthenticated caller (even with confirm)", async () => {
+    const res = await del("alice", { confirm: "alice" });
+    expect(res.status).toBe(403);
+  });
+
+  it("400 when authed but confirmation is missing/wrong", async () => {
+    process.env.YOPEDIA_SERVICE_TOKEN = "tok";
+    process.env.YOPEDIA_SERVICE_PRINCIPAL = "yopedia";
+    expect((await del("alice", { token: "tok" })).status).toBe(400);
+    expect((await del("alice", { token: "tok", confirm: "nope" })).status).toBe(
+      400,
+    );
+  });
+
+  it("deletes with the service token + matching confirm", async () => {
+    process.env.YOPEDIA_SERVICE_TOKEN = "tok";
+    process.env.YOPEDIA_SERVICE_PRINCIPAL = "yopedia";
+    await write("alice-1", { owner: "alice" });
+
+    const res = await del("alice", { token: "tok", confirm: "alice" });
+    expect(res.status).toBe(200);
+    expect((await res.json()).deletedPages).toBe(1);
+    expect(await readWikiPage("alice-1")).toBeNull();
+  });
+});

--- a/src/lib/tenant-admin.ts
+++ b/src/lib/tenant-admin.ts
@@ -2,7 +2,7 @@
  * Per-tenant admin ops (tenant-silos P5c).
  */
 
-import { listWikiPages, tenantForOwner } from "./wiki";
+import { listWikiPages, tenantForOwner, validateTenant } from "./wiki";
 import { deleteWikiPage } from "./lifecycle";
 import { getStorage } from "./storage";
 import { isEnoent } from "./errors";
@@ -27,6 +27,10 @@ export interface DeleteTenantResult {
  */
 export async function deleteTenant(handle: string): Promise<DeleteTenantResult> {
   const tenant = tenantForOwner(handle);
+  // Defense in depth before an irreversible prefix `rm -rf`: ownerToTenant
+  // already strips path-unsafe chars, but the storage layer has no traversal
+  // guard of its own, so assert the tenant can't contain a separator/`..`.
+  validateTenant(tenant);
   const errors: string[] = [];
 
   // Owner-only slugs — NOT contributors, so we never delete another tenant's

--- a/src/lib/tenant-admin.ts
+++ b/src/lib/tenant-admin.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-tenant admin ops (tenant-silos P5c).
+ */
+
+import { listWikiPages, tenantForOwner } from "./wiki";
+import { deleteWikiPage } from "./lifecycle";
+import { getStorage } from "./storage";
+import { isEnoent } from "./errors";
+import { logger } from "./logger";
+
+export interface DeleteTenantResult {
+  tenant: string;
+  /** Pages hard-deleted (owned by this tenant). */
+  deletedPages: number;
+  errors: string[];
+}
+
+/**
+ * Hard-delete a tenant's entire content: every page it OWNS — flat file, the
+ * per-page silo mirror, revisions, discussion, embeddings, and commons entry
+ * (all via {@link deleteWikiPage}) — plus the tenant's silo folder. Owner is
+ * matched by TENANT, so ownerless/seed pages belong to "yopedia". Pages the
+ * handle only CONTRIBUTED to (owned by another tenant) are never touched.
+ *
+ * Best-effort: a per-page failure is collected in `errors` and the rest proceed,
+ * so one bad page can't strand the deletion.
+ */
+export async function deleteTenant(handle: string): Promise<DeleteTenantResult> {
+  const tenant = tenantForOwner(handle);
+  const errors: string[] = [];
+
+  // Owner-only slugs — NOT contributors, so we never delete another tenant's
+  // page. (index/log are infrastructure, not pages.)
+  const owned = (await listWikiPages())
+    .filter(
+      (p) =>
+        p.slug !== "index" &&
+        p.slug !== "log" &&
+        tenantForOwner(p.owner) === tenant,
+    )
+    .map((p) => p.slug);
+
+  let deletedPages = 0;
+  for (const slug of owned) {
+    try {
+      await deleteWikiPage(slug);
+      deletedPages++;
+    } catch (e) {
+      errors.push(`delete ${slug}: ${String(e)}`);
+      logger.warn("tenant-admin", `failed to delete "${slug}"`, e);
+    }
+  }
+
+  // Remove the silo folder itself (any orphans + the now-empty tree). Fail-soft.
+  try {
+    await getStorage().deleteDirectory(`tenants/${tenant}`);
+  } catch (e) {
+    if (!isEnoent(e)) {
+      errors.push(`silo dir: ${String(e)}`);
+      logger.warn("tenant-admin", `failed to remove silo dir for "${tenant}"`, e);
+    }
+  }
+
+  return { tenant, deletedPages, errors };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,9 +28,16 @@ const IN_ROUTE_AUTH_PATHS = new Set([
   "/api/admin/migrate",
 ]);
 const AGENT_INGEST_RE = /^\/api\/agents\/[^/]+\/ingest$/;
+// Admin tenant delete: authenticated in-route by the service token, the site
+// owner, or the tenant's own owner (it 403s everyone else).
+const ADMIN_TENANT_RE = /^\/api\/admin\/tenant\/[^/]+$/;
 
 function authenticatesInRoute(pathname: string): boolean {
-  return IN_ROUTE_AUTH_PATHS.has(pathname) || AGENT_INGEST_RE.test(pathname);
+  return (
+    IN_ROUTE_AUTH_PATHS.has(pathname) ||
+    AGENT_INGEST_RE.test(pathname) ||
+    ADMIN_TENANT_RE.test(pathname)
+  );
 }
 
 export default clerkMiddleware(async (auth, req) => {


### PR DESCRIPTION
## Phase 5c — delete-tenant

Hard-delete a tenant's entire content + its silo folder. **API/admin only** this phase (no self-serve UI yet). **Quotas deferred** until Clerk Billing (P4) gives a real free/paid split.

- **`deleteTenant(handle)`** (`src/lib/tenant-admin.ts`) — deletes every page the tenant **owns** (matched by *tenant*, so ownerless/seed → `yopedia`) via `deleteWikiPage` (flat + per-page silo + revisions + discuss + embeddings + commons), then removes the `tenants/<tenant>/` folder. **Owner-only** — pages the handle merely *contributed* to (owned by another tenant) are never touched. Best-effort: a per-page failure is collected, the rest proceed.
- **`DELETE /api/admin/tenant/<handle>?confirm=<tenant>`** — gated to the **service token**, the **site owner**, or the **tenant's own owner** (self-serve); 403 otherwise. Destructive → requires `?confirm=<tenant>` matching the target, else 400 and nothing is deleted. Middleware exempts the path (it authenticates in-route).

### Tests
`deleteTenant` (owned-only, contributor-safe, ownerless→yopedia) + route gating (403 unauth / 400 no-confirm / 200 service-token+confirm). Full suite green (2433).

🤖 Generated with [Claude Code](https://claude.com/claude-code)