### PR TITLE
yopedia: B1 — curation + public vault lens

### DIFF
--- a/src/app/api/vault/route.ts
+++ b/src/app/api/vault/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { getPrincipal } from "@/lib/auth";
+import { readWikiPageWithFrontmatter } from "@/lib/wiki";
+import { belongsInCommons } from "@/lib/commons";
+import { addVaultRef, removeVaultRef } from "@/lib/vault";
+import { logger } from "@/lib/logger";
+
+/**
+ * Curate / uncurate a commons page into YOUR vault — a personal reference lens
+ * over the commons.
+ *
+ *   POST   /api/vault   { slug }  → curate (add a reference)
+ *   DELETE /api/vault   { slug }  → uncurate (remove the reference)
+ *
+ * The target vault is the caller's own, derived from the session (never the
+ * body). Curating references a single, collective commons page — no copy is
+ * made — so only PUBLIC, non-agent (commons) pages can be added. Uncurating just
+ * drops the reference and is allowed regardless of the page's current state.
+ */
+async function handle(req: Request, curate: boolean) {
+  try {
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    let body: { slug?: unknown };
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const slug = body?.slug;
+    if (!slug || typeof slug !== "string") {
+      return NextResponse.json(
+        { error: "Missing or invalid 'slug'" },
+        { status: 400 },
+      );
+    }
+
+    if (!curate) {
+      // Uncurate: just drop the reference (the page may have gone private since
+      // it was curated — removal must always work).
+      await removeVaultRef(principal.handle, slug);
+      return NextResponse.json({ curated: false, slug });
+    }
+
+    // Curate: the page must exist and be a commons page (public, non-agent) —
+    // you reference the collective page, you don't copy it.
+    const page = await readWikiPageWithFrontmatter(slug);
+    if (!page) {
+      return NextResponse.json(
+        { error: `Page "${slug}" not found` },
+        { status: 404 },
+      );
+    }
+    if (
+      !belongsInCommons({
+        visibility:
+          typeof page.frontmatter.visibility === "string"
+            ? page.frontmatter.visibility
+            : undefined,
+        type:
+          typeof page.frontmatter.type === "string"
+            ? page.frontmatter.type
+            : undefined,
+      })
+    ) {
+      return NextResponse.json(
+        { error: "Only public commons pages can be curated into a vault." },
+        { status: 400 },
+      );
+    }
+
+    await addVaultRef(principal.handle, slug);
+    return NextResponse.json({ curated: true, slug });
+  } catch (err) {
+    logger.error("vault", "curate toggle failed:", err);
+    return NextResponse.json(
+      { error: "Failed to update vault." },
+      { status: 500 },
+    );
+  }
+}
+
+export const POST = (req: Request) => handle(req, true);
+export const DELETE = (req: Request) => handle(req, false);

--- a/src/app/u/[handle]/[slug]/page.tsx
+++ b/src/app/u/[handle]/[slug]/page.tsx
@@ -23,8 +23,11 @@ import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { DeletePageButton } from "@/components/DeletePageButton";
 import { ReingestButton } from "@/components/ReingestButton";
 import { ShareWithYoyoButton } from "@/components/ShareWithYoyoButton";
+import { SaveToVaultButton } from "@/components/SaveToVaultButton";
 import { getPrincipal } from "@/lib/auth";
 import { canReadFrontmatter } from "@/lib/authz";
+import { belongsInCommons } from "@/lib/commons";
+import { isInVault } from "@/lib/vault";
 import { agentIdFor, DEFAULT_AGENT_NAME, isAgentHandle } from "@/lib/agents";
 import { listRevisions } from "@/lib/revisions";
 import { AgentBadge } from "@/components/AgentBadge";
