### PR TITLE
yopedia: Q0+Q1 agent task queue — on-demand reconcile

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -77,3 +77,14 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx wrangler deploy --config workers/x-ingest/wrangler.jsonc
+
+      # Standalone consumer for the agent task queue (Cloudflare Queues). Drains
+      # `yopedia-tasks` and POSTs each task to the main app's /api/tasks/run.
+      # Secret YOPEDIA_SERVICE_TOKEN is set once via
+      # `wrangler secret put --config workers/task-consumer/wrangler.jsonc`; the
+      # queue + DLQ are created once via `wrangler queues create`.
+      - name: Deploy task-consumer Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler deploy --config workers/task-consumer/wrangler.jsonc

--- a/src/app/api/tasks/run/route.ts
+++ b/src/app/api/tasks/run/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { getServicePrincipal } from "@/lib/auth";
+import { parseTask } from "@/lib/tasks";
+import { reconcileFromTalk } from "@/lib/reconcile";
+import { ingest, ingestUrl } from "@/lib/ingest";
+import { agentIdFor, DEFAULT_AGENT_NAME } from "@/lib/agents";
+import { getErrorMessage } from "@/lib/errors";
+import { logger } from "@/lib/logger";
+
+/**
+ * POST /api/tasks/run — execute one agent task.
+ *
+ * The SOLE caller is the task-consumer worker (`workers/task-consumer/`), which
+ * drains the Cloudflare Queue and POSTs each message here with the service
+ * token. Gated to {@link getServicePrincipal} only — never a human/Clerk session.
+ *
+ * Status contract (drives the consumer's ack/retry, which maps to CF Queues):
+ *   - 2xx → done, ack the message.
+ *   - 4xx → permanently-bad/poison task → ack + drop (don't retry; → DLQ on the
+ *           consumer side if it chooses). Malformed body, or a missing page/thread.
+ *   - 5xx → transient failure → the consumer retries (CF redelivers; DLQ after
+ *           max_retries).
+ *
+ * Handlers are idempotent/retry-safe: reconcile re-reconciles harmlessly, ingest
+ * dedups.
+ */
+export async function POST(req: Request) {
+  // Service-token only.
+  const principal = getServicePrincipal(req);
+  if (!principal) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const task = parseTask(body);
+  if (!task) {
+    // Poison message — don't retry.
+    return NextResponse.json({ error: "malformed task" }, { status: 400 });
+  }
+
+  try {
+    if (task.kind === "reconcile") {
+      // Attribute the edit to the requester's yoyo (the human who asked), else a
+      // generic yoyo for autonomous/unknown triggers.
+      const author = task.requestedBy
+        ? agentIdFor(task.requestedBy, DEFAULT_AGENT_NAME)
+        : undefined;
+      const result = await reconcileFromTalk(task.slug, task.threadIndex, {
+        author,
+      });
+      return NextResponse.json({ ok: true, ...result });
+    }
+
+    // kind === "ingest"
+    const opts = {
+      ...(task.owner ? { owner: task.owner } : {}),
+      ...(task.author ? { author: task.author, triggeredBy: task.author } : {}),
+    };
+    const result = task.url
+      ? await ingestUrl(task.url, opts)
+      : await ingest(task.title?.trim() || "Untitled", task.content ?? "", opts);
+    return NextResponse.json({ ok: true, slug: result.primarySlug });
+  } catch (err) {
+    const message = getErrorMessage(err);
+    // A missing page/thread is permanent → poison (4xx), don't retry forever.
+    if (/not found/i.test(message)) {
+      logger.warn("tasks", `task "${task.kind}" permanently failed: ${message}`);
+      return NextResponse.json({ error: message }, { status: 422 });
+    }
+    // Otherwise transient (LLM hiccup, lock contention) → retry.
+    logger.error("tasks", `task "${task.kind}" failed`, err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/wiki/[slug]/discuss/[threadIndex]/ask-yoyo/route.ts
+++ b/src/app/api/wiki/[slug]/discuss/[threadIndex]/ask-yoyo/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { decodeSlug } from "@/lib/slugify";
+import { getThread, addComment } from "@/lib/talk";
+import { getPrincipal } from "@/lib/auth";
+import { canReadSlug } from "@/lib/authz";
+import { enqueueTask } from "@/lib/tasks";
+import { agentIdFor, DEFAULT_AGENT_NAME } from "@/lib/agents";
+import { getErrorMessage } from "@/lib/errors";
+import { logger } from "@/lib/logger";
+
+type RouteParams = { params: Promise<{ slug: string; threadIndex: string }> };
+
+/**
+ * POST /api/wiki/[slug]/discuss/[threadIndex]/ask-yoyo
+ *
+ * The "Ask yoyo to address this" producer: enqueue a `reconcile` task so an
+ * agent reads the page + this thread and revises the page asynchronously (the
+ * "agents maintain, humans discuss" loop). Signed-in only; read-gated (a private
+ * page's discussions are cloaked as 404 for non-owners). Posts a "yoyo is on it"
+ * note so the thread shows pending state; the agent posts the result later.
+ */
+export async function POST(_req: Request, { params }: RouteParams) {
+  try {
+    const { slug: encodedSlug, threadIndex } = await params;
+    const slug = decodeSlug(encodedSlug);
+    const idx = parseInt(threadIndex, 10);
+    if (!Number.isFinite(idx) || idx < 0) {
+      return NextResponse.json(
+        { error: "threadIndex must be a non-negative integer" },
+        { status: 400 },
+      );
+    }
+
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    // Realm-aware read ACL: cloak a private page's discussions as 404.
+    if (!(await canReadSlug(slug, principal))) {
+      return NextResponse.json({ error: "not found" }, { status: 404 });
+    }
+
+    const thread = await getThread(slug, idx);
+    if (!thread) {
+      return NextResponse.json({ error: "thread not found" }, { status: 404 });
+    }
+
+    const queued = await enqueueTask({
+      kind: "reconcile",
+      slug,
+      threadIndex: idx,
+      requestedBy: principal.handle,
+    });
+
+    if (!queued) {
+      // The task queue isn't available (e.g. off the Workers runtime). Surface
+      // it rather than silently claiming success.
+      return NextResponse.json(
+        { error: "Task queue unavailable." },
+        { status: 503 },
+      );
+    }
+
+    // Best-effort pending note from the requester's yoyo, so the thread shows
+    // it's being worked on. Non-fatal if it fails (e.g. a resolved thread).
+    const agent = agentIdFor(principal.handle, DEFAULT_AGENT_NAME);
+    try {
+      await addComment(
+        slug,
+        idx,
+        agent,
+        "🛠 Queued — yoyo will review this thread and update the page shortly.",
+      );
+    } catch (err) {
+      logger.warn("ask-yoyo", "pending note failed (non-fatal):", err);
+    }
+
+    return NextResponse.json({ queued: true });
+  } catch (err) {
+    logger.error("ask-yoyo", "enqueue failed:", err);
+    return NextResponse.json({ error: getErrorMessage(err) }, { status: 500 });
+  }
+}

--- a/src/components/DiscussionPanel.tsx
+++ b/src/components/DiscussionPanel.tsx
@@ -183,6 +183,24 @@ export function DiscussionPanel({ slug }: DiscussionPanelProps) {
     }
   }
 
+  async function handleAskYoyo(idx: number) {
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/wiki/${encodeURIComponent(slug)}/discuss/${idx}/ask-yoyo`,
+        { method: "POST" },
+      );
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `Failed to ask yoyo (${res.status})`);
+      }
+      await fetchThreads();
+      if (expandedIdx === idx) await refreshThread(idx);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  }
+
   async function handleResolve(idx: number, newStatus: "open" | "resolved" | "wontfix") {
     setError(null);
     try {
@@ -288,6 +306,7 @@ export function DiscussionPanel({ slug }: DiscussionPanelProps) {
                       onSubmitReply={handleReplySubmit}
                       onResolve={(status) => handleResolve(idx, status)}
                       onAddComment={handleAddComment}
+                      onAskYoyo={() => handleAskYoyo(idx)}
                       inputClasses={inputClasses}
                     />
                   )}

--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -13,6 +13,9 @@ interface ThreadViewProps {
   onSubmitReply: (parentId: string, author: string, body: string) => Promise<void>;
   onResolve: (status: "open" | "resolved" | "wontfix") => void;
   onAddComment: (author: string, body: string) => Promise<void>;
+  /** Ask yoyo to address this thread (enqueue a reconcile task). Omitted when
+   *  the viewer isn't signed in. */
+  onAskYoyo?: () => Promise<void>;
   inputClasses: string;
 }
 
@@ -25,11 +28,23 @@ export function ThreadView({
   onSubmitReply,
   onResolve,
   onAddComment,
+  onAskYoyo,
   inputClasses,
 }: ThreadViewProps) {
   const [commentAuthor, setCommentAuthor] = useState("");
   const [commentBody, setCommentBody] = useState("");
   const [commenting, setCommenting] = useState(false);
+  const [asking, setAsking] = useState(false);
+
+  async function handleAskYoyo() {
+    if (!onAskYoyo) return;
+    setAsking(true);
+    try {
+      await onAskYoyo();
+    } finally {
+      setAsking(false);
+    }
+  }
 
   async function handleAddComment(e: React.FormEvent) {
     e.preventDefault();
@@ -62,9 +77,20 @@ export function ThreadView({
         ))}
       </div>
 
-      {/* Resolve / Won't Fix buttons for open threads */}
+      {/* Resolve / Won't Fix / Ask-yoyo buttons for open threads */}
       {thread.status === "open" && (
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
+          {onAskYoyo && (
+            <button
+              type="button"
+              onClick={handleAskYoyo}
+              disabled={asking}
+              title="Ask yoyo to read this thread and update the page"
+              className="rounded bg-accent px-3 py-1 text-xs font-medium text-accent-foreground hover:bg-accent-hover disabled:opacity-50"
+            >
+              {asking ? "Queuing…" : "🛠 Ask yoyo to address this"}
+            </button>
+          )}
           <button
             type="button"
             onClick={() => onResolve("resolved")}

--- a/src/lib/__tests__/ask-yoyo-route.test.ts
+++ b/src/lib/__tests__/ask-yoyo-route.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({ getPrincipal: vi.fn() }));
+vi.mock("@/lib/authz", () => ({ canReadSlug: vi.fn() }));
+vi.mock("@/lib/talk", () => ({ getThread: vi.fn(), addComment: vi.fn() }));
+vi.mock("@/lib/tasks", () => ({ enqueueTask: vi.fn() }));
+
+import { getPrincipal } from "@/lib/auth";
+import { canReadSlug } from "@/lib/authz";
+import { getThread, addComment } from "@/lib/talk";
+import { enqueueTask } from "@/lib/tasks";
+
+const mockedGetPrincipal = vi.mocked(getPrincipal);
+const mockedCanReadSlug = vi.mocked(canReadSlug);
+const mockedGetThread = vi.mocked(getThread);
+const mockedAddComment = vi.mocked(addComment);
+const mockedEnqueue = vi.mocked(enqueueTask);
+
+async function ask(slug: string, idx: string) {
+  const { POST } = await import(
+    "@/app/api/wiki/[slug]/discuss/[threadIndex]/ask-yoyo/route"
+  );
+  return POST(new Request("http://localhost", { method: "POST" }), {
+    params: Promise.resolve({ slug, threadIndex: idx }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetPrincipal.mockResolvedValue({ id: "u1", handle: "alice" });
+  mockedCanReadSlug.mockResolvedValue(true);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockedGetThread.mockResolvedValue({ status: "open", comments: [] } as any);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockedAddComment.mockResolvedValue({} as any);
+  mockedEnqueue.mockResolvedValue(true);
+});
+
+describe("POST .../discuss/[threadIndex]/ask-yoyo", () => {
+  it("enqueues a reconcile task attributed to the requester (200)", async () => {
+    const res = await ask("transformers", "2");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ queued: true });
+    expect(mockedEnqueue).toHaveBeenCalledWith({
+      kind: "reconcile",
+      slug: "transformers",
+      threadIndex: 2,
+      requestedBy: "alice",
+    });
+  });
+
+  it("401s when signed out, without enqueuing", async () => {
+    mockedGetPrincipal.mockResolvedValue(null);
+    const res = await ask("p", "0");
+    expect(res.status).toBe(401);
+    expect(mockedEnqueue).not.toHaveBeenCalled();
+  });
+
+  it("404-cloaks a private page the caller can't read", async () => {
+    mockedCanReadSlug.mockResolvedValue(false);
+    const res = await ask("secret", "0");
+    expect(res.status).toBe(404);
+    expect(mockedEnqueue).not.toHaveBeenCalled();
+  });
+
+  it("404s a missing thread", async () => {
+    mockedGetThread.mockResolvedValue(null);
+    const res = await ask("p", "9");
+    expect(res.status).toBe(404);
+    expect(mockedEnqueue).not.toHaveBeenCalled();
+  });
+
+  it("503s when the task queue is unavailable (off-Workers)", async () => {
+    mockedEnqueue.mockResolvedValue(false);
+    const res = await ask("p", "0");
+    expect(res.status).toBe(503);
+  });
+
+  it("400s a bad threadIndex", async () => {
+    const res = await ask("p", "-1");
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/lib/__tests__/middleware-write-gate.test.ts
+++ b/src/lib/__tests__/middleware-write-gate.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from "vitest";
+
+// clerkMiddleware runs at module load (`export default clerkMiddleware(...)`);
+// stub it so importing the middleware doesn't require a Clerk runtime.
+vi.mock("@clerk/nextjs/server", () => ({
+  clerkMiddleware: (fn: unknown) => fn,
+}));
+
+import { authenticatesInRoute } from "@/middleware";
+
+describe("write-gate in-route auth exemptions", () => {
+  it("exempts the service-token-authenticated routes", () => {
+    // These authenticate in-route with a token (no Clerk session) — a missing
+    // entry silently 401s the caller before it reaches the route.
+    expect(authenticatesInRoute("/api/tasks/run")).toBe(true); // task-consumer
+    expect(authenticatesInRoute("/api/ingest")).toBe(true);
+    expect(authenticatesInRoute("/api/ingest/x-mention")).toBe(true);
+    expect(authenticatesInRoute("/api/agents/seed")).toBe(true);
+    expect(authenticatesInRoute("/api/agents/alice--yoyo/ingest")).toBe(true);
+    expect(authenticatesInRoute("/api/admin/migrate")).toBe(true);
+    expect(authenticatesInRoute("/api/admin/tenant/alice")).toBe(true);
+  });
+
+  it("does NOT exempt normal write paths (they need a Clerk session)", () => {
+    expect(authenticatesInRoute("/api/wiki/transformers")).toBe(false);
+    expect(authenticatesInRoute("/api/vault")).toBe(false);
+    expect(authenticatesInRoute("/api/tasks/run/extra")).toBe(false);
+  });
+});

--- a/src/lib/__tests__/reconcile.test.ts
+++ b/src/lib/__tests__/reconcile.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+// Mock the LLM so reconcile never calls a real API.
+vi.mock("../llm", () => ({
+  hasLLMKey: vi.fn(() => true),
+  callLLM: vi.fn(),
+}));
+
+import {
+  ensureDirectories,
+  writeWikiPage,
+  serializeFrontmatter,
+  readWikiPageWithFrontmatter,
+  type Frontmatter,
+} from "../wiki";
+import { createThread, getThread } from "../talk";
+import { reconcileFromTalk } from "../reconcile";
+import { hasLLMKey, callLLM } from "../llm";
+import { _resetStorage } from "../storage";
+
+const mockedHasLLMKey = vi.mocked(hasLLMKey);
+const mockedCallLLM = vi.mocked(callLLM);
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "reconcile-test-"));
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetStorage();
+  await ensureDirectories();
+  mockedHasLLMKey.mockReturnValue(true);
+});
+
+afterEach(async () => {
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  mockedCallLLM.mockReset();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function seedPage(slug: string, body: string, over: Partial<Frontmatter> = {}) {
+  const fm: Frontmatter = {
+    created: "2026-01-01",
+    updated: "2026-01-01",
+    owner: "alice",
+    visibility: "public",
+    authors: ["alice"],
+    contributors: [],
+    confidence: 0.7,
+    expiry: "2099-01-01",
+    tags: [],
+    disputed: false,
+    ...over,
+  };
+  await writeWikiPage(slug, serializeFrontmatter(fm, `# ${slug}\n\n${body}`));
+}
+
+describe("reconcileFromTalk", () => {
+  it("revises the page to address a thread, posts a yoyo reply, and resolves it", async () => {
+    await seedPage("transformers", "Transformers were invented in 2017.");
+    await createThread(
+      "transformers",
+      "Wrong date",
+      "bob",
+      "The invention date is wrong — it was 2015, not 2017.",
+    );
+    mockedCallLLM.mockResolvedValue(
+      "# transformers\n\nTransformers were invented in 2015.",
+    );
+
+    const result = await reconcileFromTalk("transformers", 0, {
+      author: "bob--yoyo",
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.disputed).toBe(false);
+
+    const page = await readWikiPageWithFrontmatter("transformers");
+    expect(page!.body).toContain("invented in 2015");
+    expect(page!.frontmatter.disputed).toBe(false);
+
+    const thread = await getThread("transformers", 0);
+    expect(thread!.status).toBe("resolved");
+    // yoyo posted a reply as the acting agent.
+    const last = thread!.comments[thread!.comments.length - 1];
+    expect(last.author).toBe("bob--yoyo");
+    expect(last.body.toLowerCase()).toContain("updated");
+  });
+
+  it("flags disputed and leaves the thread open on an unresolved contradiction", async () => {
+    await seedPage("ai", "AI was coined in 1956.");
+    await createThread("ai", "Disagree", "carol", "Some say it was 1955.");
+    mockedCallLLM.mockResolvedValue(
+      "DISPUTED: yes\n\n# ai\n\nSources disagree: 1956 (McCarthy) vs 1955 (others).",
+    );
+
+    const result = await reconcileFromTalk("ai", 0);
+
+    expect(result.disputed).toBe(true);
+    const page = await readWikiPageWithFrontmatter("ai");
+    expect(page!.frontmatter.disputed).toBe(true);
+    expect(page!.body).not.toContain("DISPUTED:");
+    // Left open for a human to settle.
+    expect((await getThread("ai", 0))!.status).toBe("open");
+  });
+
+  it("makes no change and does not blank the page on an empty LLM response", async () => {
+    await seedPage("stable", "Original content that must survive.");
+    await createThread("stable", "Vague", "dan", "idk something feels off");
+    mockedCallLLM.mockResolvedValue("");
+
+    const result = await reconcileFromTalk("stable", 0);
+
+    expect(result.changed).toBe(false);
+    expect((await readWikiPageWithFrontmatter("stable"))!.body).toContain(
+      "Original content that must survive.",
+    );
+  });
+
+  it("no-ops when no LLM is configured", async () => {
+    await seedPage("topic", "Body.");
+    await createThread("topic", "t", "ed", "issue");
+    mockedHasLLMKey.mockReturnValue(false);
+
+    const result = await reconcileFromTalk("topic", 0);
+    expect(result.changed).toBe(false);
+    expect(mockedCallLLM).not.toHaveBeenCalled();
+  });
+
+  it("throws on a missing page (→ poison/422 at the route)", async () => {
+    await expect(reconcileFromTalk("nope", 0)).rejects.toThrow(/not found/i);
+  });
+});

--- a/src/lib/__tests__/tasks-route.test.ts
+++ b/src/lib/__tests__/tasks-route.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({ getServicePrincipal: vi.fn() }));
+vi.mock("@/lib/reconcile", () => ({ reconcileFromTalk: vi.fn() }));
+vi.mock("@/lib/ingest", () => ({ ingest: vi.fn(), ingestUrl: vi.fn() }));
+
+import { getServicePrincipal } from "@/lib/auth";
+import { reconcileFromTalk } from "@/lib/reconcile";
+import { ingest, ingestUrl } from "@/lib/ingest";
+
+const mockedGetService = vi.mocked(getServicePrincipal);
+const mockedReconcile = vi.mocked(reconcileFromTalk);
+const mockedIngest = vi.mocked(ingest);
+const mockedIngestUrl = vi.mocked(ingestUrl);
+
+async function run(body: unknown) {
+  const { POST } = await import("@/app/api/tasks/run/route");
+  return POST(
+    new Request("http://localhost/api/tasks/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: authenticated as the service principal.
+  mockedGetService.mockReturnValue({ id: "service:yopedia", handle: "yopedia" });
+});
+
+describe("POST /api/tasks/run", () => {
+  it("401s without the service token (no other side effects)", async () => {
+    mockedGetService.mockReturnValue(null);
+    const res = await run({ kind: "reconcile", slug: "p", threadIndex: 0 });
+    expect(res.status).toBe(401);
+    expect(mockedReconcile).not.toHaveBeenCalled();
+  });
+
+  it("400s a malformed task (poison → don't retry)", async () => {
+    const res = await run({ kind: "bogus" });
+    expect(res.status).toBe(400);
+    expect(mockedReconcile).not.toHaveBeenCalled();
+  });
+
+  it("dispatches a reconcile task, attributing to the requester's yoyo", async () => {
+    mockedReconcile.mockResolvedValue({ slug: "p", changed: true, disputed: false });
+    const res = await run({
+      kind: "reconcile",
+      slug: "p",
+      threadIndex: 3,
+      requestedBy: "alice",
+    });
+    expect(res.status).toBe(200);
+    expect(mockedReconcile).toHaveBeenCalledWith("p", 3, { author: "alice--yoyo" });
+  });
+
+  it("dispatches an ingest task by URL", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedIngestUrl.mockResolvedValue({ primarySlug: "made" } as any);
+    const res = await run({ kind: "ingest", url: "https://example.com", owner: "alice" });
+    expect(res.status).toBe(200);
+    expect(mockedIngestUrl).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.objectContaining({ owner: "alice" }),
+    );
+    expect(mockedIngest).not.toHaveBeenCalled();
+  });
+
+  it("maps a 'not found' failure to 422 (poison), other failures to 500 (retry)", async () => {
+    mockedReconcile.mockRejectedValueOnce(new Error('page "x" not found'));
+    expect((await run({ kind: "reconcile", slug: "x", threadIndex: 0 })).status).toBe(422);
+
+    mockedReconcile.mockRejectedValueOnce(new Error("LLM timeout"));
+    expect((await run({ kind: "reconcile", slug: "x", threadIndex: 0 })).status).toBe(500);
+  });
+});

--- a/src/lib/__tests__/tasks.test.ts
+++ b/src/lib/__tests__/tasks.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock the OpenNext context. Default: throws (off-Workers) → enqueue no-ops.
+// Workers tests opt in by setting a return value with a TASK_QUEUE binding.
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => {
+    throw new Error("no cloudflare context");
+  }),
+}));
+
+import { enqueueTask, parseTask } from "../tasks";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+const mockGetCfContext = getCloudflareContext as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetCfContext.mockImplementation(() => {
+    throw new Error("no cloudflare context");
+  });
+});
+
+describe("enqueueTask", () => {
+  it("no-ops (returns false) off the Workers runtime", async () => {
+    const ok = await enqueueTask({ kind: "reconcile", slug: "p", threadIndex: 0 });
+    expect(ok).toBe(false);
+  });
+
+  it("no-ops when the TASK_QUEUE binding is absent on the runtime", async () => {
+    mockGetCfContext.mockReturnValue({ env: { AI: {} } }); // no TASK_QUEUE
+    const ok = await enqueueTask({ kind: "reconcile", slug: "p", threadIndex: 0 });
+    expect(ok).toBe(false);
+  });
+
+  it("sends to the queue binding and returns true when bound", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    mockGetCfContext.mockReturnValue({ env: { TASK_QUEUE: { send } } });
+
+    const task = { kind: "reconcile" as const, slug: "transformers", threadIndex: 2 };
+    const ok = await enqueueTask(task);
+
+    expect(ok).toBe(true);
+    expect(send).toHaveBeenCalledWith(task);
+  });
+});
+
+describe("parseTask", () => {
+  it("accepts a well-formed reconcile task", () => {
+    expect(
+      parseTask({ kind: "reconcile", slug: "p", threadIndex: 3, requestedBy: "alice" }),
+    ).toEqual({ kind: "reconcile", slug: "p", threadIndex: 3, requestedBy: "alice" });
+  });
+
+  it("accepts a reconcile task without requestedBy", () => {
+    expect(parseTask({ kind: "reconcile", slug: "p", threadIndex: 0 })).toEqual({
+      kind: "reconcile",
+      slug: "p",
+      threadIndex: 0,
+    });
+  });
+
+  it("rejects a reconcile task with a bad slug or threadIndex", () => {
+    expect(parseTask({ kind: "reconcile", slug: "", threadIndex: 0 })).toBeNull();
+    expect(parseTask({ kind: "reconcile", slug: "p", threadIndex: 1.5 })).toBeNull();
+    expect(parseTask({ kind: "reconcile", slug: "p" })).toBeNull();
+  });
+
+  it("accepts an ingest task with a url or content; rejects neither", () => {
+    expect(parseTask({ kind: "ingest", url: "https://x.com" })).toMatchObject({
+      kind: "ingest",
+      url: "https://x.com",
+    });
+    expect(parseTask({ kind: "ingest", content: "some text" })).toMatchObject({
+      kind: "ingest",
+      content: "some text",
+    });
+    expect(parseTask({ kind: "ingest" })).toBeNull();
+  });
+
+  it("rejects unknown kinds and non-objects", () => {
+    expect(parseTask({ kind: "nope" })).toBeNull();
+    expect(parseTask(null)).toBeNull();
+    expect(parseTask("string")).toBeNull();
+    expect(parseTask(42)).toBeNull();
+  });
+});

