### PR TITLE
yopedia: homepage declutter + single SSO sign-in + owner-only settings

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { OnboardingWizard } from "@/components/OnboardingWizard";
-import { WikiPageCard } from "@/components/WikiPageCard";
 import { ContributorBadge } from "@/components/ContributorBadge";
 import { HomeAsk } from "@/components/HomeAsk";
 import { Trail } from "@/components/Trail";
@@ -25,10 +24,6 @@ export default async function Home() {
   const pageCount = pages.length;
   const sourceCount = pages.reduce((n, p) => n + (p.sourceCount ?? 0), 0);
   const contributorCount = contributors.length;
-
-  const recent = [...pages]
-    .sort((a, b) => (b.updated ?? "").localeCompare(a.updated ?? ""))
-    .slice(0, 6);
 
   const topContributors = contributors.slice(0, 6);
 
@@ -93,24 +88,6 @@ export default async function Home() {
                 </p>
               )}
             </div>
-          </section>
-
-          {/* Recently accumulated */}
-          <section className="mt-16">
-            <div className="flex items-baseline justify-between">
-              <h2 className="label">recently accumulated</h2>
-              <Link
-                href="/wiki"
-                className="receipt text-xs text-muted hover:text-foreground transition-colors"
-              >
-                browse all →
-              </Link>
-            </div>
-            <ul className="mt-4 grid gap-3 sm:grid-cols-2">
-              {recent.map((p) => (
-                <WikiPageCard key={p.slug} page={p} />
-              ))}
-            </ul>
           </section>
 
           {/* Contributors (humans; agents shown distinctly in the trail) */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,8 @@
 import Link from "next/link";
-import { StatusBadge } from "@/components/StatusBadge";
 import { OnboardingWizard } from "@/components/OnboardingWizard";
 import { WikiPageCard } from "@/components/WikiPageCard";
 import { ContributorBadge } from "@/components/ContributorBadge";
-import { TagChip } from "@/components/TagChip";
 import { HomeAsk } from "@/components/HomeAsk";
-import { HomeGraph } from "@/components/HomeGraph";
 import { Trail } from "@/components/Trail";
 import { listCommonsPages } from "@/lib/commons";
 import { listContributors } from "@/lib/contributors";
@@ -32,15 +29,6 @@ export default async function Home() {
   const recent = [...pages]
     .sort((a, b) => (b.updated ?? "").localeCompare(a.updated ?? ""))
     .slice(0, 6);
-
-  const tagFreq = new Map<string, number>();
-  for (const p of pages) {
-    for (const t of p.tags ?? []) tagFreq.set(t, (tagFreq.get(t) ?? 0) + 1);
-  }
-  const topTags = [...tagFreq.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 10)
-    .map(([tag, count]) => ({ tag, count }));
 
   const topContributors = contributors.slice(0, 6);
 
@@ -81,9 +69,6 @@ export default async function Home() {
             <span className="font-semibold text-foreground">{contributorCount}</span>{" "}
             {contributorCount === 1 ? "contributor" : "contributors"}
           </span>
-          <span className="ml-auto">
-            <StatusBadge />
-          </span>
         </div>
       )}
 
@@ -93,29 +78,20 @@ export default async function Home() {
         </div>
       ) : (
         <>
-          {/* The lab running: live trail + the substrate */}
-          <section className="mt-16 grid gap-10 lg:grid-cols-5">
-            <div className="lg:col-span-3">
-              <h2 className="label">the trail</h2>
-              <p className="mt-1 text-sm text-muted">
-                Every ingest and edit, humans and agents alike.
-              </p>
-              <div className="mt-4">
-                {trail.length > 0 ? (
-                  <Trail events={trail} />
-                ) : (
-                  <p className="text-sm text-muted">
-                    Nothing yet — ingest a source to start the trail.
-                  </p>
-                )}
-              </div>
-            </div>
-            <div className="lg:col-span-2">
-              <h2 className="label">the substrate</h2>
-              <p className="mt-1 text-sm text-muted">Pages, interlinked.</p>
-              <div className="mt-4">
-                <HomeGraph />
-              </div>
+          {/* The lab running: the live trail */}
+          <section className="mt-16">
+            <h2 className="label">the trail</h2>
+            <p className="mt-1 text-sm text-muted">
+              Every ingest and edit, humans and agents alike.
+            </p>
+            <div className="mt-4">
+              {trail.length > 0 ? (
+                <Trail events={trail} />
+              ) : (
+                <p className="text-sm text-muted">
+                  Nothing yet — ingest a source to start the trail.
+                </p>
+              )}
             </div>
           </section>
 
@@ -136,23 +112,6 @@ export default async function Home() {
               ))}
             </ul>
           </section>
