### PR TITLE
yopedia: visibility-aware ingest dedup (private pages owner-only)

### DIFF
--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -25,10 +25,17 @@ import {
 import { findRelatedPages, updateRelatedPages } from "../search";
 import { parseSources } from "../sources";
 import { MAX_LLM_INPUT_CHARS } from "../constants";
-import { listWikiPages, readWikiPage, writeWikiPage, readWikiPageWithFrontmatter } from "../wiki";
+import {
+  listWikiPages,
+  readWikiPage,
+  writeWikiPage,
+  readWikiPageWithFrontmatter,
+  serializeFrontmatter,
+  type Frontmatter,
+} from "../wiki";
 import { resetSourceIndex } from "../source-index";
 import { resetAliasIndex } from "../alias-index";
-import { hasEmbeddingSupport, searchByVector } from "../embeddings";
+import { hasEmbeddingSupport, searchByVector, contentHash } from "../embeddings";
 import type { IndexEntry } from "../types";
 
 const mockedHasEmbeddingSupport = vi.mocked(hasEmbeddingSupport);
@@ -2006,6 +2013,150 @@ describe("ingest — reconcile on merge", () => {
     expect(page!.content).toContain("Fresh synthesis body.");
     expect(page!.frontmatter.disputed).toBe(false);
     expect(Number(page!.frontmatter.source_count)).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ingest — realm guard: never converge a non-owner onto a PRIVATE page
+// (private = owner-only; the Finding-1 fix)
+// ---------------------------------------------------------------------------
+
+describe("ingest — private-page convergence guard", () => {
+  beforeEach(() => {
+    resetSourceIndex();
+    resetAliasIndex();
+    mockedHasLLMKey.mockReturnValue(true);
+  });
+  afterEach(() => {
+    mockedHasLLMKey.mockReturnValue(false);
+    mockedCallLLM.mockReset();
+  });
+
+  /** Seed a PRIVATE page owned by `owner` with the given slug + body/hash. */
+  async function seedPrivate(
+    slug: string,
+    owner: string,
+    body: string,
+    extra: Partial<Frontmatter> = {},
+  ) {
+    const fm: Frontmatter = {
+      created: "2026-01-01",
+      updated: "2026-01-01",
+      owner,
+      visibility: "private",
+      authors: [owner],
+      contributors: [],
+      source_count: "1",
+      confidence: 0.7,
+      expiry: "2099-01-01",
+      tags: [],
+      content_hash: contentHash(body),
+      ...extra,
+    };
+    await writeWikiPage(slug, serializeFrontmatter(fm, `# ${slug}\n\n${body}`));
+    // Rebuild the source + alias indexes so the seeded page is resolvable.
+    resetSourceIndex();
+    resetAliasIndex();
+  }
+
+  it("does NOT dedup a non-owner's identical-content ingest into a private page", async () => {
+    const body = "Identical body for the private dedup test. More detail here.";
+    await seedPrivate("alice-secret", "alice", body);
+    mockedCallLLM.mockResolvedValue(
+      "CONCEPT: Bob Topic\nALIASES: none\n\n# Bob Topic\n\n## Summary\n\nBob's own.",
+    );
+
+    const result = await ingest("Bob Doc", body, {
+      owner: "bob",
+      author: "bob",
+    });
+
+    // Bob got his OWN page, not alice's private slug.
+    expect(result.primarySlug).not.toBe("alice-secret");
+    expect(result.deduped).toBeFalsy();
+    // Alice's private page is untouched (no new source, no bob contributor).
+    const priv = await readWikiPageWithFrontmatter("alice-secret");
+    expect(Number(priv!.frontmatter.source_count)).toBe(1);
+    expect(priv!.frontmatter.contributors).not.toContain("bob");
+  });
+
+  it("forks when a non-owner's concept slug collides with a private page", async () => {
+    await seedPrivate("transformer", "alice", "Alice's private notes on transformers.");
+    mockedCallLLM.mockResolvedValue(
+      "CONCEPT: Transformer\nALIASES: none\n\n# Transformer\n\n## Summary\n\nBob's public take.",
+    );
+
+    const result = await ingest("Bob On Transformers", "Bob's distinct source text about them.", {
+      owner: "bob",
+      author: "bob",
+    });
+
+    // Forked off the occupied private slug.
+    expect(result.primarySlug).not.toBe("transformer");
+    expect(result.primarySlug).toMatch(/^transformer-\d+$/);
+    // Alice's private page is untouched.
+    const priv = await readWikiPageWithFrontmatter("transformer");
+    expect(priv!.frontmatter.owner).toBe("alice");
+    expect(priv!.frontmatter.visibility).toBe("private");
+    expect(Number(priv!.frontmatter.source_count)).toBe(1);
+  });
+
+  it("lets the OWNER re-ingest into their own private page (merge, no fork)", async () => {
+    await seedPrivate("transformer", "alice", "Alice's first private take on transformers.");
+    mockedCallLLM.mockResolvedValue(
+      "CONCEPT: Transformer\nALIASES: none\n\n# Transformer\n\n## Summary\n\nAlice's refined take.",
+    );
+
+    const result = await ingest("Transformers", "Alice's second private source.", {
+      owner: "alice",
+      author: "alice",
+    });
+
+    expect(result.primarySlug).toBe("transformer");
+    const priv = await readWikiPageWithFrontmatter("transformer");
+    expect(Number(priv!.frontmatter.source_count)).toBe(2);
+    expect(priv!.frontmatter.visibility).toBe("private"); // stays private
+  });
+
+  it("lets the owner's AGENT write the owner's private page (agents of owner can write his vault)", async () => {
+    await seedPrivate("transformer", "alice", "Alice's first private take.");
+    mockedCallLLM.mockResolvedValue(
+      "CONCEPT: Transformer\nALIASES: none\n\n# Transformer\n\n## Summary\n\nAgent's addition.",
+    );
+
+    // The agent acts for alice (owner = alice--yoyo → same human owner).
+    const result = await ingest("Transformers", "A source the agent found.", {
+      owner: "alice--yoyo",
+      author: "alice--yoyo",
+    });
+
+    expect(result.primarySlug).toBe("transformer");
+    expect(Number((await readWikiPageWithFrontmatter("transformer"))!.frontmatter.source_count)).toBe(2);
+  });
+
+  it("does NOT leak a private page's slug via PREVIEW (forks before returning)", async () => {
+    await seedPrivate("transformer", "alice", "Alice's private notes on transformers.");
+    mockedCallLLM.mockResolvedValue(
+      "CONCEPT: Transformer\nALIASES: none\n\n# Transformer\n\n## Summary\n\nBob preview.",
+    );
+
+    // Bob previews under a title that resolves (via the alias index) to alice's
+    // private slug "transformer". The fork guard must run BEFORE the preview
+    // return, so the private slug never comes back.
+    const result = await ingest("Transformer", "Bob's distinct source text.", {
+      owner: "bob",
+      author: "bob",
+      preview: true,
+    });
+
+    expect(result.previewContent).toBeDefined();
+    expect(result.primarySlug).not.toBe("transformer");
+    expect(result.wikiPages).not.toContain("transformer");
+    expect(result.relatedUpdated).not.toContain("transformer");
+    // Nothing was written (preview): alice's page still has one source.
+    expect(
+      Number((await readWikiPageWithFrontmatter("transformer"))!.frontmatter.source_count),
+    ).toBe(1);
   });
 });
 

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -55,6 +55,7 @@ import {
   updateSourceIndexForPage,
 } from "./source-index";
 import { contentHash, searchByVector, hasEmbeddingSupport } from "./embeddings";
+import { canReadEntry } from "./authz";
 import { getStorage } from "./storage";
 import { logger } from "./logger";
 
@@ -156,6 +157,7 @@ export async function ingestUrl(
         url,
         type: options?.sourceType ?? "url",
         triggeredBy: options?.triggeredBy,
+        actorOwner: options?.owner ?? options?.author,
       });
       if (result) return result;
     }
@@ -223,6 +225,7 @@ export async function ingestImage(
         url: imageUrl,
         type: "image",
         triggeredBy: options?.triggeredBy,
+        actorOwner: options?.owner ?? options?.author,
       });
       if (result) return result;
     }