--- a/src/lib/reconcile.ts
+++ b/src/lib/reconcile.ts
@@ -1,0 +1,134 @@
+/**
+ * Reconcile a commons page from a human-flagged discussion thread — the
+ * "agents maintain, humans discuss" loop (B2b). A reader opens a talk thread
+ * ("this claim is wrong", "these two pages are the same"), an agent (yoyo) reads
+ * the page + the thread and revises the page to address the valid points,
+ * flagging `disputed` when it can't resolve a contradiction. Triggered async via
+ * the task queue (`/api/tasks/run` → here), never blocking the human's request.
+ *
+ * Reuses the ingest reconcile primitives (`parseDisputedMarker`,
+ * `parseConceptMarker`, `extractSummary`) and the unified write path
+ * (`writeWikiPageWithSideEffects`), so this stays consistent with how pages are
+ * synthesized and how `disputed`/revisions/log all behave.
+ */
+
+import {
+  readWikiPageWithFrontmatter,
+  writeWikiPageWithSideEffects,
+  serializeFrontmatter,
+  type Frontmatter,
+} from "./wiki";
+import { extractSummary, parseDisputedMarker, parseConceptMarker } from "./ingest";
+import { callLLM, hasLLMKey } from "./llm";
+import { INGEST_MAX_OUTPUT_TOKENS } from "./constants";
+import { getThread, addComment, resolveThread } from "./talk";
+import { logger } from "./logger";
+
+/** Default acting agent when no per-user yoyo handle is supplied. */
+const DEFAULT_AGENT_AUTHOR = "yoyo";
+
+const RECONCILE_FROM_TALK_SYSTEM_PROMPT = `You are a wiki editor maintaining a single canonical page. You are given the page's CURRENT content and a DISCUSSION thread in which readers have flagged issues (a wrong claim, a missing nuance, a request to merge/split, a question). Revise the page to address the VALID points raised.
+
+Rules:
+- Apply corrections and incorporate well-supported additions; keep the existing section structure (## Summary, ## Key Points, ## Concepts, ## Details) and any image markdown.
+- Only change what the discussion justifies. Do NOT invent facts not supported by the page or the discussion, and do NOT remove substantive existing content unless the discussion shows it is wrong.
+- Ignore off-topic chatter, opinions without support, and questions that don't imply a change.
+- If the discussion raises a CONTRADICTION you cannot resolve from the available information, do not silently pick a side: keep both positions (attributing each) and begin your ENTIRE output with a single line, exactly:
+DISPUTED: yes
+  Otherwise do not emit a DISPUTED line.
+
+Output the optional DISPUTED line, then the full revised page as pure markdown, and nothing else. Do not wrap in code fences.`;
+
+export interface ReconcileFromTalkResult {
+  slug: string;
+  /** True when the page body actually changed. */
+  changed: boolean;
+  /** True when the reconcile surfaced an unresolved contradiction. */
+  disputed: boolean;
+}
+
+/**
+ * Reconcile `slug` against discussion thread `threadIndex`: read both, LLM-revise
+ * the page to address the readers' valid points, write via the unified pipeline
+ * (escalating `disputed`), then post a yoyo reply summarizing what changed and
+ * resolve the thread (left open + `disputed` when unresolved).
+ *
+ * Idempotent and fail-soft: a missing page/thread or an empty LLM response makes
+ * no change (the page is never blanked). Safe to re-run (queue redelivery).
+ */
+export async function reconcileFromTalk(
+  slug: string,
+  threadIndex: number,
+  opts: { author?: string } = {},
+): Promise<ReconcileFromTalkResult> {
+  const author = opts.author?.trim() || DEFAULT_AGENT_AUTHOR;
+
+  const page = await readWikiPageWithFrontmatter(slug);
+  if (!page) throw new Error(`reconcile: page "${slug}" not found`);
+
+  const thread = await getThread(slug, threadIndex);
+  if (!thread) throw new Error(`reconcile: thread ${threadIndex} not found on "${slug}"`);
+
+  if (!hasLLMKey()) {
+    logger.warn("reconcile", `no LLM configured — skipping reconcile of "${slug}"`);
+    return { slug, changed: false, disputed: false };
+  }
+
+  // Build the reader-flagged-issues block from the thread.
+  const discussion = [
+    `## ${thread.title}`,
+    ...thread.comments.map((c) => `**${c.author}**: ${c.body}`),
+  ].join("\n\n");
+
+  const user = `# Current page\n\n${page.body}\n\n# Discussion (reader-flagged issues)\n\n${discussion}`;
+  const out = await callLLM(RECONCILE_FROM_TALK_SYSTEM_PROMPT, user, {
+    maxOutputTokens: INGEST_MAX_OUTPUT_TOKENS,
+  });
+
+  // Fail-soft: never blank the page on an empty/failed response.
+  if (!out || out.trim() === "") {
+    logger.warn("reconcile", `empty LLM response — leaving "${slug}" unchanged`);
+    return { slug, changed: false, disputed: false };
+  }
+
+  const { disputed, body: afterDisputed } = parseDisputedMarker(out);
+  // Strip any echoed CONCEPT:/ALIASES: synthesis headers.
+  const { body: newBody } = parseConceptMarker(afterDisputed);
+  const changed = newBody.trim() !== page.body.trim();
+
+  if (changed || disputed) {
+    const fm: Frontmatter = { ...page.frontmatter };
+    fm.updated = new Date().toISOString().slice(0, 10);
+    if (disputed) fm.disputed = true; // escalate only
+    const summary = extractSummary(newBody.replace(/^#\s+.+$/m, "").trim());
+
+    await writeWikiPageWithSideEffects({
+      slug,
+      title: page.title,
+      content: serializeFrontmatter(fm, changed ? newBody : page.body),
+      summary,
+      logOp: "edit",
+      crossRefSource: null, // a reconcile isn't a new source for cross-ref
+      author,
+      logDetails: () =>
+        `reconciled from discussion thread ${threadIndex}${disputed ? " (disputed)" : ""}`,
+    });
+  }
+
+  // Reply in the thread (must precede resolve — resolved threads reject comments),
+  // then resolve unless it ended disputed (leave it open for a human to weigh in).
+  const reply = disputed
+    ? "I reviewed this but found an unresolved contradiction — I've flagged the page as **disputed** and kept both views. Leaving this open for a human to settle."
+    : changed
+      ? "I've updated the page to address this. Thanks for flagging it."
+      : "I reviewed this but didn't find a change the page needed. Reopen with more detail if you disagree.";
+  try {
+    await addComment(slug, threadIndex, author, reply);
+    await resolveThread(slug, threadIndex, disputed ? "open" : "resolved");
+  } catch (err) {
+    // The page edit already succeeded; a thread-reply hiccup shouldn't fail the task.
+    logger.warn("reconcile", `thread reply/resolve failed for "${slug}":`, err);
+  }
+
+  return { slug, changed, disputed };
+}

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -1,0 +1,124 @@
+/**
+ * Agent task queue — the producer side.
+ *
+ * A durable queue of asynchronous agent work (Cloudflare Queues). Producers in
+ * the main app enqueue {@link Task}s; a thin consumer worker
+ * (`workers/task-consumer/`) drains the queue and POSTs each task back to the
+ * main app's `/api/tasks/run` endpoint, where it executes with the full lib +
+ * OpenNext context. See `yopedia-concept.md` / the task-queue plan.
+ *
+ * This module is the **producer**: `enqueueTask` sends to the `TASK_QUEUE`
+ * binding when on the Workers runtime, and is a logged no-op off-Workers (local
+ * dev, `next start`, vitest) — mirroring `getWorkersAiBinding` — so nothing
+ * crashes where the binding is absent.
+ */
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { logger } from "./logger";
+
+/**
+ * A unit of asynchronous agent work. Discriminated by `kind` so the executor
+ * (`/api/tasks/run`) can dispatch. Keep payloads small (ids/slugs, not bodies) —
+ * Cloudflare Queues caps a message at 128 KB.
+ */
+export type Task =
+  | {
+      /** Reconcile a commons page from a human-flagged talk thread (B2b loop). */
+      kind: "reconcile";
+      slug: string;
+      threadIndex: number;
+      /** Handle of the human who asked yoyo to address it (attribution). */
+      requestedBy?: string;
+    }
+  | {
+      /** Async/batch ingestion (the queue is the scale path; interactive ingest
+       *  stays synchronous). One of `url` or `content` must be set. */
+      kind: "ingest";
+      url?: string;
+      title?: string;
+      content?: string;
+      owner?: string;
+      author?: string;
+    };
+
+/** Minimal Cloudflare Queue producer binding — we only ever call `send`. */
+interface QueueBinding {
+  send(body: unknown): Promise<void>;
+}
+
+/**
+ * Resolve the `TASK_QUEUE` producer binding (matches `queues.producers[].binding`
+ * in wrangler.jsonc), or `null` when it isn't available
+ * (off the Workers runtime, or the binding isn't bound). `getCloudflareContext`
+ * throws outside the OpenNext request scope — expected in dev/tests.
+ */
+function getTaskQueue(): QueueBinding | null {
+  let env: { TASK_QUEUE?: QueueBinding };
+  try {
+    ({ env } = getCloudflareContext() as { env: { TASK_QUEUE?: QueueBinding } });
+  } catch {
+    return null; // off-Workers — expected
+  }
+  const q = env.TASK_QUEUE;
+  return q && typeof q.send === "function" ? q : null;
+}
+
+/**
+ * Enqueue a task for asynchronous processing. Returns `true` when it was sent to
+ * the queue, `false` when the queue is unavailable (off-Workers) — in which case
+ * it's a logged no-op so callers (routes, dev, tests) never crash. Callers that
+ * need the work to definitely happen should check the return value.
+ */
+export async function enqueueTask(task: Task): Promise<boolean> {
+  const queue = getTaskQueue();
+  if (!queue) {
+    logger.info(
+      "tasks",
+      `TASK_QUEUE unavailable (off-Workers) — skipped enqueue of "${task.kind}"`,
+    );
+    return false;
+  }
+  await queue.send(task);
+  logger.info("tasks", `enqueued task "${task.kind}"`);
+  return true;
+}
+
+/**
+ * Validate + narrow an untrusted JSON body into a {@link Task}, or `null` if it
+ * isn't a well-formed task. Used by `/api/tasks/run` to reject malformed
+ * messages as poison (4xx → DLQ) rather than retrying them forever.
+ */
+export function parseTask(body: unknown): Task | null {
+  if (!body || typeof body !== "object") return null;
+  const t = body as Record<string, unknown>;
+  switch (t.kind) {
+    case "reconcile":
+      if (typeof t.slug !== "string" || t.slug.trim() === "") return null;
+      if (typeof t.threadIndex !== "number" || !Number.isInteger(t.threadIndex)) {
+        return null;
+      }
+      return {
+        kind: "reconcile",
+        slug: t.slug,
+        threadIndex: t.threadIndex,
+        ...(typeof t.requestedBy === "string"
+          ? { requestedBy: t.requestedBy }
+          : {}),
+      };
+    case "ingest": {
+      const hasUrl = typeof t.url === "string" && t.url.trim() !== "";
+      const hasContent = typeof t.content === "string" && t.content.trim() !== "";
+      if (!hasUrl && !hasContent) return null; // need a source
+      return {
+        kind: "ingest",
+        ...(hasUrl ? { url: t.url as string } : {}),
+        ...(typeof t.title === "string" ? { title: t.title } : {}),
+        ...(hasContent ? { content: t.content as string } : {}),
+        ...(typeof t.owner === "string" ? { owner: t.owner } : {}),
+        ...(typeof t.author === "string" ? { author: t.author } : {}),
+      };
+    }
+    default:
+      return null;
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,6 +16,8 @@ const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 //   - /api/agents/<id>/ingest     — the agent's own per-agent token
 //   - /api/ingest                 — Clerk session OR the system service token
 //   - /api/ingest/x-mention       — Clerk session OR the system service token
+//   - /api/tasks/run              — the system service token ONLY (the task-
+//                                   consumer worker; has no Clerk session)
 // This is not a hole.
 //
 // The MCP server is stdio-only and not exposed over HTTP, so it is unaffected.
@@ -23,6 +25,10 @@ const IN_ROUTE_AUTH_PATHS = new Set([
   "/api/agents/seed",
   "/api/ingest",
   "/api/ingest/x-mention",
+  // Agent task-queue executor: authenticated in-route by the service token
+  // (getServicePrincipal); the sole caller is the task-consumer worker, which
+  // has no Clerk session. Rejects everyone else with 401.
+  "/api/tasks/run",
   // Admin migration: authenticated in-route by the service token OR the site
   // owner's session (it rejects everyone else with 403).
   "/api/admin/migrate",
@@ -32,7 +38,13 @@ const AGENT_INGEST_RE = /^\/api\/agents\/[^/]+\/ingest$/;
 // owner, or the tenant's own owner (it 403s everyone else).
 const ADMIN_TENANT_RE = /^\/api\/admin\/tenant\/[^/]+$/;
 
-function authenticatesInRoute(pathname: string): boolean {
+/**
+ * Whether a path authenticates in-route (token, not a Clerk session) and is
+ * therefore exempt from the middleware's Clerk write-gate. Exported so the
+ * exemption list is regression-tested (a missing entry silently 401s a
+ * service-token caller before it reaches the route — see /api/tasks/run).
+ */
+export function authenticatesInRoute(pathname: string): boolean {
   return (
     IN_ROUTE_AUTH_PATHS.has(pathname) ||
     AGENT_INGEST_RE.test(pathname) ||

--- a/workers/task-consumer/README.md
+++ b/workers/task-consumer/README.md
@@ -1,0 +1,56 @@
+# task-consumer Worker
+
+The consumer for the **yopedia agent task queue** (Cloudflare Queues), as a
+**standalone Worker** (so it gets a first-class Queues consumer without wrapping
+the OpenNext entry — same reasoning as `workers/x-ingest/`).
+
+It drains the **`yopedia-tasks`** queue and, for each message, POSTs the task to
+the deployed main app's **`POST /api/tasks/run`** with the system token. It is a
+**thin dispatcher** — the actual work (`reconcile` a page from a discussion
+thread, async `ingest`) runs in the main app, which has the full `src/lib` and
+the OpenNext request context. This worker imports **no `src/lib` code** (that
+would transitively pull Clerk/Next + require the OpenNext context it can't
+provide).
+
+**Producers** (who enqueues) live in the main app: the "Ask yoyo to address this"
+button (`/api/wiki/<slug>/discuss/<idx>/ask-yoyo`) today; autonomous maintenance
+crons and batch ingest later. `enqueueTask()` (`src/lib/tasks.ts`) sends to the
+`TASK_QUEUE` producer binding, and no-ops gracefully off the Workers runtime.
+
+**Ack/retry** maps onto Cloudflare Queues:
+- `2xx` → ack (done).
+- `4xx` → poison (malformed / not-found) → ack + drop (don't retry forever).
+- `5xx` / network → retry (CF redelivers; → dead-letter queue after `max_retries`).
+
+> **Same-zone fetch note:** the `/api/tasks/run` call targets the main yopedia
+> Worker on the same account. A plain same-zone Worker→Worker `fetch()` is blocked
+> (**error 1042**), so this Worker sets the **`global_fetch_strictly_public`**
+> compatibility flag (same as `x-ingest`).
+
+## One-time setup (operator)
+
+```sh
+# Create the queue + dead-letter queue:
+pnpm exec wrangler queues create yopedia-tasks
+pnpm exec wrangler queues create yopedia-tasks-dlq
+
+# Secret (same value as the main Worker's):
+pnpm exec wrangler secret put YOPEDIA_SERVICE_TOKEN --config workers/task-consumer/wrangler.jsonc
+
+# First deploy (afterwards it auto-deploys via deploy-cloudflare.yml on push to main):
+pnpm exec wrangler deploy --config workers/task-consumer/wrangler.jsonc
+```
+
+The main app's `wrangler.jsonc` already declares the `TASK_QUEUE` producer
+binding for the same `yopedia-tasks` queue.
+
+## Test it
+
+Open a discussion thread on a commons page → **🛠 Ask yoyo to address this** →
+within a queue cycle the page updates and yoyo replies in the thread. Logs:
+
+```sh
+pnpm exec wrangler tail --config workers/task-consumer/wrangler.jsonc
+```
+
+Health check: `GET https://yopedia-task-consumer.<subdomain>.workers.dev` → `ok`.

--- a/workers/task-consumer/index.ts
+++ b/workers/task-consumer/index.ts
@@ -1,0 +1,97 @@
+/**
+ * yopedia agent task-queue consumer.
+ *
+ * A thin dispatcher: drains the `yopedia-tasks` Cloudflare Queue and POSTs each
+ * message to the main yopedia app's `/api/tasks/run` endpoint with the system
+ * token. The actual work (reconcile / ingest) runs in the main app, which has
+ * the full `src/lib` + OpenNext request context. This worker imports NO `src/lib`
+ * code — that would transitively pull Clerk/Next and the OpenNext context it
+ * can't provide (same reasoning as workers/x-ingest).
+ *
+ * Ack/retry maps straight onto Cloudflare Queues semantics:
+ *   - 2xx  → ack (done).
+ *   - 4xx  → poison (malformed / not-found) → ack + drop (don't retry forever).
+ *   - 5xx / network → retry (CF redelivers; → DLQ after max_retries).
+ */
+
+interface Env {
+  YOPEDIA_URL?: string;
+  YOPEDIA_SERVICE_TOKEN?: string;
+}
+
+// Minimal Cloudflare Queues consumer types (avoid pulling @cloudflare/workers-types).
+interface QueueMessage<T = unknown> {
+  readonly id: string;
+  readonly body: T;
+  ack(): void;
+  retry(): void;
+}
+interface MessageBatch<T = unknown> {
+  readonly queue: string;
+  readonly messages: QueueMessage<T>[];
+}
+
+async function runTask(
+  base: string,
+  token: string,
+  message: QueueMessage,
+): Promise<void> {
+  let res: Response;
+  try {
+    res = await fetch(`${base}/api/tasks/run`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(message.body),
+    });
+  } catch (err) {
+    console.error(`task-consumer: fetch failed for ${message.id} — retry`, err);
+    message.retry();
+    return;
+  }
+
+  if (res.status >= 200 && res.status < 300) {
+    message.ack();
+    return;
+  }
+  if (res.status >= 400 && res.status < 500) {
+    // Permanently-bad task — don't retry it forever.
+    const snip = (await res.text().catch(() => "")).slice(0, 200).replace(/\s+/g, " ");
+    console.warn(`task-consumer: poison ${message.id} (${res.status}): ${snip}`);
+    message.ack();
+    return;
+  }
+  // 5xx — transient; let CF redeliver (and DLQ after max_retries).
+  console.warn(`task-consumer: transient ${message.id} (${res.status}) — retry`);
+  message.retry();
+}
+
+export default {
+  async queue(batch: MessageBatch, env: Env): Promise<void> {
+    const base = (env.YOPEDIA_URL ?? "").replace(/\/+$/, "");
+    const token = env.YOPEDIA_SERVICE_TOKEN;
+    if (!base || !token) {
+      // Misconfiguration — retry the whole batch so nothing is lost.
+      console.error(
+        "task-consumer: missing YOPEDIA_URL or YOPEDIA_SERVICE_TOKEN — retrying batch",
+      );
+      for (const m of batch.messages) m.retry();
+      return;
+    }
+
+    // Sequential (not Promise.all): each task triggers an LLM call in the main
+    // app; serial processing keeps us within provider rate limits.
+    for (const message of batch.messages) {
+      await runTask(base, token, message);
+    }
+  },
+
+  // Health check (no task triggering — not an open relay).
+  async fetch(): Promise<Response> {
+    return new Response("yopedia task-consumer ok\n", {
+      headers: { "content-type": "text/plain" },
+    });
+  },
+};

--- a/workers/task-consumer/wrangler.jsonc
+++ b/workers/task-consumer/wrangler.jsonc
@@ -1,0 +1,36 @@
+{
+  // Standalone consumer for the yopedia agent task queue. Separate from the main
+  // yopedia (OpenNext) Worker so we get a first-class Queues consumer without
+  // wrapping the OpenNext entry. It drains `yopedia-tasks` and POSTs each task to
+  // the deployed yopedia `/api/tasks/run` endpoint with the system token — a thin
+  // dispatcher; the actual work runs in the main app (full lib + OpenNext context).
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "yopedia-task-consumer",
+  "main": "index.ts",
+  "compatibility_date": "2025-01-01",
+
+  // The /api/tasks/run call targets the main yopedia Worker on the same zone. A
+  // plain same-zone Worker→Worker fetch is blocked (error 1042); this flag makes
+  // fetch() resolve as a normal public request (same as workers/x-ingest).
+  "compatibility_flags": ["global_fetch_strictly_public"],
+
+  // Queue consumer. One-time provisioning of the queue + dead-letter queue:
+  //   npx wrangler queues create yopedia-tasks
+  //   npx wrangler queues create yopedia-tasks-dlq
+  "queues": {
+    "consumers": [
+      {
+        "queue": "yopedia-tasks",
+        "dead_letter_queue": "yopedia-tasks-dlq",
+        "max_retries": 3,
+        "max_batch_size": 5,
+        "max_batch_timeout": 10
+      }
+    ]
+  },
+
+  "vars": { "YOPEDIA_URL": "https://yopedia.yuanhao-li.workers.dev" }
+
+  // Secret (set with `wrangler secret put --config workers/task-consumer/wrangler.jsonc`):
+  //   YOPEDIA_SERVICE_TOKEN — the system write credential (same value as the main Worker's)
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -51,6 +51,21 @@
     "binding": "AI"
   },
 
+  // --- Queues: producer for the agent task queue (async maintenance + ingest).
+  // The consumer is a separate worker (workers/task-consumer/). enqueueTask()
+  // (src/lib/tasks.ts) sends here; it no-ops gracefully when this binding is
+  // absent (local dev / next start / tests). One-time provisioning:
+  //   npx wrangler queues create yopedia-tasks
+  //   npx wrangler queues create yopedia-tasks-dlq
+  "queues": {
+    "producers": [
+      {
+        "binding": "TASK_QUEUE",
+        "queue": "yopedia-tasks"
+      }
+    ]
+  },
+
   // Public site-owner handle for runtime server gates (owner-only Lint). The
   // authoritative copy for the client is the build-time inline (deploy
   // workflow); this is runtime parity for server reads. Public, not a secret.


### PR DESCRIPTION
First shippable unit of the **agent task queue** (Cloudflare Queues) — the "agents maintain, humans discuss" loop. A human flags an issue on a commons page's talk thread → **🛠 Ask yoyo to address this** → a `reconcile` task is enqueued → a thin consumer worker drains it → an agent reads the page + thread, revises the page (flagging `disputed` if it can't resolve a contradiction), replies, and resolves the thread. All async — the human's click never blocks.

## Architecture
**Thin consumer, work in the main app.** The consumer worker (`workers/task-consumer/`, the proven `x-ingest` pattern) imports **no `src/lib`** (that transitively pulls Clerk/Next + needs the OpenNext context it can't provide) — it just POSTs each queue message to a service-token-gated `POST /api/tasks/run` where the real work runs as a normal, testable route.

```
"Ask yoyo" button → enqueueTask(reconcile) → CF Queue → consumer → POST /api/tasks/run
                                              (+ DLQ)              (service token)
                                                                  → reconcileFromTalk()
```

## Files
- `src/lib/tasks.ts` — `Task` union, `enqueueTask` (sends to `TASK_QUEUE`; **no-ops gracefully off-Workers** so dev/test never crash), `parseTask`.
- `src/lib/reconcile.ts` — `reconcileFromTalk`: reuses the #369 reconcile primitives + the unified write path; **fail-soft (never blanks a page)**; escalates `disputed`; posts a yoyo reply + resolves.
- `src/app/api/tasks/run/route.ts` — service-token-only executor (2xx ok / 4xx poison / 5xx retry; "not found" → 422).
- `src/app/api/wiki/[slug]/discuss/[threadIndex]/ask-yoyo/route.ts` — signed-in + `canReadSlug`-gated producer.
- `src/components/{ThreadView,DiscussionPanel}.tsx` — the button.
- `workers/task-consumer/` + `wrangler.jsonc` producer binding + deploy workflow step.
- `src/middleware.ts` — exempts `/api/tasks/run` (service-token in-route, like `/api/ingest`).

## Security (code-reviewed)
- **Critical fix from review:** the Clerk write-gate middleware was blocking `/api/tasks/run` (service token, no Clerk session) → the consumer's call would 401 and the loop would silently never run. Now exempted (in-route service-token auth) + **regression-tested** (`middleware-write-gate.test.ts`).
- Producer is read-gated: a private page's thread is cloaked 404 — no non-owner can enqueue a reconcile on a page they can't read.
- Reconcile preserves owner/visibility/created; never blanks a page; idempotent under queue redelivery.

## Tests
`tasks` / `reconcile` / `tasks-route` / `ask-yoyo-route` / `middleware-write-gate`. **Full suite 2542 green**; tsc clean (6 pre-existing unrelated); lint clean.

## ⚠️ One-time owner setup REQUIRED before merge/deploy
The new queue bindings make `wrangler deploy` fail until the queue exists, so run first:
```sh
npx wrangler queues create yopedia-tasks
npx wrangler queues create yopedia-tasks-dlq
npx wrangler secret put YOPEDIA_SERVICE_TOKEN --config workers/task-consumer/wrangler.jsonc   # same value as the main worker
```

## Deferred
Thread `kind` field + autonomous maintenance cron (**Q2**), async/batch ingest (**Q3**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)