### PR TITLE
yopedia: canonical concept resolver — converge ingests onto one accumulating page

### DIFF
--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -9,6 +9,8 @@ import {
   reingest,
   buildIngestSystemPrompt,
   chunkText,
+  parseConceptMarker,
+  parseDisputedMarker,
 } from "../ingest";
 import { slugify } from "../slugify";
 import { loadPageConventions } from "../schema";
@@ -26,13 +28,31 @@ import { MAX_LLM_INPUT_CHARS } from "../constants";
 import { listWikiPages, readWikiPage, writeWikiPage, readWikiPageWithFrontmatter } from "../wiki";
 import { resetSourceIndex } from "../source-index";
 import { resetAliasIndex } from "../alias-index";
+import { hasEmbeddingSupport, searchByVector } from "../embeddings";
 import type { IndexEntry } from "../types";
+
+const mockedHasEmbeddingSupport = vi.mocked(hasEmbeddingSupport);
+const mockedSearchByVector = vi.mocked(searchByVector);
 
 // Mock the LLM module so ingest never calls the real API
 vi.mock("../llm", () => ({
   hasLLMKey: vi.fn(() => false),
   callLLM: vi.fn(),
 }));
+
+// Partial-mock embeddings: keep every real export (contentHash, the no-op
+// embed/upsert behaviour, etc.) but make `hasEmbeddingSupport` and
+// `searchByVector` overridable so the concept resolver's SEMANTIC step (layer 3)
+// can be exercised. Defaults delegate to the real impls, so non-embedding tests
+// behave exactly as before (no provider → support false → semantic step skipped).
+vi.mock("../embeddings", async (orig) => {
+  const actual = await orig<typeof import("../embeddings")>();
+  return {
+    ...actual,
+    hasEmbeddingSupport: vi.fn(actual.hasEmbeddingSupport),
+    searchByVector: vi.fn(actual.searchByVector),
+  };
+});
 
 // Mock unpdf for PDF extraction tests
 const mockIngestExtractText = vi.fn();