@@ -293,6 +296,7 @@ export async function ingestPdf(
           url,
           type: "pdf",
           triggeredBy: options?.triggeredBy,
+          actorOwner: options?.owner ?? options?.author,
         });
         if (result) return result;
       }
@@ -922,16 +926,61 @@ export interface IngestOptions {
  * body is unchanged) any new embedding. Returns `null` if the page is missing
  * (stale index) so the caller can fall through to a normal ingest.
  */
+/**
+ * Reduce a handle to its human identity: an agent id `<user>--<name>` collapses
+ * to `<user>` (slugified), a plain handle slugifies as-is. Mirrors the
+ * owner-equivalence `canReadPage`/`canWritePage` use, at the handle level.
+ */
+function humanOf(handle: string): string {
+  const i = handle.indexOf("--");
+  return slugify(i >= 0 ? handle.slice(0, i) : handle);
+}
+
+/**
+ * True iff ingest actor `actorOwner` belongs to the same human-owner class as a
+ * page owned by `pageOwner` — i.e. the actor (or their agent) owns it. Used to
+ * decide whether an ingest may converge onto a PRIVATE page: private content is
+ * owner-only, so a non-owner must never dedup/merge into it.
+ */
+function sameHumanOwner(actorOwner: string | undefined, pageOwner: unknown): boolean {
+  if (typeof pageOwner !== "string" || pageOwner.trim() === "") return false;
+  if (!actorOwner || actorOwner.trim() === "") return false;
+  return humanOf(actorOwner) === humanOf(pageOwner);
+}
+
+/** Find a slug not taken by any existing page (`base`, `base-2`, `base-3`, …). */
+async function findFreeSlug(base: string): Promise<string> {
+  let candidate = base;
+  let n = 2;
+  while (await readWikiPageWithFrontmatter(candidate)) {
+    candidate = `${base}-${n++}`;
+  }
+  return candidate;
+}
+
 async function attachIngestTrigger(
   slug: string,
   source: {
     url: string;
     type: SourceEntry["type"];
     triggeredBy?: string;
+    /** The ingest's acting owner — used to gate dedup into a PRIVATE page. */
+    actorOwner?: string;
   },
 ): Promise<IngestResult | null> {
   const existing = await readWikiPageWithFrontmatter(slug);
   if (!existing) return null; // index drifted — let the caller ingest normally
+
+  // Realm-aware dedup: private content is owner-only, so a caller who isn't the
+  // owner (or their agent) must NOT dedup into a private page — no write, no
+  // slug leak. Return null so the caller falls through to a normal ingest that
+  // creates the actor's OWN page.
+  if (
+    existing.frontmatter.visibility === "private" &&
+    !sameHumanOwner(source.actorOwner, existing.frontmatter.owner)
+  ) {
+    return null;
+  }
 
   const frontmatter: Frontmatter = { ...existing.frontmatter };
   frontmatter.updated = new Date().toISOString().slice(0, 10);
@@ -1066,6 +1115,7 @@ export async function ingest(
         url: options?.sourceUrl ?? "text-paste",
         type: options?.sourceType ?? (options?.sourceUrl ? "url" : "text"),
         triggeredBy: options?.triggeredBy,
+        actorOwner: owner,
       });
       if (result) return result;
     }
