### PR TITLE
yopedia: B2a — realm-aware write ACL (private pages owner-only)

### DIFF
--- a/src/app/api/ingest/reingest/route.ts
+++ b/src/app/api/ingest/reingest/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { reingest } from "@/lib/ingest";
 import { readWikiPageWithFrontmatter } from "@/lib/wiki";
 import { getPrincipal, getServicePrincipal } from "@/lib/auth";
+import { canReadFrontmatter, canWriteFrontmatter } from "@/lib/authz";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 
@@ -30,6 +31,21 @@ export async function POST(request: NextRequest) {
         { error: `Page "${trimmedSlug}" not found` },
         { status: 404 },
       );
+    }
+
+    // Realm-aware write ACL: re-ingest rewrites the page. Denied → cloak: a
+    // private page the caller can't read is 404 (no existence oracle); a
+    // readable-but-unwritable page is 403.
+    if (!canWriteFrontmatter(page.frontmatter, principal)) {
+      return canReadFrontmatter(page.frontmatter, principal)
+        ? NextResponse.json(
+            { error: "You don't have permission to re-ingest this page." },
+            { status: 403 },
+          )
+        : NextResponse.json(
+            { error: `Page "${trimmedSlug}" not found` },
+            { status: 404 },
+          );
     }
 
     // Check if page has a source_url

--- a/src/app/api/wiki/[slug]/route.ts
+++ b/src/app/api/wiki/[slug]/route.ts
@@ -8,17 +8,46 @@ import {
   type Frontmatter,
 } from "@/lib/wiki";
 import { extractSummary } from "@/lib/ingest";
