### PR TITLE
yopedia: B1 follow-ups — auto-ref contributions into the vault

### DIFF
--- a/src/components/QueryResultPanel.tsx
+++ b/src/components/QueryResultPanel.tsx
@@ -96,6 +96,19 @@ export function QueryResultPanel({
 
       setSaveState({ status: "saved", slug: data.slug });
 
+      // Commons-first: a saved answer is a public commons page; also curate it
+      // into the saver's vault so it shows in their personal lens. Best-effort —
+      // the save already succeeded, so a vault hiccup must not surface an error.
+      try {
+        await fetch("/api/vault", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ slug: data.slug }),
+        });
+      } catch {
+        // Non-critical — the page is saved either way.
+      }
+
       // Mark the history entry as saved
       if (currentHistoryId) {
         try {
@@ -223,7 +236,7 @@ export function QueryResultPanel({
 
           {saveState.status === "saved" && saveState.slug && (
             <Alert variant="success">
-              Saved!{" "}
+              Saved to the wiki and your vault.{" "}
               <Link
                 href={hrefForSlug(saveState.slug)}
                 className="underline font-medium hover:opacity-80"

--- a/src/lib/__tests__/vault-autoref.test.ts
+++ b/src/lib/__tests__/vault-autoref.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  ensureDirectories,
+  writeWikiPageWithSideEffects,
+  serializeFrontmatter,
+  type Frontmatter,
+} from "../wiki";
+import { getVaultRefs } from "../vault";
+import { _resetStorage } from "../storage";
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-autoref-test-"));
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetStorage();
+  await ensureDirectories();
+});
+
+afterEach(async () => {
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function fm(over: Partial<Frontmatter> = {}): Frontmatter {
+  return {
+    owner: "alice",
+    visibility: "public",
+    authors: ["alice"],
+    contributors: [],
+    tags: [],
+    ...over,
+  } as Frontmatter;
+}
+
+async function write(slug: string, over: Partial<Frontmatter> = {}) {
+  await writeWikiPageWithSideEffects({
+    slug,
+    title: slug,
+    content: serializeFrontmatter(fm(over), `# ${slug}\n\nBody for ${slug}.`),
+    summary: `Summary for ${slug}.`,
+    logOp: "ingest",
+  });
+}
+
+describe("vault auto-ref on commons write (lifecycle step 3d)", () => {
+  it("adds an owner's new public commons page to their vault", async () => {
+    await write("transformers", { owner: "alice" });
+    expect(await getVaultRefs("alice")).toContain("transformers");
+  });
+
+  it("is idempotent across re-writes", async () => {
+    await write("transformers", { owner: "alice" });
+    await write("transformers", { owner: "alice" });
+    expect(await getVaultRefs("alice")).toEqual(["transformers"]);
+  });
+
+  it("does NOT auto-ref a private page", async () => {
+    await write("secret", { owner: "alice", visibility: "private" });
+    expect(await getVaultRefs("alice")).toEqual([]);
+  });
+
+  it("does NOT auto-ref an agent-scoped page", async () => {
+    await write("agent-note", { owner: "alice", type: "agent-knowledge" });
+    expect(await getVaultRefs("alice")).toEqual([]);
+  });
+
+  it("does NOT auto-ref a system-owned (seed) page", async () => {
+    await write("seed-page", { owner: "system" });
+    expect(await getVaultRefs("system")).toEqual([]);
+  });
+
+  it("does NOT auto-ref an agent-owned (handle--name) page", async () => {
+    await write("learned", { owner: "alice--yoyo" });
+    expect(await getVaultRefs("alice--yoyo")).toEqual([]);
+    expect(await getVaultRefs("alice")).toEqual([]);
+  });
+});

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -22,7 +22,8 @@ import { escapeRegex } from "./links";
 import { getErrorMessage } from "./errors";
 import { removeAliasForPage, updateAliasIndexForPage } from "./alias-index";
 import { removeSourceForPage } from "./source-index";
-import { syncCommonsForPage, removeCommonsEntryBySlug } from "./commons";
+import { syncCommonsForPage, removeCommonsEntryBySlug, belongsInCommons } from "./commons";
+import { addVaultRef } from "./vault";
 import { parseFrontmatter } from "./frontmatter";
 import type { LogOperation } from "./wiki";
 import { logger } from "./logger";
@@ -381,6 +382,27 @@ async function runPageLifecycleOp(
     }
   } catch (err) {
     logger.warn("silo", `silo mirror skipped for "${slug}":`, err);
+  }
+
+  // 3d. Auto-add the page into its owner's vault — the commons-first reference
+  //     lens. A contributor's own commons pages show in their vault without a
+  //     manual curate (ingest-into-my-vault). Owner-keyed, commons-only (public,
+  //     non-agent), humans-only (skip "system" and agent-owned `a--b` handles).
+  //     Idempotent + fail-soft — a vault error must never break the write.
+  try {
+    if (op.kind !== "delete") {
+      const fm = parseFrontmatter(op.content).data;
+      const owner = typeof fm.owner === "string" ? fm.owner.trim() : "";
+      const isCommons = belongsInCommons({
+        visibility: typeof fm.visibility === "string" ? fm.visibility : undefined,
+        type: typeof fm.type === "string" ? fm.type : undefined,
+      });
+      if (owner && owner !== "system" && !owner.includes("--") && isCommons) {
+        await addVaultRef(owner, slug);
+      }
+    }
+  } catch (err) {
+    logger.warn("vault", `vault auto-ref skipped for "${slug}":`, err);
   }
 
   // 4. Cross-reference other pages.


### PR DESCRIPTION
The two deferred pieces from B1 (#370), so a user's vault fills without manual curation.

## What's in this PR
- **Ingest → my vault** — `src/lib/lifecycle.ts` step 3d: every commons write auto-adds the page's owner to their vault (`addVaultRef`). Fail-soft, idempotent, commons-only (`belongsInCommons`: public, non-agent), humans-only (skips `""`/`"system"`/agent-owned `a--b` handles). Mirrors the adjacent commons (3b) and silo (3c) sync steps in the unified write pipeline used by `ingest()` and `saveAnswerToWiki()`.
- **Save query answer → my vault** — `src/components/QueryResultPanel.tsx`: after a successful "Save to Wiki", curate the saved answer into the saver's vault (best-effort `POST /api/vault`). Success copy now reads "Saved to the wiki and your vault."

## Why
B1 shipped the curation core (save *others'* commons pages to your vault). These follow-ups close the loop: your *own* contributions — ingests and saved answers — land in your vault automatically, so the vault index is the complete personal lens.

## Safety (verified by code review — no issues)
- Owner-keying is correct and unbypassable (`"system"` + `a--b` agent-handle guards; `slugify` never emits `--`).
- No private-page leak: `op.content` is the authoritative committed frontmatter; `belongsInCommons` rejects private + agent-scoped.
- Fail-soft: the whole step is `try/catch`; a vault error can never break the page write.
- The best-effort curate runs only inside the `!readOnly` save handler (the signed-out demo path can't trigger it) and can't regress the save UX.
- No double-ref: an auto-ref'd owned page shows in the owned list, excluded from the profile's "Curated" section (`curated = refs − mine`).

## Tests
- `vault-autoref.test.ts` (6): public add, idempotency, private skip, agent-type skip, system-owner skip, agent-handle skip.
- Full suite **2486 green**; `tsc` clean (6 pre-existing unrelated errors); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)