@@ -1146,10 +1196,30 @@ export async function ingest(
   // the original document, not the LLM's reformatting.
   const summary = extractSummary(content);
 
+  // Realm guard: never converge onto a PRIVATE page this actor can't write
+  // (private = owner-only). If the resolved slug landed on someone else's
+  // private page — via the concept resolver, an alias, or a slug collision —
+  // FORK to a fresh slug so the ingest produces the actor's OWN page and never
+  // writes to (or leaks the slug of) the private one. Runs BEFORE the preview
+  // return too, so a non-owner's preview can't read back the private slug.
+  const resolvedExisting = await readWikiPageWithFrontmatter(slug);
+  if (
+    resolvedExisting &&
+    resolvedExisting.frontmatter.visibility === "private" &&
+    !sameHumanOwner(owner, resolvedExisting.frontmatter.owner)
+  ) {
+    slug = await findFreeSlug(slug);
+  }
+
   // --- Preview mode: return the generated content without writing ---
   if (isPreview) {
-    // Identify which related pages would be updated (read-only check)
-    const existingEntries = await listWikiPages();
+    // Identify which related pages would be updated — read-gated to the actor
+    // so a private page the actor can't read never leaks (title/summary/slug)
+    // into the preview's cross-ref set.
+    const reader = owner ? { handle: owner } : null;
+    const existingEntries = (await listWikiPages()).filter((e) =>
+      canReadEntry(e, reader),
+    );
     const relatedSlugs = await findRelatedPages(slug, content, existingEntries);
 
     return {


### PR DESCRIPTION
Closes **Finding 1** from the B2a security review: the ingest pipeline could converge a non-owner's ingest onto someone else's **private** page — writing to it (adding the non-owner as a contributor, bumping counters) and leaking its slug. Enforces the invariant: *private content is owner-only, so a non-owner's ingest never matches a private page.*

## The fix (two guards in `src/lib/ingest.ts`)
1. **Dedup guard** (`attachIngestTrigger`): the dedup path (`resolveSourceUrl`/`resolveContentHash` → `attachIngestTrigger`) now takes `actorOwner`; if the matched page is private and the actor isn't its owner (or the owner's agent), it returns `null` → the caller falls through to a normal ingest creating the actor's **own** page. Threaded into all 4 dedup call sites (text/url/image/pdf).
2. **Fork guard** (commit path, before `saveRawSource` **and** before the preview return): re-reads the resolved `slug`; if it landed on a private page the actor can't write (concept-slug exact/alias resolution, or a slug collision), `findFreeSlug` forks to a fresh slug. No write to — and no slug leak of — the private page.
3. **Preview read-gating**: preview's `findRelatedPages` set is filtered by `canReadEntry`, so a private page's title/summary/slug never leaks into a non-owner's preview.

Helpers: `humanOf` (`<user>--<name>` → `<user>`), `sameHumanOwner` (handle-level owner-equivalence, mirrors `canReadPage`), `findFreeSlug`.

## Owner + agents preserved
The owner — and that owner's agents (`alice--yoyo` → `alice`) — still write their own private pages (re-ingest merges; the agent path merges). Verified by tests.

## Security review (silent-failure-hunter)
- **Write vector: fully closed** on every commit path (text content-hash, url/image/pdf dedup, concept exact/alias/semantic, slug collision, commit-from-preview). Fork runs before the first write.
- **Caught + fixed a CRITICAL preview leak** (the fork originally ran *after* the preview return) — now closed.
- **`sameHumanOwner`**: no false-allow; fail-closed on empty/missing owner; agent-id `--` handling correct.
- **Residual** (confirmed *not* a security hole): private pages stay in the source index, so an owner's later re-ingest of the same source can route to a public fork (intent-integrity nit, not a private write/leak). Optional follow-up.

## Tests
5 new (`ingest — private-page convergence guard`): non-owner dedup blocked, fork-on-collision, owner re-ingest merges, agent-of-owner merges, preview no-leak. **Full suite 2507 green**; tsc clean (6 pre-existing unrelated); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)