@@ -811,6 +814,25 @@ export default async function WikiPageView({ params }: WikiPageProps) {
     Array.isArray(page.frontmatter.sharedWith) &&
     (page.frontmatter.sharedWith as string[]).includes(myYoyoId);
 
+  // "Save to vault" — curate a commons (public, non-agent) page into the signed-in
+  // viewer's reference lens. Shown only on pages the viewer does NOT own or
+  // contribute to (those are already in their vault); curation is for pulling in
+  // OTHERS' commons pages.
+  const isCommonsPage = belongsInCommons({
+    visibility:
+      typeof page.frontmatter.visibility === "string"
+        ? page.frontmatter.visibility
+        : undefined,
+    type:
+      typeof page.frontmatter.type === "string"
+        ? page.frontmatter.type
+        : undefined,
+  });
+  // canShare is true when the viewer owns or contributed to the page — those are
+  // already in their vault, so the curate button is for everyone else's pages.
+  const canCurate = !!principal && isCommonsPage && !canShare;
+  const inVault = canCurate && (await isInVault(principal!.handle, slug));
+
   const revisions = await listRevisions(slug);
   const lineageSources = parseSources(
     page.frontmatter.sources as string | string[] | undefined,
@@ -904,6 +926,9 @@ export default async function WikiPageView({ params }: WikiPageProps) {
               </Link>
             )}
             {hasSourceUrl && <ReingestButton slug={slug} />}
+            {canCurate && (
+              <SaveToVaultButton slug={slug} initiallyInVault={inVault} />
+            )}
             {canShare && (
               <ShareWithYoyoButton slug={slug} initiallyShared={alreadyShared} />
             )}

--- a/src/app/u/[handle]/page.tsx
+++ b/src/app/u/[handle]/page.tsx
@@ -4,6 +4,7 @@ import { slugsForOwner } from "@/lib/search";
 import { listAgentsForOwner, agentShortName } from "@/lib/agents";
 import { getDiscussionStatsForSlugs } from "@/lib/talk";
 import { getPrincipal } from "@/lib/auth";
+import { getVaultRefs } from "@/lib/vault";
 import { decodeSlug } from "@/lib/slugify";
 import { WikiIndexClient } from "@/components/WikiIndexClient";
 
@@ -22,7 +23,19 @@ export default async function UserPage({
   const pages = readable.filter((p) => mine.has(p.slug));
   const agents = await listAgentsForOwner(handle);
 
-  const statsMap = await getDiscussionStatsForSlugs(pages.map((p) => p.slug));
+  // Curated commons pages this handle referenced into their vault — the lens
+  // part of the vault. Dedup against pages they already own/contributed (those
+  // show above), and keep only what's still readable (a curated page that went
+  // private drops out for non-owners).
+  const curatedSet = new Set(await getVaultRefs(handle));
+  const curated = readable.filter(
+    (p) => curatedSet.has(p.slug) && !mine.has(p.slug),
+  );
+
+  const statsMap = await getDiscussionStatsForSlugs([
+    ...pages.map((p) => p.slug),
+    ...curated.map((p) => p.slug),
+  ]);
   const discussionStats: Record<string, { total: number; open: number }> = {};
   for (const [slug, stats] of statsMap) discussionStats[slug] = stats;
 
@@ -88,10 +101,24 @@ export default async function UserPage({
         </section>
       )}
 
-      {pages.length === 0 ? (
+      {pages.length === 0 && curated.length === 0 ? (
         <p className="text-foreground/60">No pages yet.</p>
       ) : (
-        <WikiIndexClient pages={pages} discussionStats={discussionStats} />
+        pages.length > 0 && (
+          <WikiIndexClient pages={pages} discussionStats={discussionStats} />
+        )
+      )}
+
+      {curated.length > 0 && (
+        <section className="mt-10">
+          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-foreground/50">
+            Curated
+          </h2>
+          <p className="mb-3 text-sm text-foreground/50">
+            Commons pages {handle} saved to their vault — live references, not copies.
+          </p>
+          <WikiIndexClient pages={curated} discussionStats={discussionStats} />
+        </section>
       )}
     </main>
   );

--- a/src/components/SaveToVaultButton.tsx
+++ b/src/components/SaveToVaultButton.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface SaveToVaultButtonProps {
+  slug: string;
+  /** Whether this page is already curated into the viewer's vault. */
+  initiallyInVault: boolean;
+}
+
+/**
+ * Curate / uncurate a commons page into your vault — a personal reference lens
+ * over the commons. "Curate" adds a *reference*, not a copy: the page stays a
+ * single collective commons page; your vault just points at it (always live).
+ * Rendered only to signed-in viewers on commons (public, non-agent) pages; the
+ * server re-checks both on the request.
+ */
+export function SaveToVaultButton({
+  slug,
+  initiallyInVault,
+}: SaveToVaultButtonProps) {
+  const router = useRouter();
+  const [inVault, setInVault] = useState(initiallyInVault);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function toggle() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/vault", {
+        method: inVault ? "DELETE" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `request failed (${res.status})`);
+      }
+      setInVault(!inVault);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={busy}
+        className="rounded-md border border-foreground/20 px-4 py-2 text-sm font-medium text-foreground hover:bg-foreground/5 transition-colors disabled:opacity-50"
+        title={
+          inVault
+            ? "Remove this page from your vault"
+            : "Save this page to your vault (a live reference, not a copy)"
+        }
+      >
+        {inVault ? "✓ In your vault" : "Save to vault"}
+      </button>
+      {error && (
+        <span className="text-xs text-red-600 dark:text-red-400">{error}</span>
+      )}
+    </span>
+  );
+}

--- a/src/lib/__tests__/vault-route.test.ts
+++ b/src/lib/__tests__/vault-route.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+// Default: signed in as "alice". Individual tests override (e.g. signed out).
+vi.mock("@/lib/auth", () => ({
+  getPrincipal: vi.fn(async () => ({ id: "alice", handle: "alice" })),
+}));
+
+import {
+  ensureDirectories,
+  writeWikiPage,
+  serializeFrontmatter,
+  type Frontmatter,
+} from "../wiki";
+import { getVaultRefs, addVaultRef } from "../vault";
+import { getPrincipal } from "../auth";
+import { _resetStorage } from "../storage";
+
+const mockedGetPrincipal = vi.mocked(getPrincipal);
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-route-test-"));
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetStorage();
+  await ensureDirectories();
+  mockedGetPrincipal.mockResolvedValue({ id: "alice", handle: "alice" });
+});
+
+afterEach(async () => {
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function fm(over: Partial<Frontmatter> = {}): Frontmatter {
+  return {
+    owner: "bob",
+    visibility: "public",
+    authors: ["bob"],
+    contributors: [],
+    tags: [],
+    ...over,
+  } as Frontmatter;
+}
+
+async function writePage(slug: string, over: Partial<Frontmatter> = {}) {
+  await writeWikiPage(
+    slug,
+    serializeFrontmatter(fm(over), `# ${slug}\n\nBody for ${slug}.`),
+  );
+}
+
+async function callVault(method: "POST" | "DELETE", body: unknown) {
+  const mod = await import("@/app/api/vault/route");
+  const handler = method === "POST" ? mod.POST : mod.DELETE;
+  const req = new Request("http://localhost/api/vault", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return handler(req);
+}
+
+describe("POST /api/vault — curate", () => {
+  it("curates a public commons page into the caller's own vault", async () => {
+    await writePage("transformers");
+
+    const res = await callVault("POST", { slug: "transformers" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ curated: true, slug: "transformers" });
+
+    // Stored under the SESSION handle (alice), not anything from the body.
+    expect(await getVaultRefs("alice")).toEqual(["transformers"]);
+    expect(await getVaultRefs("bob")).toEqual([]);
+  });
+
+  it("401s when signed out, without touching the vault", async () => {
+    mockedGetPrincipal.mockResolvedValueOnce(null);
+    await writePage("transformers");
+
+    const res = await callVault("POST", { slug: "transformers" });
+    expect(res.status).toBe(401);
+    expect(await getVaultRefs("alice")).toEqual([]);
+  });
+
+  it("404s a missing page", async () => {
+    const res = await callVault("POST", { slug: "does-not-exist" });
+    expect(res.status).toBe(404);
+  });
+
+  it("400s a private page (not a commons page)", async () => {
+    await writePage("secret", { visibility: "private", owner: "alice" });
+    const res = await callVault("POST", { slug: "secret" });
+    expect(res.status).toBe(400);
+    expect(await getVaultRefs("alice")).toEqual([]);
+  });
+
+  it("400s an agent-scoped page", async () => {
+    await writePage("agent-note", { type: "agent-knowledge" });
+    const res = await callVault("POST", { slug: "agent-note" });
+    expect(res.status).toBe(400);
+  });
+
+  it("400s a missing slug", async () => {
+    const res = await callVault("POST", {});
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/vault — uncurate", () => {
+  it("removes a curated reference", async () => {
+    await addVaultRef("alice", "transformers");
+    const res = await callVault("DELETE", { slug: "transformers" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ curated: false, slug: "transformers" });
+    expect(await getVaultRefs("alice")).toEqual([]);
+  });
+
+  it("uncurates without requiring the page to still be a commons page", async () => {
+    // Page has since gone private — removal must still work.
+    await addVaultRef("alice", "was-public");
+    await writePage("was-public", { visibility: "private", owner: "bob" });
+    const res = await callVault("DELETE", { slug: "was-public" });
+    expect(res.status).toBe(200);
+    expect(await getVaultRefs("alice")).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/vault.test.ts
+++ b/src/lib/__tests__/vault.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  getVaultRefs,
+  addVaultRef,
+  removeVaultRef,
+  isInVault,
+} from "../vault";
+import { _resetStorage } from "../storage";
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-test-"));
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetStorage();
+});
+
+afterEach(async () => {
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("vault refs", () => {
+  it("returns an empty list for a handle with no vault", async () => {
+    expect(await getVaultRefs("alice")).toEqual([]);
+    expect(await isInVault("alice", "transformers")).toBe(false);
+  });
+
+  it("adds and reads back curated slugs (insertion order)", async () => {
+    await addVaultRef("alice", "transformers");
+    await addVaultRef("alice", "rag");
+    expect(await getVaultRefs("alice")).toEqual(["transformers", "rag"]);
+    expect(await isInVault("alice", "rag")).toBe(true);
+  });
+
+  it("is idempotent — a duplicate add does not double-list", async () => {
+    await addVaultRef("alice", "transformers");
+    await addVaultRef("alice", "transformers");
+    expect(await getVaultRefs("alice")).toEqual(["transformers"]);
+  });
+
+  it("removes a slug (no-op when absent)", async () => {
+    await addVaultRef("alice", "transformers");
+    await addVaultRef("alice", "rag");
+    await removeVaultRef("alice", "transformers");
+    expect(await getVaultRefs("alice")).toEqual(["rag"]);
+    // Removing something not present is a no-op.
+    await removeVaultRef("alice", "not-there");
+    expect(await getVaultRefs("alice")).toEqual(["rag"]);
+  });
+
+  it("keeps each handle's vault separate", async () => {
+    await addVaultRef("alice", "transformers");
+    await addVaultRef("bob", "rag");
+    expect(await getVaultRefs("alice")).toEqual(["transformers"]);
+    expect(await getVaultRefs("bob")).toEqual(["rag"]);
+  });
+
+  it("keys by normalized handle (case-insensitive, same as the tenant)", async () => {
+    await addVaultRef("Alice", "transformers");
+    // A differently-cased handle resolves to the same vault (tenant key).
+    expect(await getVaultRefs("alice")).toEqual(["transformers"]);
+    expect(await isInVault("ALICE", "transformers")).toBe(true);
+  });
+});

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1,0 +1,82 @@
+/**
+ * Per-user **vault** — a personal *reference lens* over the commons.
+ *
+ * In the commons-first model (see `yopedia-concept.md`) public content has one
+ * home: the collective commons. A user's public vault is NOT separate storage —
+ * it's a curated set of **references** to commons pages. "Curating" a page adds
+ * its slug here; the page itself stays single and collective, so a curated entry
+ * is always live (never a stale copy).
+ *
+ * Stored as a derived index keyed `vault:<tenant>` (tenant = the normalized
+ * owner handle, same key space as the commons/silo), holding the list of
+ * curated commons slugs. Fail-soft on read so a missing/corrupt index never
+ * breaks a profile render.
+ */
+
+import { getStorage } from "./storage";
+import { withFileLock } from "./lock";
+import { tenantForOwner } from "./wiki";
+import { logger } from "./logger";
+
+/** The stored shape of one user's vault. */
+interface VaultIndex {
+  /** Curated commons slugs, insertion-ordered (most-recent last). */
+  slugs: string[];
+}
+
+/** Derived-index key for a handle's vault (`_idx:vault:<tenant>` on R2). */
+function vaultKey(handle: string): string {
+  return `vault:${tenantForOwner(handle)}`;
+}
+
+/** Lock key for a handle's vault writes (per-user, so no cross-user contention). */
+function vaultLock(handle: string): string {
+  return `vault:${tenantForOwner(handle)}`;
+}
+
+/**
+ * Read a handle's curated commons slugs (empty array when absent). Fail-soft: a
+ * missing or corrupt index returns `[]` rather than throwing.
+ */
+export async function getVaultRefs(handle: string): Promise<string[]> {
+  try {
+    const idx = await getStorage().getIndex<VaultIndex>(vaultKey(handle));
+    return Array.isArray(idx?.slugs) ? idx.slugs : [];
+  } catch (err) {
+    logger.warn("vault", "vault index unreadable; treating as empty:", err);
+    return [];
+  }
+}
+
+/** Whether a slug is already curated into a handle's vault. */
+export async function isInVault(handle: string, slug: string): Promise<boolean> {
+  return (await getVaultRefs(handle)).includes(slug);
+}
+
+/**
+ * Curate a commons slug into a handle's vault (idempotent — a duplicate add is a
+ * no-op). The caller is responsible for verifying the slug is a readable commons
+ * page; this only maintains the reference list.
+ */
+export async function addVaultRef(handle: string, slug: string): Promise<void> {
+  await withFileLock(vaultLock(handle), async () => {
+    const slugs = await getVaultRefs(handle);
+    if (slugs.includes(slug)) return;
+    slugs.push(slug);
+    await getStorage().putIndex<VaultIndex>(vaultKey(handle), { slugs });
+  });
+}
+
+/** Remove a curated slug from a handle's vault (no-op if absent). */
+export async function removeVaultRef(
+  handle: string,
+  slug: string,
+): Promise<void> {
+  await withFileLock(vaultLock(handle), async () => {
+    const slugs = await getVaultRefs(handle);
+    const next = slugs.filter((s) => s !== slug);
+    if (next.length !== slugs.length) {
+      await getStorage().putIndex<VaultIndex>(vaultKey(handle), { slugs: next });
+    }
+  });
+}


### PR DESCRIPTION
First build phase of the **commons-first** pivot (see `yopedia-concept.md`). A user's public **vault** is a personal *reference lens* over the commons: **curating a commons page adds a reference, never a copy**, so it stays live as the commons updates.

## What's in this PR
- **`src/lib/vault.ts`** (new) — per-user vault = a list of curated commons slugs, stored as a derived index keyed `vault:<tenant>` (`tenantForOwner(handle)` — the same normalized key space as commons/silo). `getVaultRefs` / `addVaultRef` / `removeVaultRef` / `isInVault`, via `getStorage().getIndex/putIndex` + `withFileLock`, fail-soft on read.
- **`POST/DELETE /api/vault`** (new) — curate / uncurate. The target vault is the caller's own (handle from `getPrincipal()`, **never the body** → no cross-user writes). POST validates the page exists + `belongsInCommons` (public, non-agent). DELETE always removes (the page may have gone private since it was curated).
- **`SaveToVaultButton`** (new) — client toggle, modeled on `ShareWithYoyoButton`. Shown to signed-in viewers on commons pages they do **not** own/contribute to (curation pulls in *others'* pages; your own are already in your vault).
- **`/u/<handle>` "Curated" section** — your curated commons pages (refs ∩ readable − owned, so no double-count), rendered as the live commons pages.

## Security / correctness (verified by code review)
- Vault keyed by the **session handle only**; body carries `slug` only → cross-user writes structurally impossible. Middleware gates `/api/**` writes (401) + the route re-checks `getPrincipal`.
- Curation rejects private + agent-scoped pages; uncurate just drops a reference from your own vault.
- Read/write keys both funnel through `tenantForOwner` (case-insensitive, idempotent) → no key mismatch.
- `curated = readable ∩ vaultRefs − mine`: a curated page that goes private drops out for non-owners (no private leak), stays for the owner.

## Tests
- `vault.test.ts` (6), `vault-route.test.ts` (8). **Full suite 2480 green**; `tsc` clean (6 pre-existing errors in unrelated files); lint clean.

## Deferred (fast-follow, core is fully usable without them)
- Ingest-into-my-vault = commons ingest + auto-added reference.
- Save-to-vault on a query result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)