-import { getPrincipal } from "@/lib/auth";
+import { getPrincipal, getServicePrincipal } from "@/lib/auth";
+import { canReadFrontmatter, canWriteFrontmatter } from "@/lib/authz";
 import { getErrorMessage } from "@/lib/errors";
 import { patchMetadata } from "@/lib/patch-metadata";
 
 export async function DELETE(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ slug: string }> },
 ) {
   try {
     const { slug: encodedSlug } = await params;
     const slug = decodeSlug(encodedSlug);
+
+    // Realm-aware write ACL: a private page may be deleted only by its owner
+    // (or their agents / the service principal); public commons pages stay
+    // collectively manageable. (The middleware already blocks unauthenticated
+    // mutations; this is the per-page check on top.)
+    const principal = (await getPrincipal()) ?? getServicePrincipal(req);
+    const existing = await readWikiPageWithFrontmatter(slug);
+    if (!existing) {
+      return NextResponse.json(
+        { error: `page not found: ${slug}` },
+        { status: 404 },
+      );
+    }
+    // Realm-aware write ACL. When the write is denied, CLOAK: a private page the
+    // caller can't even read is 404 (no existence oracle, matching reads); a
+    // readable-but-unwritable page is 403.
+    if (!canWriteFrontmatter(existing.frontmatter, principal)) {
+      return canReadFrontmatter(existing.frontmatter, principal)
+        ? NextResponse.json(
+            { error: "You don't have permission to delete this page." },
+            { status: 403 },
+          )
+        : NextResponse.json(
+            { error: `page not found: ${slug}` },
+            { status: 404 },
+          );
+    }
+
     const result = await deleteWikiPage(slug);
     return NextResponse.json(result);
   } catch (err) {
@@ -78,7 +107,8 @@ export async function PUT(
     }
 
     // Attribution comes from the authenticated session, never the body.
-    const authorStr = (await getPrincipal())?.handle;
+    const principal = (await getPrincipal()) ?? getServicePrincipal(req);
+    const authorStr = principal?.handle;
 
     const existing = await readWikiPageWithFrontmatter(slug);
     if (!existing) {
@@ -86,6 +116,20 @@ export async function PUT(
         { error: `page not found: ${slug}` },
         { status: 404 },
       );
+    }
+
+    // Realm-aware write ACL. Denied → cloak: a private page the caller can't
+    // read is 404 (no existence oracle); readable-but-unwritable is 403.
+    if (!canWriteFrontmatter(existing.frontmatter, principal)) {
+      return canReadFrontmatter(existing.frontmatter, principal)
+        ? NextResponse.json(
+            { error: "You don't have permission to edit this page." },
+            { status: 403 },
+          )
+        : NextResponse.json(
+            { error: `page not found: ${slug}` },
+            { status: 404 },
+          );
     }
 
     // Derive title from the new body's first H1, falling back to the old title.

--- a/src/lib/__tests__/authz.test.ts
+++ b/src/lib/__tests__/authz.test.ts
@@ -4,12 +4,19 @@ import {
   canReadEntry,
   canReadFrontmatter,
   canSetPrivate,
+  canWritePage,
+  canWriteFrontmatter,
 } from "../authz";
 import { agentOwnerHandle } from "../agents";
 import type { IndexEntry } from "../types";
 
 const alice = { handle: "alice" };
 const bob = { handle: "bob" };
+
+// canWritePage needs the full Principal (it inspects `id` for the service case).
+const aliceP = { id: "user_alice", handle: "alice" };
+const bobP = { id: "user_bob", handle: "bob" };
+const service = { id: "service:yopedia", handle: "yopedia" };
 
 describe("agentOwnerHandle", () => {
   it("recovers the owner slug from a composite agent id", () => {
@@ -86,5 +93,61 @@ describe("canSetPrivate", () => {
   });
   it("denies service/token principals", async () => {
     expect(await canSetPrivate({ id: "service:ci", handle: "ci" })).toBe(false);
+  });
+});
+
+describe("canWritePage", () => {
+  it("public commons pages are collectively editable by any signed-in user", () => {
+    const pub = { owner: "alice", visibility: "public" };
+    expect(canWritePage(pub, aliceP)).toBe(true);
+    expect(canWritePage(pub, bobP)).toBe(true); // collective
+  });
+
+  it("public pages: the per-page ACL doesn't restrict (auth is the middleware's job)", () => {
+    // The write-gate middleware already rejected anon mutations; the per-page
+    // ACL only guards PRIVATE pages, so a public page passes here.
+    expect(canWritePage({ owner: "alice", visibility: "public" }, null)).toBe(true);
+  });
+
+  it("private pages fail closed for an anonymous principal", () => {
+    expect(canWritePage({ owner: "alice", visibility: "private" }, null)).toBe(false);
+  });
+
+  it("private pages are writable only by the owner", () => {
+    const priv = { owner: "alice", visibility: "private" };
+    expect(canWritePage(priv, aliceP)).toBe(true);
+    expect(canWritePage(priv, bobP)).toBe(false); // the security fix
+  });
+
+  it("a private agent-owned page is writable by the agent's human owner", () => {
+    const priv = {
+      owner: "alice--yoyo",
+      visibility: "private",
+      type: "agent-knowledge",
+    };
+    expect(canWritePage(priv, aliceP)).toBe(true); // alice owns the agent
+    expect(canWritePage(priv, bobP)).toBe(false);
+  });
+
+  it("the service principal may write anything (autonomous agents / jobs)", () => {
+    expect(canWritePage({ owner: "alice", visibility: "private" }, service)).toBe(true);
+    expect(canWritePage({ owner: "bob", visibility: "private" }, service)).toBe(true);
+  });
+
+  it("fails closed on a private page with no owner", () => {
+    expect(canWritePage({ visibility: "private" }, aliceP)).toBe(false);
+  });
+});
+
+describe("canWriteFrontmatter", () => {
+  it("coerces frontmatter fields and applies the same rule", () => {
+    expect(
+      canWriteFrontmatter({ owner: "alice", visibility: "private" }, aliceP),
+    ).toBe(true);
+    expect(
+      canWriteFrontmatter({ owner: "alice", visibility: "private" }, bobP),
+    ).toBe(false);
+    // Non-string fields → treated as public → collectively editable.
+    expect(canWriteFrontmatter({ owner: 123, visibility: 1 }, bobP)).toBe(true);
   });
 });

--- a/src/lib/__tests__/ingest-routes.test.ts
+++ b/src/lib/__tests__/ingest-routes.test.ts
@@ -546,4 +546,29 @@ describe("POST /api/ingest/reingest — service token auth", () => {
       expect.objectContaining({ author: "alice", triggeredBy: "alice" }),
     );
   });
+
+  it("cloaks a non-owner re-ingesting a PRIVATE page (404), never calling reingest", async () => {
+    mockedGetPrincipal.mockResolvedValue({ id: "clerk-user", handle: "alice" });
+    mockedGetServicePrincipal.mockReturnValue(null);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const bobSecretPage: any = {
+      content: "# Secret",
+      frontmatter: {
+        title: "Secret",
+        source_url: "https://example.com/source",
+        owner: "bob",
+        visibility: "private",
+      },
+    };
+    mockedReadWikiPage.mockResolvedValue(bobSecretPage);
+
+    const res = await POST_REINGEST(
+      makeRequest("http://localhost:3000/api/ingest/reingest", {
+        slug: "bob-secret",
+      }),
+    );
+    // A private page the caller can't read is "not found" (no existence oracle).
+    expect(res.status).toBe(404);
+    expect(mockedReingest).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/__tests__/mcp.test.ts
+++ b/src/lib/__tests__/mcp.test.ts
@@ -1014,6 +1014,49 @@ describe("update_metadata", () => {
     expect(fileContent).toContain("Original body.");
   });
 
+  it("patches a PRIVATE page's metadata via the trusted MCP path (realm-aware ACL)", async () => {
+    // MCP is deployment-trusted; update_metadata must still work on a private
+    // page (the write ACL admits it via a service principal). Before the fix
+    // this threw NOT_OWNER because no principal was threaded through.
+    const { writeWikiPageWithSideEffects, serializeFrontmatter } = await import(
+      "../wiki"
+    );
+    await writeWikiPageWithSideEffects({
+      slug: "mcp-private",
+      title: "MCP Private",
+      content: serializeFrontmatter(
+        {
+          owner: "alice",
+          visibility: "private",
+          authors: ["alice"],
+          contributors: [],
+          created: "2026-01-01",
+          confidence: 0.5,
+          expiry: "2099-01-01",
+          sources: [],
+        },
+        "# MCP Private\n\nSecret body.",
+      ),
+      summary: "private",
+      logOp: "ingest",
+      crossRefSource: null,
+    });
+
+    const result = await handleUpdateMetadata({
+      slug: "mcp-private",
+      metadata: { confidence: 0.95 },
+    });
+    expect(result.updated).toBe(true);
+
+    const fileContent = await fs.readFile(
+      path.join(tmpDir, "wiki", "mcp-private.md"),
+      "utf-8",
+    );
+    expect(fileContent).toContain("confidence: 0.95");
+    expect(fileContent).toContain("Secret body.");
+    expect(fileContent).toContain("visibility: private");
+  });
+
   it("rejects lifecycle-managed fields", async () => {
     await handleCreatePage({
       slug: "meta-lifecycle",

--- a/src/lib/__tests__/wiki-routes.test.ts
+++ b/src/lib/__tests__/wiki-routes.test.ts
@@ -5,6 +5,8 @@ import path from "path";
 
 vi.mock("@/lib/auth", () => ({
   getPrincipal: vi.fn(async () => ({ id: "test-user", handle: "test-user" })),
+  // The write routes resolve a service principal as a fallback; default to none.
+  getServicePrincipal: vi.fn(() => null),
 }));
 
 import {
@@ -14,6 +16,9 @@ import {
   writeWikiPageWithSideEffects,
 } from "../wiki";
 import type { Frontmatter } from "../frontmatter";
+import { getPrincipal } from "@/lib/auth";
+
+const mockedGetPrincipal = vi.mocked(getPrincipal);
 
 // ---------------------------------------------------------------------------
 // Temp directory setup — mirrors lifecycle.test.ts approach
@@ -538,6 +543,102 @@ describe("PATCH /api/wiki/[slug] — metadata updates", () => {
 // ---------------------------------------------------------------------------
 // GET /api/wiki — agent-identity filtering
 // ---------------------------------------------------------------------------
+
+describe("realm-aware write ACL — /api/wiki/[slug]", () => {
+  async function seed(slug: string, fm: Frontmatter) {
+    const today = new Date().toISOString().slice(0, 10);
+    const full: Frontmatter = {
+      created: today,
+      confidence: 0.5,
+      authors: [typeof fm.owner === "string" ? fm.owner : "system"],
+      contributors: [],
+      expiry: "2099-01-01",
+      sources: [],
+      ...fm,
+    };
+    await writeWikiPageWithSideEffects({
+      slug,
+      title: slug,
+      content: serializeFrontmatter(full, `# ${slug}\n\nOriginal secret.`),
+      summary: "a test page",
+      logOp: "ingest",
+      crossRefSource: null,
+    });
+  }
+  async function put(slug: string) {
+    const { PUT } = await import("@/app/api/wiki/[slug]/route");
+    return PUT(
+      new Request(`http://localhost/api/wiki/${slug}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: `# ${slug}\n\nEdited.` }),
+      }),
+      { params: Promise.resolve({ slug }) },
+    );
+  }
+  async function del(slug: string) {
+    const { DELETE } = await import("@/app/api/wiki/[slug]/route");
+    return DELETE(
+      new Request(`http://localhost/api/wiki/${slug}`, { method: "DELETE" }),
+      { params: Promise.resolve({ slug }) },
+    );
+  }
+  async function patch(slug: string) {
+    const { PATCH } = await import("@/app/api/wiki/[slug]/route");
+    return PATCH(
+      new Request(`http://localhost/api/wiki/${slug}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ metadata: { confidence: 0.9 } }),
+      }),
+      { params: Promise.resolve({ slug }) },
+    );
+  }
+
+  it("cloaks a non-owner editing a private page (PUT 404, no oracle); body unchanged", async () => {
+    await seed("alice-secret", { owner: "alice", visibility: "private" });
+    // Default mock principal is "test-user" — not the owner. A private page they
+    // can't read is 404 (indistinguishable from missing), not a 403 oracle.
+    const res = await put("alice-secret");
+    expect(res.status).toBe(404);
+    const page = await readWikiPageWithFrontmatter("alice-secret");
+    expect(page!.body).toContain("Original secret.");
+  });
+
+  it("cloaks a non-owner deleting a private page (DELETE 404)", async () => {
+    await seed("alice-secret-del", { owner: "alice", visibility: "private" });
+    const res = await del("alice-secret-del");
+    expect(res.status).toBe(404);
+    expect(await readWikiPageWithFrontmatter("alice-secret-del")).not.toBeNull();
+  });
+
+  it("cloaks a non-owner patching a private page's metadata (PATCH 404)", async () => {
+    await seed("alice-secret-patch", { owner: "alice", visibility: "private" });
+    const res = await patch("alice-secret-patch");
+    expect(res.status).toBe(404);
+  });
+
+  it("allows the owner to edit their own private page (PUT 200)", async () => {
+    await seed("alice-own", { owner: "alice", visibility: "private" });
+    mockedGetPrincipal.mockResolvedValueOnce({ id: "u_alice", handle: "alice" });
+    const res = await put("alice-own");
+    expect(res.status).toBe(200);
+  });
+
+  it("allows a private agent-owned page to be edited by the agent's human owner", async () => {
+    await seed("alice-agent-note", { owner: "alice--yoyo", visibility: "private" });
+    mockedGetPrincipal.mockResolvedValueOnce({ id: "u_alice", handle: "alice" });
+    const res = await put("alice-agent-note");
+    expect(res.status).toBe(200);
+  });
+
+  it("keeps PUBLIC pages collectively editable by any signed-in user (PUT 200)", async () => {
+    // Owner is someone else, but a public commons page stays collectively editable.
+    await seed("shared-public", { owner: "alice", visibility: "public" });
+    const res = await put("shared-public"); // principal = test-user (non-owner)
+    expect(res.status).toBe(200);
+  });
+});
 
 describe("GET /api/wiki — agent-identity filtering", () => {
   async function seedPage(slug: string, fm: Frontmatter = {}) {

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -92,6 +92,61 @@ export async function canReadSlug(
   return canReadFrontmatter(page.frontmatter, principal);
 }
 
+// ---------------------------------------------------------------------------
+// Write-path authorization (realm-aware writes)
+// ---------------------------------------------------------------------------
+
+/**
+ * True iff `principal` may WRITE a page (edit / patch / delete / re-ingest),
+ * mirroring the realm model and staying symmetric with {@link canReadPage}:
+ *
+ *   - The deployment-trusted **service principal** (bearer token) may write
+ *     anything — it is how autonomous agents and scheduled jobs write on an
+ *     owner's behalf (the caller sets `owner` explicitly).
+ *   - **Public** (commons) pages are collectively editable by any signed-in
+ *     user — the commons is a shared wiki.
+ *   - **Private** (vault) pages are writable ONLY by the set {@link canReadPage}
+ *     admits for a private page: the owner's human and that human's agents
+ *     (`<user>--<name>` resolves to `<user>`). So a user's agents can write
+ *     their owner's private vault, but no one else can.
+ *
+ * The per-page ACL only restricts **private** pages; authentication for public
+ * edits is the write-gate middleware's job (it rejects unauthenticated
+ * mutations), so a public page is writable by any caller that reached here.
+ * Private pages fail-closed for an anonymous principal.
+ */
+export function canWritePage(
+  meta: PageReadMeta,
+  principal: Principal | null,
+): boolean {
+  // Deployment-trusted automated caller — writes for owners (agents, cron).
+  if (principal?.id.startsWith("service:")) return true;
+  // Public / collective commons — editable by any caller the write-gate admits.
+  if (meta.visibility !== "private") return true;
+  // Private — exactly the owner-equivalence class that may READ it (requires an
+  // authenticated, matching principal).
+  if (!principal) return false;
+  return canReadPage(
+    { owner: meta.owner, visibility: "private", type: meta.type },
+    principal,
+  );
+}
+
+/** {@link canWritePage} over a parsed frontmatter record. */
+export function canWriteFrontmatter(
+  fm: { owner?: unknown; visibility?: unknown; type?: unknown },
+  principal: Principal | null,
+): boolean {
+  return canWritePage(
+    {
+      owner: typeof fm.owner === "string" ? fm.owner : undefined,
+      visibility: typeof fm.visibility === "string" ? fm.visibility : undefined,
+      type: typeof fm.type === "string" ? fm.type : undefined,
+    },
+    principal,
+  );
+}
+
 /**
  * True when the principal is entitled to create private (paid) content.
  *

--- a/src/lib/patch-metadata.ts
+++ b/src/lib/patch-metadata.ts
@@ -88,6 +88,23 @@ export async function patchMetadata(
     throw err;
   }
 
+  // Realm-aware write ACL: a private page's metadata may only be patched by its
+  // owner (or their agents / the service principal); public commons pages stay
+  // collectively editable. Enforced here so REST and MCP share the same gate.
+  // Denied → cloak: a private page the caller can't read is "not found" (no
+  // existence oracle, matching reads); a readable-but-unwritable page is 403.
+  const { canReadFrontmatter, canWriteFrontmatter } = await import("./authz");
+  if (!canWriteFrontmatter(existing.frontmatter, principal)) {
+    if (canReadFrontmatter(existing.frontmatter, principal)) {
+      const err = new Error("You don't have permission to edit this page.");
+      (err as NodeJS.ErrnoException).code = "NOT_OWNER";
+      throw err;
+    }
+    const err = new Error(`page not found: ${slug}`);
+    (err as NodeJS.ErrnoException).code = "NOT_FOUND";
+    throw err;
+  }
+
   // Making a page private is a paid, owner-only action — enforced here, the
   // single shared write path for both REST and MCP.
   if ("visibility" in metadata && metadata.visibility === "private") {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -301,6 +301,11 @@ export async function handleUpdateMetadata(args: {
     slug: args.slug,
     metadata: args.metadata,
     author: args.author,
+    // MCP is deployment-trusted (stdio-only). Act as a service principal so the
+    // realm-aware write ACL admits metadata patches on private pages (setting
+    // visibility:private stays paid-gated via canSetPrivate, which rejects
+    // service principals — unchanged from before).
+    principal: { id: "service:mcp", handle: args.author ?? "system" },
   });
 }
 


### PR DESCRIPTION
First half of B2 (realm-aware writes). Closes the edit-ACL gap: previously **any signed-in user could PUT/PATCH/DELETE/re-ingest any page** (ownership gated *reads* only, not writes).

## The model
`canWritePage(meta, principal)` / `canWriteFrontmatter` in `authz.ts`:
- **Service principal** (`id` starts with `service:`) → writes anything. This is how autonomous agents and scheduled jobs write on an owner's behalf (the caller sets `owner` explicitly).
- **Public** (commons) pages → collectively editable by any signed-in user (the commons is a shared wiki; auth is the middleware's job).
- **Private** (vault) pages → writable only by the owner-equivalence class `canReadPage` already admits: the owner **and that owner's agents** (`<user>--<name>` → `<user>`). So *a user's agents can write their private vault* (both mediated and via the service token); no one else can.

Enforced in **PUT, DELETE, PATCH** (`src/app/api/wiki/[slug]/route.ts`, REST + the MCP `update_metadata` path via `src/lib/patch-metadata.ts`) and **re-ingest** (`src/app/api/ingest/reingest/route.ts`).

## Security review (silent-failure-hunter) — core sound, 3 findings handled
- **No bypass**: `service:` ids are minted only by `getServicePrincipal` behind a constant-time token compare; Clerk ids are `user_…` and read server-side. The agent-owner equivalence reuse of `canReadPage` is correct for writes. No authz-swallowing catches.
- **Fixed regression**: MCP `update_metadata` called `patchMetadata` without a principal → the new gate rejected even the owner's private-page patches. Now passes a trusted (service) principal; setting `visibility:private` stays paid-gated as before.
- **404-cloak**: a private page a non-owner can't read returns **404, not a 403 existence oracle** (matches the read surfaces). Write is checked first, so the trusted service principal is never cloaked.

## Tests
- `canWritePage` / `canWriteFrontmatter` units (owner, agent-owned, public-collective, service, fail-closed).
- Route enforcement: non-owner private PUT/DELETE/PATCH/re-ingest → 404 (cloaked); owner & agent's-human-owner → 200; public collective → 200.
- MCP private-metadata-patch regression test.
- **Full suite 2502 green**; `tsc` clean (6 pre-existing unrelated errors); lint clean.

## Known follow-up (next PR — NOT this one)
The ingest **dedup** path (`attachIngestTrigger`) is still visibility-blind: a non-owner ingesting content/a URL matching an existing **private** page can mutate it and learn its slug. Per the model (private = owner-only), the fix is to make dedup owner/visibility-aware so non-owner ingestion never resolves to a private page. Tracked as the immediate next change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)