-
-          {/* Browse by topic */}
-          {topTags.length >= 3 && (
-            <section className="mt-12">
-              <h2 className="label">browse by topic</h2>
-              <div className="mt-4 flex flex-wrap gap-2">
-                {topTags.map(({ tag, count }) => (
-                  <TagChip
-                    key={tag}
-                    tag={tag}
-                    count={count}
-                    href={`/wiki?scope=all&tag=${encodeURIComponent(tag)}`}
-                  />
-                ))}
-              </div>
-            </section>
-          )}
 
           {/* Contributors (humans; agents shown distinctly in the trail) */}
           {contributorCount >= 2 && (

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -1,0 +1,20 @@
+import { notFound } from "next/navigation";
+import { getPrincipal } from "@/lib/auth";
+import { isOwnerHandle } from "@/lib/owner";
+
+/**
+ * Settings is an admin (site-owner) surface — it exposes the LLM provider/model
+ * + embedding config. Gate the whole `/settings` route to the owner; everyone
+ * else gets a 404 (don't even reveal it exists). The page itself is a client
+ * component, so the gate lives in this server layout. The entry point is the
+ * owner-only "Settings" item in the user menu (see NavHeader).
+ */
+export default async function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const principal = await getPrincipal();
+  if (!isOwnerHandle(principal?.handle)) notFound();
+  return <>{children}</>;
+}

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -6,6 +6,7 @@ import { slugsForOwner } from "@/lib/search";
 import { getDiscussionStatsForSlugs } from "@/lib/talk";
 import { getPrincipal } from "@/lib/auth";
 import { WikiIndexClient } from "@/components/WikiIndexClient";
+import { TagChip } from "@/components/TagChip";
 
 export default async function WikiIndex({
   searchParams,
@@ -42,7 +43,18 @@ export default async function WikiIndex({
     pages = await listCommonsPages();
   }
 
-  // Optional topic filter (from the homepage "Browse by topic" chips).
+  // Top topics across the current scope (computed BEFORE the tag filter so the
+  // chips always show every available topic). Drives the "browse by topic" row.
+  const tagFreq = new Map<string, number>();
+  for (const p of pages) {
+    for (const t of p.tags ?? []) tagFreq.set(t, (tagFreq.get(t) ?? 0) + 1);
+  }
+  const topTags = [...tagFreq.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 14)
+    .map(([t, count]) => ({ tag: t, count }));
+
+  // Optional topic filter (from a "browse by topic" chip).
   if (tag) {
     pages = pages.filter((p) => (p.tags ?? []).includes(tag));
   }
@@ -93,6 +105,23 @@ export default async function WikiIndex({
           All
         </Link>
       </div>
+
+      {/* Browse by topic — filter the current scope by tag. */}
+      {topTags.length >= 3 && !tag && (
+        <div className="mb-6">
+          <h2 className="label mb-2">browse by topic</h2>
+          <div className="flex flex-wrap gap-2">
+            {topTags.map(({ tag: t, count }) => (
+              <TagChip
+                key={t}
+                tag={t}
+                count={count}
+                href={`/wiki?scope=${encodeURIComponent(effectiveScope)}&tag=${encodeURIComponent(t)}`}
+              />
+            ))}
+          </div>
+        </div>
+      )}
 
       {tag && (
         <div className="mb-4 flex items-center gap-2 text-sm text-foreground/60">

--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -6,7 +6,6 @@ import { useState, useEffect, useRef } from "react";
 import { Show, SignInButton, UserButton, useUser } from "@clerk/nextjs";
 import { GlobalSearch } from "./GlobalSearch";
 import { ThemeToggle } from "./ThemeToggle";
-import { Logo } from "./Logo";
 import { isOwnerHandle } from "@/lib/owner";
 
 // Primary actions — shown to everyone, always in the bar.
@@ -83,8 +82,11 @@ export function NavHeader() {
   return (
     <header className="sticky top-0 z-50 bg-background border-b border-border shadow-sm">
       <nav aria-label="Main navigation" className="mx-auto flex h-14 max-w-5xl items-center justify-between px-6">
-        <Link href="/" className="hover:opacity-90 transition-opacity">
-          <Logo />
+        <Link
+          href="/"
+          className="text-lg font-bold tracking-tight text-foreground hover:opacity-90 transition-opacity"
+        >
+          yopedia
         </Link>
 
         {/* Desktop nav */}

--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -3,13 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState, useEffect, useRef } from "react";
-import {
-  Show,
-  SignInButton,
-  SignUpButton,
-  UserButton,
-  useUser,
-} from "@clerk/nextjs";
+import { Show, SignInButton, UserButton, useUser } from "@clerk/nextjs";
 import { GlobalSearch } from "./GlobalSearch";
 import { ThemeToggle } from "./ThemeToggle";
 import { Logo } from "./Logo";
@@ -211,16 +205,13 @@ export function NavHeader() {
           <li className="mx-1 h-4 w-px bg-foreground/10" aria-hidden="true" />
           <li className="flex items-center gap-2">
             <Show when="signed-out">
+              {/* SSO only: a single button — Clerk auto-creates the account on
+                  first "Continue with X", so a separate sign-up is redundant. */}
               <SignInButton mode="modal">
-                <button className="rounded-md px-3 py-1.5 text-sm text-foreground/60 hover:text-foreground hover:bg-foreground/5 transition-colors">
-                  Sign in
+                <button className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-colors">
+                  Sign in with X
                 </button>
               </SignInButton>
-              <SignUpButton mode="modal">
-                <button className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-colors">
-                  Sign up
-                </button>
-              </SignUpButton>
             </Show>
             <Show when="signed-in">
               <UserButton>
@@ -345,11 +336,8 @@ export function NavHeader() {
           <div className="px-6 py-2 flex items-center gap-3 text-sm">
             <Show when="signed-out">
               <SignInButton mode="modal">
-                <button className="text-foreground/60 hover:text-foreground">Sign in</button>
+                <button className="font-medium text-accent">Sign in with X</button>
               </SignInButton>
-              <SignUpButton mode="modal">
-                <button className="font-medium text-accent">Sign up</button>
-              </SignUpButton>
             </Show>
             <Show when="signed-in">
               <UserButton />

--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -25,7 +25,10 @@ const secondaryLinks = [
 // Owner-only admin tools (also hard-gated server-side).
 const ownerLinks = [{ href: "/lint", label: "Lint" }];
 
-const utilityLinks = [{ href: "/settings", label: "Settings" }];
+// Settings is owner-only (admin) and lives under the user menu (UserButton),
+// not the public nav — so this is empty. Kept as the seam for any future
+// always-visible utility link.
+const utilityLinks: { href: string; label: string }[] = [];
 
 // Every link that can be "active" — used to highlight the matching nav item.
 const ALL_LINKS = [...primaryLinks, ...secondaryLinks, ...ownerLinks, ...utilityLinks];
@@ -217,13 +220,22 @@ export function NavHeader() {
             </Show>
             <Show when="signed-in">
               <UserButton>
-                {profileHref && (
+                {(profileHref || isOwner) && (
                   <UserButton.MenuItems>
-                    <UserButton.Link
-                      label="My pages"
-                      labelIcon={<span aria-hidden>📄</span>}
-                      href={profileHref}
-                    />
+                    {profileHref && (
+                      <UserButton.Link
+                        label="My pages"
+                        labelIcon={<span aria-hidden>📄</span>}
+                        href={profileHref}
+                      />
+                    )}
+                    {isOwner && (
+                      <UserButton.Link
+                        label="Settings"
+                        labelIcon={<span aria-hidden>⚙️</span>}
+                        href="/settings"
+                      />
+                    )}
                   </UserButton.MenuItems>
                 )}
               </UserButton>


### PR DESCRIPTION
A batch of front-of-house cleanups.

### Auth
- **Single "Sign in with X"** — with X SSO, Clerk auto-creates the account on first sign-in, so the separate **Sign up** button was redundant. Collapsed to one button (desktop + mobile); dropped `SignUpButton`.

### Homepage
- **Logo** → plain **"yopedia"** wordmark (dropped the node-constellation glyph).
- **Removed the substrate graph**; "the trail" is now full-width.
- **Removed the "Connected: <provider>" status badge** (it already lives on `/settings`).
- **Dropped "recently accumulated"** — it duplicated the trail; `/wiki` covers the page list. The **trail** is the single "what's happening" surface now.
- **"browse by topic" moved to `/wiki`** (the browse page), computed from the current scope, preserving scope in the link.

### Settings → admin-only, under the profile
- **`/settings` is gated to the site owner** via a server `settings/layout.tsx` (404s everyone else — same pattern as `/lint`). It exposes LLM provider/model config, so it's admin-only.
- **Settings moved off the public nav** into the **owner-only user menu** (UserButton → "⚙️ Settings", beside "My pages").

Build green; full suite unaffected (UI + a server gate). `/settings` content fully gated (verified: no settings UI served to non-owners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)