@@ -1582,10 +1602,410 @@ describe("schema-aware ingest prompt", () => {
     // intact — graceful degradation rather than a crash on a fresh clone.
     const prompt = await buildIngestSystemPrompt();
     expect(prompt).toContain("You are a wiki editor");
-    expect(prompt).toContain("Output pure markdown and nothing else");
+    expect(prompt).toContain("then pure markdown, and nothing else");
+    // Asks the LLM to emit the leading CONCEPT marker (drives concept-slug
+    // convergence — see parseConceptMarker).
+    expect(prompt).toContain("CONCEPT: <canonical concept name>");
     // Fidelity section: the prompt asks for a Details section that preserves
     // substantive source content (not just a thin summary).
     expect(prompt).toContain("## Details");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseConceptMarker — pull the leading CONCEPT line out of synthesis output
+// ---------------------------------------------------------------------------
+
+describe("parseConceptMarker", () => {
+  it("extracts the concept and strips the marker line from the body", () => {
+    const { concept, aliases, body } = parseConceptMarker(
+      "CONCEPT: Transformer\n\n# Transformer\n\n## Summary\n\nAttention.",
+    );
+    expect(concept).toBe("Transformer");
+    expect(aliases).toEqual([]);
+    expect(body).toBe("# Transformer\n\n## Summary\n\nAttention.");
+    expect(body).not.toContain("CONCEPT:");
+  });
+
+  it("parses the ALIASES line into a synonym list and strips both headers", () => {
+    const { concept, aliases, body } = parseConceptMarker(
+      "CONCEPT: Retrieval-Augmented Generation\nALIASES: RAG, retrieval augmentation; RAG pipeline\n\n# RAG\n\nBody.",
+    );
+    expect(concept).toBe("Retrieval-Augmented Generation");
+    expect(aliases).toEqual(["RAG", "retrieval augmentation", "RAG pipeline"]);
+    expect(body).toBe("# RAG\n\nBody.");
+    expect(body).not.toContain("ALIASES:");
+  });
+
+  it("treats ALIASES: none as no aliases", () => {
+    const { concept, aliases, body } = parseConceptMarker(
+      "CONCEPT: Backpropagation\nALIASES: none\n\n# Backpropagation\n",
+    );
+    expect(concept).toBe("Backpropagation");
+    expect(aliases).toEqual([]);
+    expect(body).toBe("# Backpropagation\n");
+  });
+
+  it("returns concept '' and the unchanged body when no marker is present", () => {
+    const raw = "# Plain Page\n\n## Summary\n\nNo marker here.";
+    const { concept, aliases, body } = parseConceptMarker(raw);
+    expect(concept).toBe("");
+    expect(aliases).toEqual([]);
+    expect(body).toBe(raw);
+  });
+
+  it("is case-insensitive and tolerates leading whitespace / a BOM", () => {
+    const { concept, body } = parseConceptMarker(
+      "﻿  concept:   Self-Attention  \n# Title",
+    );
+    expect(concept).toBe("Self-Attention");
+    expect(body).toBe("# Title");
+  });
+
+  it("handles CRLF line endings", () => {
+    const { concept, body } = parseConceptMarker(
+      "CONCEPT: RAG\r\n\r\n# RAG\r\n",
+    );
+    expect(concept).toBe("RAG");
+    expect(body).toBe("# RAG\r\n");
+  });
+
+  it("only consumes a marker on the FIRST line, not mid-body", () => {
+    const raw = "# Title\n\nThe line CONCEPT: not-a-marker appears in prose.";
+    const { concept, body } = parseConceptMarker(raw);
+    expect(concept).toBe("");
+    expect(body).toBe(raw);
+  });
+});
+
+describe("parseDisputedMarker", () => {
+  it("detects a leading DISPUTED: yes line and strips it", () => {
+    const { disputed, body } = parseDisputedMarker(
+      "DISPUTED: yes\n\n# Topic\n\nBoth views.",
+    );
+    expect(disputed).toBe(true);
+    expect(body).toBe("# Topic\n\nBoth views.");
+    expect(body).not.toContain("DISPUTED:");
+  });
+
+  it("returns disputed=false and the unchanged body when no marker", () => {
+    const raw = "# Topic\n\nA reconciled, undisputed page.";
+    const { disputed, body } = parseDisputedMarker(raw);
+    expect(disputed).toBe(false);
+    expect(body).toBe(raw);
+  });
+
+  it("does not trip on the word disputed appearing mid-body", () => {
+    const raw = "# Topic\n\nThe sources are DISPUTED: yes, in prose.";
+    const { disputed, body } = parseDisputedMarker(raw);
+    expect(disputed).toBe(false);
+    expect(body).toBe(raw);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ingest — concept-slug convergence (content-derived slug from CONCEPT marker)
+// ---------------------------------------------------------------------------
+
+describe("ingest — concept-slug convergence", () => {
+  beforeEach(() => {
+    resetSourceIndex();
+    resetAliasIndex();
+    mockedHasLLMKey.mockReturnValue(true);
+  });
+  afterEach(() => {
+    mockedHasLLMKey.mockReturnValue(false);
+    mockedCallLLM.mockReset();
+  });
+
+  it("derives the page slug from the CONCEPT marker, not the title", async () => {
+    mockedCallLLM.mockResolvedValue(
+      "CONCEPT: Transformer\n\n# Transformer\n\n## Summary\n\nSelf-attention architecture.",
+    );
+
+    const result = await ingest(
+      "An Illustrated Intro to Transformers",
+      "Transformers use self-attention. More detail about the architecture here.",
+    );
+
+    // Slug comes from the concept, not slugify(title).
+    expect(result.primarySlug).toBe("transformer");
+
+    const page = await readWikiPageWithFrontmatter("transformer");
+    expect(page).not.toBeNull();
+    // Marker line never leaks into the stored body.
+    expect(page!.content).not.toContain("CONCEPT:");
+    // The page is titled by the concept, and the source title becomes an alias
+    // so a later ingest under that title also converges here.
+    expect(page!.frontmatter.aliases).toContain(
+      "An Illustrated Intro to Transformers",
+    );
+  });
+
+  it("converges two differently-titled sources of one concept onto a single page", async () => {
+    mockedCallLLM.mockResolvedValue(
+      "CONCEPT: Transformer\n\n# Transformer\n\n## Summary\n\nThe attention architecture.",
+    );
+
+    await ingest("Intro to Transformers", "First source about transformers. Details.");
+    await ingest("The Transformer, Explained", "A second, differently-worded source. More.");
+
+    const entries = await listWikiPages();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].slug).toBe("transformer");
+
+    const page = await readWikiPageWithFrontmatter("transformer");
+    // Both ingests counted as sources of the one concept page. (YAML may
+    // round-trip the count as a number, so compare numerically.)
+    expect(Number(page!.frontmatter.source_count)).toBe(2);
+    // Both source titles recorded as aliases.
+    expect(page!.frontmatter.aliases).toContain("Intro to Transformers");
+    expect(page!.frontmatter.aliases).toContain("The Transformer, Explained");
+  });
+
+  it("falls back to the title slug when the LLM emits no CONCEPT marker", async () => {
+    mockedCallLLM.mockResolvedValue(
+      "# Plain Page\n\n## Summary\n\nNo concept marker emitted.",
+    );
+
+    const result = await ingest("Plain Title", "Some content without a marker. More.");
+
+    expect(result.primarySlug).toBe("plain-title");
+    const page = await readWikiPageWithFrontmatter("plain-title");
+    // No self-alias when no convergence happened (concept == title route).
+    expect((page!.frontmatter.aliases ?? []) as string[]).not.toContain(
+      "Plain Title",
+    );
+  });
+
+  it("records the LLM-supplied concept synonyms as aliases", async () => {
+    mockedCallLLM.mockResolvedValue(
+      "CONCEPT: Retrieval-Augmented Generation\nALIASES: RAG, retrieval augmentation\n\n# RAG\n\n## Summary\n\nGrounded generation.",
+    );
+
+    const result = await ingest(
+      "A Deep Dive on RAG Systems",
+      "RAG grounds an LLM in retrieved documents. Architecture details here.",
+    );
+
+    expect(result.primarySlug).toBe("retrieval-augmented-generation");
+    const page = await readWikiPageWithFrontmatter(
+      "retrieval-augmented-generation",
+    );
+    const aliases = (page!.frontmatter.aliases ?? []) as string[];
+    expect(aliases).toContain("RAG");
+    expect(aliases).toContain("retrieval augmentation");
+    // Plus the source title.
+    expect(aliases).toContain("A Deep Dive on RAG Systems");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ingest — semantic concept resolver (layer 3: embedding nearest-page merge)
+// ---------------------------------------------------------------------------
+
+describe("ingest — semantic concept resolver", () => {
+  beforeEach(() => {
+    resetSourceIndex();
+    resetAliasIndex();
+    mockedHasLLMKey.mockReturnValue(true);
+    // Each ingest's synthesis reports a concept derived from the source body, so
+    // two differently-worded sources get DIFFERENT concept slugs — only the
+    // embedding step can merge them.
+    mockedCallLLM.mockImplementation(async (_system: string, user: string) =>
+      user.includes("alpha")
+        ? "CONCEPT: Alpha Thing\nALIASES: none\n\n# Alpha Thing\n\n## Summary\n\nAbout alpha."
+        : "CONCEPT: Beta Thing\nALIASES: none\n\n# Beta Thing\n\n## Summary\n\nAbout beta.",
+    );
+  });
+  afterEach(() => {
+    mockedHasLLMKey.mockReturnValue(false);
+    mockedCallLLM.mockReset();
+    mockedHasEmbeddingSupport.mockReturnValue(false);
+    mockedSearchByVector.mockResolvedValue([]);
+  });
+
+  it("merges a differently-worded source into the nearest page above threshold", async () => {
+    mockedHasEmbeddingSupport.mockReturnValue(true);
+    // The nearest existing page is "alpha-thing" with a confident score.
+    mockedSearchByVector.mockResolvedValue([
+      { slug: "alpha-thing", score: 0.95 },
+    ]);
+
+    // First source forks its own page (no existing page to merge into yet —
+    // the search hit names a page that doesn't exist at that moment, so it's
+    // skipped and "alpha-thing" is created).
+    await ingest("Alpha Source", "First source, alpha topic. Details here.");
+    expect((await listWikiPages()).map((p) => p.slug)).toEqual(["alpha-thing"]);
+
+    // Second source's concept slug would be "beta-thing", but the embedding
+    // search points at "alpha-thing" ≥ threshold (same owner) → merge.
+    const result = await ingest("Beta Source", "Second source, beta wording. More.");
+
+    expect(result.primarySlug).toBe("alpha-thing");
+    const pages = await listWikiPages();
+    expect(pages).toHaveLength(1);
+    expect(pages[0].slug).toBe("alpha-thing");
+    expect(
+      Number(
+        (await readWikiPageWithFrontmatter("alpha-thing"))!.frontmatter
+          .source_count,
+      ),
+    ).toBe(2);
+  });
+
+  it("forks a new page when the nearest hit is below threshold", async () => {
+    mockedHasEmbeddingSupport.mockReturnValue(true);
+    // Nearest page exists but is NOT similar enough — err toward a new page.
+    mockedSearchByVector.mockResolvedValue([
+      { slug: "alpha-thing", score: 0.5 },
+    ]);
+
+    await ingest("Alpha Source", "First source, alpha topic. Details here.");
+    await ingest("Beta Source", "Second source, beta wording. More.");
+
+    const slugs = (await listWikiPages()).map((p) => p.slug).sort();
+    expect(slugs).toEqual(["alpha-thing", "beta-thing"]);
+  });
+
+  it("does NOT semantic-merge an agent-knowledge ingest into a public page (scope guard)", async () => {
+    mockedHasEmbeddingSupport.mockReturnValue(true);
+    mockedSearchByVector.mockResolvedValue([
+      { slug: "alpha-thing", score: 0.95 },
+    ]);
+
+    // Public page first (no `type`).
+    await ingest("Alpha Source", "First source, alpha topic. Details here.");
+    // Same owner, semantically near — but agent-scoped. The scope guard forks
+    // rather than folding agent-knowledge into the public feed page.
+    const result = await ingest("Beta Source", "Second source, beta wording. More.", {
+      pageType: "agent-knowledge",
+    });
+
+    expect(result.primarySlug).toBe("beta-thing");
+    expect(await readWikiPageWithFrontmatter("beta-thing")).not.toBeNull();
+    // The public page was left untouched (still a single source).
+    const alpha = await readWikiPageWithFrontmatter("alpha-thing");
+    expect(Number(alpha!.frontmatter.source_count)).toBe(1);
+  });
+
+  it("does NOT merge across owners even on a high-confidence hit", async () => {
+    mockedHasEmbeddingSupport.mockReturnValue(true);
+    mockedSearchByVector.mockResolvedValue([
+      { slug: "alpha-thing", score: 0.95 },
+    ]);
+
+    // Alice owns the alpha page.
+    await ingest("Alpha Source", "First source, alpha topic. Details here.", {
+      owner: "alice",
+      author: "alice",
+    });
+    // Bob ingests a semantically-near source — the same-silo guard must fork
+    // rather than attach Bob's source to Alice's page.
+    await ingest("Beta Source", "Second source, beta wording. More.", {
+      owner: "bob",
+      author: "bob",
+    });
+
+    const slugs = (await listWikiPages()).map((p) => p.slug).sort();
+    expect(slugs).toEqual(["alpha-thing", "beta-thing"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ingest — reconcile on merge (layer 4: accumulate-and-reconcile + disputed)
+// ---------------------------------------------------------------------------
+
+describe("ingest — reconcile on merge", () => {
+  // Synthesis emits a CONCEPT marker; the reconcile call (distinguished by its
+  // system prompt) returns the merged body. Keyed on the prompt so the two LLM
+  // roles never cross-contaminate.
+  function wire(reconcileOutput: string) {
+    mockedCallLLM.mockImplementation(async (system: string) =>
+      system.includes("canonical page about one concept")
+        ? reconcileOutput
+        : "CONCEPT: Topic\nALIASES: none\n\n# Topic\n\n## Summary\n\nA take on the topic.",
+    );
+  }
+
+  beforeEach(() => {
+    resetSourceIndex();
+    resetAliasIndex();
+    mockedHasLLMKey.mockReturnValue(true);
+  });
+  afterEach(() => {
+    mockedHasLLMKey.mockReturnValue(false);
+    mockedCallLLM.mockReset();
+  });
+
+  it("re-synthesizes existing + new into the merged body (not an overwrite)", async () => {
+    wire("# Topic\n\n## Summary\n\nMerged: both the first and second takes combined.");
+
+    await ingest("Topic A", "First source for the topic. Details one.");
+    const result = await ingest("Topic B", "Second complementary source. Details two.");
+
+    expect(result.primarySlug).toBe("topic");
+    const page = await readWikiPageWithFrontmatter("topic");
+    expect(page!.content).toContain("Merged: both the first and second takes combined.");
+    expect(page!.frontmatter.disputed).toBe(false);
+    // The merge counted both sources onto the one page.
+    expect(Number(page!.frontmatter.source_count)).toBe(2);
+
+    // Reconcile must see the frontmatter-STRIPPED existing body, never the YAML
+    // block — otherwise page metadata (owner/content_hash/…) leaks into the
+    // merge prompt and can bleed into the merged prose.
+    const reconcileCall = mockedCallLLM.mock.calls.find(([sys]) =>
+      (sys as string).includes("canonical page about one concept"),
+    );
+    expect(reconcileCall).toBeDefined();
+    const reconcileUser = reconcileCall![1] as string;
+    expect(reconcileUser).not.toContain("content_hash:");
+    expect(reconcileUser).not.toMatch(/^owner:/m);
+  });
+
+  it("flags the page disputed when reconcile reports a contradiction", async () => {
+    wire("DISPUTED: yes\n\n# Topic\n\n## Summary\n\nExisting says X; the new source says Y.");
+
+    await ingest("Topic A", "Original claim about the topic. Details.");
+    await ingest("Topic B", "A contradicting claim about the topic. Details.");
+
+    const page = await readWikiPageWithFrontmatter("topic");
+    expect(page!.frontmatter.disputed).toBe(true);
+    expect(page!.content).toContain("Existing says X; the new source says Y.");
+    // The DISPUTED marker is stripped from the stored body.
+    expect(page!.content).not.toContain("DISPUTED:");
+  });
+
+  it("does NOT reconcile (no extra LLM call) when there is no existing page", async () => {
+    wire("# Topic\n\nMerged body that must never appear for a brand-new page.");
+
+    await ingest("Topic A", "Only source. Details.");
+
+    // Exactly one page, and the reconcile output never reached it.
+    const page = await readWikiPageWithFrontmatter("topic");
+    expect(page!.content).not.toContain("Merged body that must never appear");
+    expect(page!.frontmatter.disputed).toBe(false);
+  });
+
+  it("degrades to the new body (ingest still succeeds) when reconcile throws", async () => {
+    // callLLM throws on API errors / empty output; the merge path must not let
+    // that fail an ingest whose synthesis already succeeded.
+    mockedCallLLM.mockImplementation(async (system: string) => {
+      if (system.includes("canonical page about one concept")) {
+        throw new Error("LLM response contained no text");
+      }
+      return "CONCEPT: Topic\nALIASES: none\n\n# Topic\n\n## Summary\n\nFresh synthesis body.";
+    });
+
+    await ingest("Topic A", "First source. Details one.");
+    const result = await ingest("Topic B", "Second source. Details two.");
+
+    expect(result.primarySlug).toBe("topic");
+    const page = await readWikiPageWithFrontmatter("topic");
+    // Reconcile failed → kept the freshly synthesized body; ingest succeeded.
+    expect(page!.content).toContain("Fresh synthesis body.");
+    expect(page!.frontmatter.disputed).toBe(false);
+    expect(Number(page!.frontmatter.source_count)).toBe(2);
   });
 });
 

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -54,7 +54,7 @@ import {
   resolveContentHash,
   updateSourceIndexForPage,
 } from "./source-index";
-import { contentHash } from "./embeddings";
+import { contentHash, searchByVector, hasEmbeddingSupport } from "./embeddings";
 import { getStorage } from "./storage";
 import { logger } from "./logger";
 
@@ -631,8 +631,14 @@ function splitSentences(text: string): string[] {
 // Conventions are documented in SCHEMA.md at the repo root.
 const INGEST_SYSTEM_PROMPT_BASE = `You are a wiki editor. Given a source document, generate a wiki article in markdown format.
 
-Include:
-- A title as a level-1 heading (# Title)
+Begin your output with these two header lines in EXACTLY this form:
+CONCEPT: <canonical concept name>
+ALIASES: <comma-separated alternative names / synonyms for the concept, or "none">
+CONCEPT names the one CANONICAL CONCEPT the document is about — the established term other writers on the same topic would also use (a concept, NOT the article's headline). Pick a granularity that is one coherent topic: general enough that other articles on the same subject would share it, specific enough not to lump distinct topics together.
+ALIASES lists other names the SAME concept is known by (acronyms, expansions, common synonyms) so future sources under those names converge here — not narrower sub-topics or related concepts. Use "none" if there are no real synonyms.
+
+Then, on the following lines, the wiki article. Include:
+- A title as a level-1 heading (# Title) — use the SAME canonical concept
 - A brief summary section (## Summary)
 - Key points or takeaways (## Key Points)
 - Notable entities, concepts, or terms worth remembering (## Concepts)
@@ -643,7 +649,7 @@ Include:
   stand in for the source. Do not pad, repeat the summary, or invent anything
   not supported by the source.
 
-Output pure markdown and nothing else. Do not wrap in code fences.`;
+Output the CONCEPT and ALIASES lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
 
 /**
  * System prompt for continuation chunks when a long source document has been
@@ -656,6 +662,177 @@ const CONTINUATION_SYSTEM_PROMPT = `You are a wiki editor. You have already star
 Add new key points, concepts, and details from the additional source material. Do NOT repeat the title, summary, or any content already in the article. Only output the new sections or bullet points to append.
 
 Output pure markdown and nothing else. Do not wrap in code fences.`;
+
+/**
+ * System prompt for reconciling an existing page with a newly ingested source
+ * on the SAME concept (the accumulate-and-reconcile step). The LLM merges both
+ * into one canonical article rather than the new ingest overwriting the page,
+ * and surfaces contradictions instead of silently picking a side.
+ */
+const RECONCILE_SYSTEM_PROMPT = `You are a wiki editor maintaining a single canonical page about one concept. You are given the page's CURRENT content and a NEWLY INGESTED article about the same concept. Merge them into one cohesive, up-to-date wiki article.
+
+Rules:
+- Preserve all substantive information from BOTH versions; integrate the new material rather than discarding what's already on the page.
+- Remove redundancy; keep the existing section structure (## Summary, ## Key Points, ## Concepts, ## Details) and any image markdown, without duplicating images.
+- Do NOT invent anything not supported by either source.
+- If the new article CONTRADICTS the current page on any material fact, do not silently pick one side: keep both positions (attributing each) and begin your ENTIRE output with a single line, exactly:
+DISPUTED: yes
+  Otherwise do not emit a DISPUTED line.
+
+Output the optional DISPUTED line, then pure markdown, and nothing else. Do not wrap in code fences.`;
+
+/**
+ * The ingest synthesis prompt asks the LLM to begin its output with two header
+ * lines naming the canonical concept and its synonyms:
+ *
+ *     CONCEPT: <canonical concept name>
+ *     ALIASES: <comma/semicolon-separated synonyms, or "none">
+ *
+ * Parse those out and return the concept, the alias list, and the body with
+ * both header lines removed.
+ *
+ * Two articles about the same concept under different headlines (e.g. "Intro
+ * to Transformers" and "The Transformer Architecture Explained") both emit
+ * `CONCEPT: Transformer`, so they converge onto one content-derived slug
+ * instead of forking by title. The aliases widen the exact-match net (acronyms,
+ * expansions) so future sources under those names also converge.
+ *
+ * Returns `concept: ""` (and no aliases) when the marker is absent — the
+ * deterministic fallback page, a commit-from-preview body (already stripped),
+ * older pages, or test mocks — so callers keep the title-derived slug unchanged.
+ * The `ALIASES` line is optional even when `CONCEPT` is present.
+ */
+export function parseConceptMarker(raw: string): {
+  concept: string;
+  aliases: string[];
+  body: string;
+} {
+  const conceptM = raw.match(/^\uFEFF?\s*CONCEPT:[ \t]*(.+?)[ \t]*(?:\r?\n|$)/i);
+  if (!conceptM) return { concept: "", aliases: [], body: raw };
+
+  let rest = raw.slice(conceptM[0].length);
+  let aliases: string[] = [];
+  const aliasM = rest.match(/^\s*ALIASES:[ \t]*(.*?)[ \t]*(?:\r?\n|$)/i);
+  if (aliasM) {
+    rest = rest.slice(aliasM[0].length);
+    aliases = aliasM[1]
+      .split(/[;,]/)
+      .map((s) => s.trim())
+      .filter((s) => s !== "" && s.toLowerCase() !== "none");
+  }
+
+  return {
+    concept: conceptM[1].trim(),
+    aliases,
+    body: rest.replace(/^\s+/, ""),
+  };
+}
+
+/** Cosine-similarity floor for treating the nearest existing page as the SAME
+ *  concept on a semantic match. Deliberately conservative — a wrong merge is
+ *  harder to undo than a fork, so we err toward a new page when unsure. */
+export const CONCEPT_MERGE_THRESHOLD = 0.86;
+
+/**
+ * Resolve the slug an ingest should land on, given a content-derived concept.
+ * Convergence ladder — each step only redirects to an EXISTING page; otherwise
+ * the candidate concept slug is used and a new page is forked:
+ *
+ *   1. Exact — the candidate concept slug is already a page.
+ *   2. Alias — the concept or one of its synonyms resolves (via the alias
+ *      index) to an existing page.
+ *   3. Semantic — the nearest existing page by embedding similarity is at or
+ *      above {@link CONCEPT_MERGE_THRESHOLD}. Scoped to the SAME owner's silo so
+ *      a fuzzy match never attaches a source to another tenant's page.
+ *
+ * `embedBody` is the synthesized page body used for the semantic query. Returns
+ * the candidate concept slug unchanged when no confident existing match is
+ * found. Embedding-unavailable environments (e.g. tests) cleanly skip step 3.
+ */
+async function resolveConceptSlug(
+  candidateSlug: string,
+  concept: string,
+  aliases: string[],
+  embedBody: string,
+  owner: string,
+  pageType: string | undefined,
+): Promise<string> {
+  // 1. Exact concept-slug hit.
+  if (await readWikiPageWithFrontmatter(candidateSlug)) return candidateSlug;
+
+  // 2. Alias / slug index over the concept and its synonyms.
+  for (const term of [concept, ...aliases]) {
+    const hit = await resolveAlias(term);
+    if (
+      hit &&
+      hit !== candidateSlug &&
+      (await readWikiPageWithFrontmatter(hit))
+    ) {
+      return hit;
+    }
+  }
+
+  // 3. Semantic nearest-page (the robust catch for LLM wording drift).
+  if (hasEmbeddingSupport()) {
+    const hits = await searchByVector(`${concept}\n\n${embedBody}`, 3);
+    for (const { slug: hitSlug, score } of hits) {
+      if (score < CONCEPT_MERGE_THRESHOLD) break; // sorted desc — none closer
+      if (hitSlug === candidateSlug) continue;
+      const page = await readWikiPageWithFrontmatter(hitSlug);
+      if (!page) continue;
+      // Same-silo guard: only merge into a page this owner owns, AND only when
+      // the page scope matches — so a fuzzy match can't fold agent-knowledge
+      // into a public feed page (or vice versa). Conservative: err toward fork.
+      const sameOwner = (page.frontmatter.owner ?? "system") === owner;
+      const sameScope = (page.frontmatter.type ?? "") === (pageType ?? "");
+      if (sameOwner && sameScope) return hitSlug;
+    }
+  }
+
+  // 4. No confident match — fork onto the candidate concept slug.
+  return candidateSlug;
+}
+
+/**
+ * Parse a leading `DISPUTED: yes` line the reconcile prompt emits when the new
+ * source contradicts the existing page. Returns whether the page is disputed
+ * plus the body with the marker line stripped. Absent / "no" → not disputed.
+ */
+export function parseDisputedMarker(raw: string): {
+  disputed: boolean;
+  body: string;
+} {
+  const m = raw.match(/^﻿?\s*DISPUTED:[ \t]*(yes|true)[ \t]*(?:\r?\n|$)/i);
+  if (!m) return { disputed: false, body: raw };
+  return { disputed: true, body: raw.slice(m[0].length).replace(/^\s+/, "") };
+}
+
+/**
+ * Reconcile an existing page body with a newly ingested article on the same
+ * concept via a single LLM call (the accumulate-and-reconcile step). Returns
+ * the merged body and whether the new source contradicts the existing page
+ * (→ `disputed`).
+ *
+ * Defensive about the model's output: strips a `DISPUTED:` marker, then any
+ * echoed `CONCEPT:`/`ALIASES:` synthesis headers. Falls back to the new body on
+ * an empty/failed response so a reconcile hiccup never blanks the page.
+ */
+async function reconcilePage(
+  existingBody: string,
+  newBody: string,
+): Promise<{ body: string; disputed: boolean }> {
+  const user = `# Current page\n\n${existingBody}\n\n# Newly ingested article (same concept)\n\n${newBody}`;
+  const out = await callLLM(RECONCILE_SYSTEM_PROMPT, user, {
+    maxOutputTokens: INGEST_MAX_OUTPUT_TOKENS,
+  });
+  if (!out || out.trim() === "") {
+    return { body: newBody, disputed: false };
+  }
+  const { disputed, body: afterDisputed } = parseDisputedMarker(out);
+  // Guard against the model echoing the synthesis headers into the merged body.
+  const { body } = parseConceptMarker(afterDisputed);
+  return { body, disputed };
+}
 
 /**
  * Build the ingest system prompt by composing the base prompt with the
@@ -850,10 +1027,23 @@ export async function ingest(
   // This prevents duplicate pages when the same concept appears under different
   // names (e.g. "React.js" vs a page with aliases: ["React.js"]).
   const resolvedSlug = await resolveAlias(title);
-  const slug = resolvedSlug ?? rawSlug;
+  // Provisional slug from the title. On the direct ingest path this is later
+  // replaced by a content-derived *concept* slug (see the CONCEPT marker below),
+  // so the same concept under different headlines converges onto one page.
+  let slug = resolvedSlug ?? rawSlug;
+  // The page title written to the index/log. Becomes the canonical concept name
+  // when one is derived; otherwise stays the source title.
+  let pageTitle = title;
 
   const isPreview = options?.preview === true;
   const preGeneratedContent = options?.generatedContent;
+
+  // Acting identity + owner come from the authenticated session (set by the
+  // route), never from client input. Fall back to "system" for legacy/bootstrap.
+  // Resolved here (not just at frontmatter-build time) so the concept resolver
+  // can scope a semantic merge to the same owner's silo.
+  const actor = options?.author?.trim() || "system";
+  const owner = options?.owner?.trim() || actor;
 
   // Download any images referenced in the source to local storage and rewrite
   // their markdown refs to `assets/<slug>/...`. Centralized here (not in
@@ -916,6 +1106,38 @@ export async function ingest(
     wikiContent = generateFallbackPage(title, content);
   }
 
+  // Pull the leading `CONCEPT:` / `ALIASES:` header lines the synthesis prompt
+  // asks for (and strip them from the body so they never leak into the page or
+  // preview). Absent for the fallback page / commit-from-preview / test mocks →
+  // concept "" and no aliases.
+  const {
+    concept,
+    aliases: conceptSynonyms,
+    body: conceptStrippedBody,
+  } = parseConceptMarker(wikiContent);
+  wikiContent = conceptStrippedBody;
+
+  // Direct ingest path only: converge onto the content-derived concept slug so
+  // re-ingests of the same concept (under any headline) land on one page. The
+  // preview→commit path keeps the title-derived slug (commit carries no marker)
+  // — preview/commit slug consistency is handled separately.
+  let conceptAliases: string[] = [];
+  if (!isPreview && !preGeneratedContent && concept) {
+    const conceptSlug = slugify(concept);
+    if (conceptSlug !== "") {
+      slug = await resolveConceptSlug(
+        conceptSlug,
+        concept,
+        conceptSynonyms,
+        wikiContent,
+        owner,
+        options?.pageType,
+      );
+      pageTitle = concept;
+      conceptAliases = conceptSynonyms;
+    }
+  }
+
   // The LLM distills text and drops image refs, so deterministically append the
   // source's downloaded images as a trailing section — reliable, no LLM cost.
   wikiContent = appendSourceImages(wikiContent, content);
@@ -954,10 +1176,8 @@ export async function ingest(
   const expiry = new Date();
   expiry.setDate(expiry.getDate() + 90);
   const expiryDate = expiry.toISOString().slice(0, 10);
-  // Acting identity + owner come from the authenticated session (set by the
-  // route), never from client input. Fall back to "system" for legacy/bootstrap.
-  const actor = options?.author?.trim() || "system";
-  const owner = options?.owner?.trim() || actor;
+  // `actor`/`owner` are resolved near the top of ingest() (the concept resolver
+  // needs `owner` for its same-silo guard).
   const frontmatter: Frontmatter = {
     created: now,
     updated: now,
@@ -1098,6 +1318,54 @@ export async function ingest(
     }
   }
 
+  // Re-synthesize on merge (accumulate-and-reconcile): when this ingest lands on
+  // an EXISTING page, fold the existing body and the new article into one
+  // canonical page instead of overwriting — and escalate to `disputed` if the
+  // new source contradicts what's there. Skipped without an LLM key (fall back
+  // to the prior overwrite behaviour) and for commit-from-preview (the user
+  // already approved a body). The page summary is computed from the raw source,
+  // so it is unaffected.
+  if (existing && hasLLMKey() && !preGeneratedContent) {
+    try {
+      // Reconcile against the frontmatter-STRIPPED body (existing.content still
+      // carries the YAML block; existing.body is the markdown) so page metadata
+      // never bleeds into the merged prose.
+      const reconciled = await reconcilePage(existing.body, wikiContent);
+      wikiContent = reconciled.body;
+      // Only escalate — never clear a disputed flag preserved from the existing
+      // page above.
+      if (reconciled.disputed) frontmatter.disputed = true;
+    } catch (err) {
+      // A reconcile hiccup (LLM API error / empty response) must not fail an
+      // ingest whose synthesis already succeeded — degrade to the prior
+      // overwrite behaviour (keep the freshly synthesized body, disputed
+      // untouched).
+      logger.warn("ingest", "reconcile-on-merge failed; using new body", err);
+    }
+  }
+
+  // When the page converged onto a concept slug, record the source title AND
+  // the LLM-supplied concept synonyms as aliases so a later ingest arriving
+  // under any of those names resolves here (extends convergence beyond the
+  // content hash to the title/synonym routes). Merges with any existing
+  // aliases; deduped case-insensitively; never aliases the concept to itself.
+  if (pageTitle !== title) {
+    const aliasList = Array.isArray(frontmatter.aliases)
+      ? [...frontmatter.aliases]
+      : [];
+    const seen = new Set(aliasList.map((a) => a.toLowerCase()));
+    for (const candidate of [title, ...conceptAliases]) {
+      const trimmed = candidate.trim();
+      const key = trimmed.toLowerCase();
+      if (trimmed === "" || key === pageTitle.toLowerCase() || seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      aliasList.push(trimmed);
+    }
+    frontmatter.aliases = aliasList;
+  }
+
   const contentWithFm = serializeFrontmatter(frontmatter, wikiContent);
 
   // 5. Hand off to the unified write pipeline. We pass the raw `content` as
@@ -1105,7 +1373,7 @@ export async function ingest(
   // pages, matching the previous behaviour.
   const { updatedSlugs } = await writeWikiPageWithSideEffects({
     slug,
-    title,
+    title: pageTitle,
     content: contentWithFm,
     summary,
     logOp: "ingest",


### PR DESCRIPTION
## What & why

Ingestion previously slugged from the **source title**, so the same concept ingested under different headlines forked into duplicate near-identical pages. This makes ingest converge onto **one canonical, accumulating concept page** — the "a page is a concept synthesized from many sources" model.

Built as the four-layer **canonical concept resolver** (one focused PR on the ingest core, behind careful review):

| Layer | What it does |
|-------|--------------|
| **1. Concept-slug from content** | Synthesis leads with `CONCEPT:` / `ALIASES:` header lines; `parseConceptMarker` parses + strips them; the slug derives from the concept, not the title. |
| **2. Auto-aliases** | The source title + the LLM-supplied concept synonyms are stored in `frontmatter.aliases` (deduped case-insensitively, never self-aliasing) — widens the exact-match net + improves search. |
| **3. Embedding nearest-page resolver** | `resolveConceptSlug`: exact concept-slug → alias index over concept+synonyms → semantic `searchByVector` ≥ `CONCEPT_MERGE_THRESHOLD` (0.86), **same-owner + same-scope guard**, else fork. The robust catch for LLM wording drift. |
| **4. Re-synthesize on merge + disputed** | When an ingest lands on an existing page (LLM available, not commit-from-preview), `reconcilePage` folds existing + new into one body instead of overwriting; a `DISPUTED:` marker escalates `frontmatter.disputed`. |

## Conservative by design (over-merge is worse than a fork)

- Semantic merge is **same-owner + same-scope only**, threshold 0.86, **err toward a new page** when unsure.
- **Test-safe by construction**: marker-absent paths (deterministic fallback page, commit-from-preview, no-LLM, test mocks) behave exactly as before — title slug, no reconcile.
- **Never blanks a page**: reconcile escalates `disputed` only (never clears), and a reconcile LLM failure degrades to the prior overwrite rather than failing the ingest.
- Scoped to the **direct ingest path**; preview→commit keeps the title slug (preview/commit slug consistency deferred — the one documented carve-out).

## Review (pr-review-toolkit:code-reviewer) — 3 findings, all fixed + regression-tested

1. **Critical** — reconcile was fed `existing.content` (includes the YAML frontmatter block) → switched to `existing.body`; test asserts the reconcile prompt contains no `content_hash:` / `owner:`.
2. **Important** — a reconcile LLM failure aborted the whole ingest (new failure mode; `callLLM` throws on error/empty) → wrapped in try/catch, degrades to overwrite; test drives a throwing reconcile and asserts the ingest still succeeds.
3. **Scope guard** — agent-knowledge could fuzzy-merge into a public page → semantic step now requires matching `type`; test asserts an agent ingest forks instead of folding into the public feed page.

## Tests

- **184 ingest tests** (was 162): `parseConceptMarker`/`parseDisputedMarker` edge cases, concept-slug convergence, synonym aliases, the semantic resolver (embedding mock — merge / below-threshold fork / cross-owner / agent-scope guards), and reconcile-on-merge (merge / disputed / no-existing / failure-fallback).
- **Full suite: 2458 green.** `tsc` clean (6 pre-existing errors in unrelated test files, none here). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)