### PR TITLE
yopedia: Q2 agent task queue — autonomous maintenance (off by default)

### DIFF
--- a/src/app/api/tasks/run/route.ts
+++ b/src/app/api/tasks/run/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getServicePrincipal } from "@/lib/auth";
 import { parseTask } from "@/lib/tasks";
 import { reconcileFromTalk } from "@/lib/reconcile";
-import { ingest, ingestUrl } from "@/lib/ingest";
+import { ingest, ingestUrl, reingest } from "@/lib/ingest";
 import { agentIdFor, DEFAULT_AGENT_NAME } from "@/lib/agents";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
@@ -55,6 +55,26 @@ export async function POST(req: Request) {
         author,
       });
       return NextResponse.json({ ok: true, ...result });
+    }
+
+    if (task.kind === "maintain") {
+      // Autonomous maintenance (Q2). Attributed to a generic yoyo (no requester).
+      if (task.op === "reconcile") {
+        if (typeof task.threadIndex !== "number") {
+          return NextResponse.json(
+            { error: "maintain:reconcile requires threadIndex" },
+            { status: 400 },
+          );
+        }
+        const result = await reconcileFromTalk(task.slug, task.threadIndex);
+        return NextResponse.json({ ok: true, ...result });
+      }
+      // op === "staleness": refresh an expired page from its source.
+      const result = await reingest(task.slug, {
+        author: DEFAULT_AGENT_NAME,
+        triggeredBy: DEFAULT_AGENT_NAME,
+      });
+      return NextResponse.json({ ok: true, slug: result.primarySlug });
     }
 
     // kind === "ingest"

--- a/src/app/api/tasks/scan/route.ts
+++ b/src/app/api/tasks/scan/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { getServicePrincipal } from "@/lib/auth";
+import { scanForMaintenance, DEFAULT_MAINTENANCE_CAP } from "@/lib/maintenance";
+import { enqueueTask } from "@/lib/tasks";
+import { getErrorMessage } from "@/lib/errors";
+import { logger } from "@/lib/logger";
+
+/**
+ * POST /api/tasks/scan — the autonomous-maintenance producer (Q2).
+ *
+ * Service-token only (the sole caller is the task-consumer worker's cron). Scans
+ * the wiki for maintenance work and enqueues `maintain` tasks. Gated by the
+ * `AUTONOMOUS_MAINTENANCE` env: anything other than `"on"` means **dry-run** —
+ * the scan still runs and logs/returns what it WOULD enqueue, but enqueues
+ * nothing. `?dry=1` forces a dry-run regardless (for inspection). `?cap=N`
+ * overrides the per-scan task cap.
+ */
+export async function POST(req: Request) {
+  const principal = getServicePrincipal(req);
+  if (!principal) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const url = new URL(req.url);
+    const enabled = process.env.AUTONOMOUS_MAINTENANCE === "on";
+    // Off (default) → always dry-run; never auto-edits until explicitly enabled.
+    const dry = url.searchParams.get("dry") === "1" || !enabled;
+
+    const capParam = Number(url.searchParams.get("cap"));
+    const cap =
+      Number.isFinite(capParam) && capParam > 0
+        ? Math.floor(capParam)
+        : DEFAULT_MAINTENANCE_CAP;
+
+    const tasks = await scanForMaintenance(cap);
+
+    let enqueued = 0;
+    if (!dry) {
+      for (const t of tasks) {
+        if (await enqueueTask(t)) enqueued++;
+      }
+    }
+
+    logger.info(
+      "maintenance",
+      `scan: enabled=${enabled} dry=${dry} found=${tasks.length} enqueued=${enqueued}`,
+    );
+
+    return NextResponse.json({
+      enabled,
+      dry,
+      found: tasks.length,
+      enqueued,
+      // The candidate list — for dry-run inspection of what it would do.
+      tasks: tasks.map((t) =>
+        t.kind === "maintain"
+          ? {
+              op: t.op,
+              slug: t.slug,
+              ...(t.threadIndex !== undefined ? { threadIndex: t.threadIndex } : {}),
+            }
+          : t,
+      ),
+    });
+  } catch (err) {
+    logger.error("maintenance", "scan failed", err);
+    return NextResponse.json({ error: getErrorMessage(err) }, { status: 500 });
+  }
+}

--- a/src/lib/__tests__/maintenance.test.ts
+++ b/src/lib/__tests__/maintenance.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  ensureDirectories,
+  writeWikiPageWithSideEffects,
+  serializeFrontmatter,
+  type Frontmatter,
+} from "../wiki";
+import { createThread, addComment } from "../talk";
+import { scanForMaintenance } from "../maintenance";
+import { _resetStorage } from "../storage";
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+const TODAY = new Date().toISOString().slice(0, 10);
+const PAST = "2020-01-01";
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "maint-test-"));
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetStorage();
+  await ensureDirectories();
+});
+
+afterEach(async () => {
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function seed(slug: string, over: Partial<Frontmatter> = {}) {
+  const fm: Frontmatter = {
+    created: PAST,
+    updated: PAST, // old, so not skipped as "edited today"
+    owner: "alice",
+    visibility: "public",
+    authors: ["alice"],
+    contributors: [],
+    confidence: 0.7,
+    expiry: "2099-01-01",
+    tags: [],
+    disputed: false,
+    ...over,
+  };
+  await writeWikiPageWithSideEffects({
+    slug,
+    title: slug,
+    content: serializeFrontmatter(fm, `# ${slug}\n\nBody.`),
+    summary: `Summary for ${slug}.`,
+    logOp: "ingest",
+    crossRefSource: null,
+  });
+}
+
+describe("scanForMaintenance", () => {
+  it("enqueues a staleness task for an expired page with a source_url", async () => {
+    await seed("stale", { expiry: PAST, source_url: "https://example.com/s" });
+    const tasks = await scanForMaintenance();
+    expect(tasks).toContainEqual({ kind: "maintain", op: "staleness", slug: "stale" });
+  });
+
+  it("does NOT flag an expired page with no source_url (nothing to refresh from)", async () => {
+    await seed("expired-nosource", { expiry: PAST });
+    expect(await scanForMaintenance()).toHaveLength(0);
+  });
+
+  it("enqueues a reconcile when a disputed page has an open thread awaiting a human reply", async () => {
+    await seed("disputed", { disputed: true });
+    await createThread("disputed", "Issue", "bob", "This claim looks wrong.");
+    const tasks = await scanForMaintenance();
+    expect(tasks).toContainEqual({
+      kind: "maintain",
+      op: "reconcile",
+      slug: "disputed",
+      threadIndex: 0,
+    });
+  });
+
+  it("skips a disputed thread yoyo already answered (last comment is an agent)", async () => {
+    await seed("answered", { disputed: true });
+    await createThread("answered", "Issue", "bob", "Wrong claim.");
+    await addComment("answered", 0, "bob--yoyo", "I looked — keeping both views (disputed).");
+    expect(await scanForMaintenance()).toHaveLength(0);
+  });
+
+  it("never flags a PRIVATE page (commons-only; avoids the reingest-fork loop)", async () => {
+    await seed("priv-stale", {
+      visibility: "private",
+      expiry: PAST,
+      source_url: "https://example.com/s",
+    });
+    await seed("priv-disputed", { visibility: "private", disputed: true });
+    await createThread("priv-disputed", "Issue", "bob", "Wrong.");
+    expect(await scanForMaintenance()).toHaveLength(0);
+  });
+
+  it("skips a page edited today (let recent changes settle)", async () => {
+    await seed("fresh", { expiry: PAST, source_url: "https://x.com", updated: TODAY });
+    expect(await scanForMaintenance()).toHaveLength(0);
+  });
+
+  it("caps the number of tasks per scan", async () => {
+    for (let i = 0; i < 5; i++) {
+      await seed(`stale-${i}`, { expiry: PAST, source_url: `https://x.com/${i}` });
+    }
+    expect(await scanForMaintenance(2)).toHaveLength(2);
+  });
+});

--- a/src/lib/__tests__/middleware-write-gate.test.ts
+++ b/src/lib/__tests__/middleware-write-gate.test.ts
@@ -13,6 +13,7 @@ describe("write-gate in-route auth exemptions", () => {
     // These authenticate in-route with a token (no Clerk session) — a missing
     // entry silently 401s the caller before it reaches the route.
     expect(authenticatesInRoute("/api/tasks/run")).toBe(true); // task-consumer
+    expect(authenticatesInRoute("/api/tasks/scan")).toBe(true); // maintenance cron
     expect(authenticatesInRoute("/api/ingest")).toBe(true);
     expect(authenticatesInRoute("/api/ingest/x-mention")).toBe(true);
     expect(authenticatesInRoute("/api/agents/seed")).toBe(true);

--- a/src/lib/__tests__/scan-route.test.ts
+++ b/src/lib/__tests__/scan-route.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({ getServicePrincipal: vi.fn() }));
+vi.mock("@/lib/maintenance", () => ({
+  scanForMaintenance: vi.fn(),
+  DEFAULT_MAINTENANCE_CAP: 10,
+}));
+vi.mock("@/lib/tasks", () => ({ enqueueTask: vi.fn() }));
+
+import { getServicePrincipal } from "@/lib/auth";
+import { scanForMaintenance } from "@/lib/maintenance";
+import { enqueueTask } from "@/lib/tasks";
+
+const mockedGetService = vi.mocked(getServicePrincipal);
+const mockedScan = vi.mocked(scanForMaintenance);
+const mockedEnqueue = vi.mocked(enqueueTask);
+
+const SAMPLE = [
+  { kind: "maintain" as const, op: "staleness" as const, slug: "stale" },
+  { kind: "maintain" as const, op: "reconcile" as const, slug: "disp", threadIndex: 0 },
+];
+
+async function scan(query = "") {
+  const { POST } = await import("@/app/api/tasks/scan/route");
+  return POST(
+    new Request(`http://localhost/api/tasks/scan${query}`, { method: "POST" }),
+  );
+}
+
+let savedFlag: string | undefined;
+beforeEach(() => {
+  vi.clearAllMocks();
+  savedFlag = process.env.AUTONOMOUS_MAINTENANCE;
+  delete process.env.AUTONOMOUS_MAINTENANCE;
+  mockedGetService.mockReturnValue({ id: "service:yopedia", handle: "yopedia" });
+  mockedScan.mockResolvedValue(SAMPLE);
+  mockedEnqueue.mockResolvedValue(true);
+});
+afterEach(() => {
+  if (savedFlag === undefined) delete process.env.AUTONOMOUS_MAINTENANCE;
+  else process.env.AUTONOMOUS_MAINTENANCE = savedFlag;
+});
+
+describe("POST /api/tasks/scan", () => {
+  it("401s without the service token", async () => {
+    mockedGetService.mockReturnValue(null);
+    expect((await scan()).status).toBe(401);
+    expect(mockedScan).not.toHaveBeenCalled();
+  });
+
+  it("dry-runs (enqueues nothing) when AUTONOMOUS_MAINTENANCE is off", async () => {
+    const res = await scan();
+    const body = await res.json();
+    expect(body).toMatchObject({ enabled: false, dry: true, found: 2, enqueued: 0 });
+    expect(mockedEnqueue).not.toHaveBeenCalled();
+    // Still reports what it WOULD enqueue.
+    expect(body.tasks).toHaveLength(2);
+  });
+
+  it("enqueues when AUTONOMOUS_MAINTENANCE=on", async () => {
+    process.env.AUTONOMOUS_MAINTENANCE = "on";
+    const res = await scan();
+    const body = await res.json();
+    expect(body).toMatchObject({ enabled: true, dry: false, found: 2, enqueued: 2 });
+    expect(mockedEnqueue).toHaveBeenCalledTimes(2);
+  });
+
+  it("?dry=1 forces a dry-run even when enabled", async () => {
+    process.env.AUTONOMOUS_MAINTENANCE = "on";
+    const res = await scan("?dry=1");
+    const body = await res.json();
+    expect(body).toMatchObject({ enabled: true, dry: true, enqueued: 0 });
+    expect(mockedEnqueue).not.toHaveBeenCalled();
+  });
+
+  it("honors a ?cap override", async () => {
+    await scan("?cap=3");
+    expect(mockedScan).toHaveBeenCalledWith(3);
+  });
+});

--- a/src/lib/__tests__/tasks-route.test.ts
+++ b/src/lib/__tests__/tasks-route.test.ts
@@ -2,16 +2,21 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("@/lib/auth", () => ({ getServicePrincipal: vi.fn() }));
 vi.mock("@/lib/reconcile", () => ({ reconcileFromTalk: vi.fn() }));
-vi.mock("@/lib/ingest", () => ({ ingest: vi.fn(), ingestUrl: vi.fn() }));
+vi.mock("@/lib/ingest", () => ({
+  ingest: vi.fn(),
+  ingestUrl: vi.fn(),
+  reingest: vi.fn(),
+}));
 
 import { getServicePrincipal } from "@/lib/auth";
 import { reconcileFromTalk } from "@/lib/reconcile";
-import { ingest, ingestUrl } from "@/lib/ingest";
+import { ingest, ingestUrl, reingest } from "@/lib/ingest";
 
 const mockedGetService = vi.mocked(getServicePrincipal);
 const mockedReconcile = vi.mocked(reconcileFromTalk);
 const mockedIngest = vi.mocked(ingest);
 const mockedIngestUrl = vi.mocked(ingestUrl);
+const mockedReingest = vi.mocked(reingest);
 
 async function run(body: unknown) {
   const { POST } = await import("@/app/api/tasks/run/route");
@@ -66,6 +71,21 @@ describe("POST /api/tasks/run", () => {
       expect.objectContaining({ owner: "alice" }),
     );
     expect(mockedIngest).not.toHaveBeenCalled();
+  });
+
+  it("dispatches maintain:reconcile (autonomous — generic yoyo, no requester)", async () => {
+    mockedReconcile.mockResolvedValue({ slug: "d", changed: true, disputed: false });
+    const res = await run({ kind: "maintain", op: "reconcile", slug: "d", threadIndex: 1 });
+    expect(res.status).toBe(200);
+    expect(mockedReconcile).toHaveBeenCalledWith("d", 1);
+  });
+
+  it("dispatches maintain:staleness via reingest", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedReingest.mockResolvedValue({ primarySlug: "s" } as any);
+    const res = await run({ kind: "maintain", op: "staleness", slug: "s" });
+    expect(res.status).toBe(200);
+    expect(mockedReingest).toHaveBeenCalledWith("s", expect.objectContaining({ author: "yoyo" }));
   });
 
   it("maps a 'not found' failure to 422 (poison), other failures to 500 (retry)", async () => {

--- a/src/lib/__tests__/tasks.test.ts
+++ b/src/lib/__tests__/tasks.test.ts
@@ -77,6 +77,21 @@ describe("parseTask", () => {
     expect(parseTask({ kind: "ingest" })).toBeNull();
   });
 
+  it("accepts maintain tasks; reconcile needs a threadIndex", () => {
+    expect(parseTask({ kind: "maintain", op: "staleness", slug: "p" })).toEqual({
+      kind: "maintain",
+      op: "staleness",
+      slug: "p",
+    });
+    expect(
+      parseTask({ kind: "maintain", op: "reconcile", slug: "p", threadIndex: 1 }),
+    ).toEqual({ kind: "maintain", op: "reconcile", slug: "p", threadIndex: 1 });
+    // reconcile without a threadIndex, or a bad op, is rejected.
+    expect(parseTask({ kind: "maintain", op: "reconcile", slug: "p" })).toBeNull();
+    expect(parseTask({ kind: "maintain", op: "bogus", slug: "p" })).toBeNull();
+    expect(parseTask({ kind: "maintain", op: "staleness", slug: "" })).toBeNull();
+  });
+
   it("rejects unknown kinds and non-objects", () => {
     expect(parseTask({ kind: "nope" })).toBeNull();
     expect(parseTask(null)).toBeNull();

--- a/src/lib/maintenance.ts
+++ b/src/lib/maintenance.ts
@@ -1,0 +1,90 @@
+/**
+ * Autonomous maintenance scan (Q2) — the producer side of the upkeep no human
+ * reports. A cron (on the task-consumer worker) calls `/api/tasks/scan`, which
+ * runs this scan and enqueues `maintain` tasks (or dry-runs when autonomous
+ * maintenance is off). Two ops, chosen for safety + reuse of proven engines:
+ *
+ *   - **reconcile**: a `disputed` page with an OPEN thread whose latest comment
+ *     is from a HUMAN (so yoyo hasn't already answered and is waiting) → run the
+ *     same `reconcileFromTalk` as the on-demand button.
+ *   - **staleness**: a page past its `expiry` with a `source_url` → re-ingest
+ *     from the source (the reconcile-on-merge step refreshes it).
+ *
+ * Guardrails (because no human is watching each one):
+ *   - **commons-only**: skip PRIVATE pages entirely. Autonomous maintenance
+ *     tends the shared commons; a private vault is the owner's, reached only via
+ *     the on-demand button (the owner asking). This also avoids a cost loop: a
+ *     private page reingested by a generic agent forks (the realm guard) instead
+ *     of refreshing, leaving the original to be re-flagged every scan;
+ *   - skip pages updated TODAY (don't act on a just-edited page);
+ *   - skip disputed threads yoyo already answered (last comment is an agent) —
+ *     avoids re-reconciling a stuck dispute on every scan;
+ *   - cap the number of tasks per scan (cost + blast-radius bound).
+ */
+
+import { listWikiPages, readWikiPageWithFrontmatter } from "./wiki";
+import { listThreads } from "./talk";
+import { isAgentHandle } from "./agents";
+import type { Task } from "./tasks";
+import { logger } from "./logger";
+
+/** Default cap on maintenance tasks enqueued per scan. */
+export const DEFAULT_MAINTENANCE_CAP = 10;
+
+/**
+ * Scan the wiki's state and return up to `cap` `maintain` tasks. Read-only — the
+ * caller enqueues (or dry-runs) the result. At most one task per page per scan.
+ */
+export async function scanForMaintenance(
+  cap: number = DEFAULT_MAINTENANCE_CAP,
+): Promise<Task[]> {
+  const today = new Date().toISOString().slice(0, 10);
+  const tasks: Task[] = [];
+  const pages = await listWikiPages();
+
+  for (const entry of pages) {
+    if (tasks.length >= cap) break;
+    const page = await readWikiPageWithFrontmatter(entry.slug);
+    if (!page) continue;
+    const fm = page.frontmatter;
+
+    // Commons-only: never autonomously touch a private vault page (privacy +
+    // avoids the reingest-fork cost loop). The owner reaches it via the button.
+    if (fm.visibility === "private") continue;
+
+    // Guardrail: skip a page edited today (let recent changes settle).
+    if (typeof fm.updated === "string" && fm.updated === today) continue;
+
+    // (1) Disputed → reconcile, but only when a HUMAN is awaiting a response
+    //     (the latest comment on an open thread isn't yoyo's).
+    if (fm.disputed === true) {
+      const threads = await listThreads(entry.slug);
+      const idx = threads.findIndex(
+        (t) =>
+          t.status === "open" &&
+          t.comments.length > 0 &&
+          !isAgentHandle(t.comments[t.comments.length - 1].author),
+      );
+      if (idx >= 0) {
+        tasks.push({ kind: "maintain", op: "reconcile", slug: entry.slug, threadIndex: idx });
+        continue; // one task per page
+      }
+    }
+
+    // (2) Stale (expiry passed) with a source to refresh from → re-ingest.
+    const expiry = fm.expiry;
+    const sourceUrl = fm.source_url;
+    if (
+      typeof expiry === "string" &&
+      expiry !== "" &&
+      expiry <= today &&
+      typeof sourceUrl === "string" &&
+      sourceUrl.trim() !== ""
+    ) {
+      tasks.push({ kind: "maintain", op: "staleness", slug: entry.slug });
+    }
+  }
+
+  logger.info("maintenance", `scan found ${tasks.length} task(s) (cap ${cap})`);
+  return tasks;
+}

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -39,6 +39,15 @@ export type Task =
       content?: string;
       owner?: string;
       author?: string;
+    }
+  | {
+      /** Autonomous maintenance, enqueued by the scan cron (Q2): `reconcile` a
+       *  disputed page from its open thread, or `staleness` re-ingest an expired
+       *  page from its source. `threadIndex` is required for `reconcile`. */
+      kind: "maintain";
+      op: "reconcile" | "staleness";
+      slug: string;
+      threadIndex?: number;
     };
 
 /** Minimal Cloudflare Queue producer binding — we only ever call `send`. */
@@ -117,6 +126,18 @@ export function parseTask(body: unknown): Task | null {
         ...(typeof t.owner === "string" ? { owner: t.owner } : {}),
         ...(typeof t.author === "string" ? { author: t.author } : {}),
       };
+    }
+    case "maintain": {
+      if (t.op !== "reconcile" && t.op !== "staleness") return null;
+      if (typeof t.slug !== "string" || t.slug.trim() === "") return null;
+      // `reconcile` needs a thread to reconcile from.
+      if (t.op === "reconcile") {
+        if (typeof t.threadIndex !== "number" || !Number.isInteger(t.threadIndex)) {
+          return null;
+        }
+        return { kind: "maintain", op: "reconcile", slug: t.slug, threadIndex: t.threadIndex };
+      }
+      return { kind: "maintain", op: "staleness", slug: t.slug };
     }
     default:
       return null;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,6 +18,7 @@ const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 //   - /api/ingest/x-mention       — Clerk session OR the system service token
 //   - /api/tasks/run              — the system service token ONLY (the task-
 //                                   consumer worker; has no Clerk session)
+//   - /api/tasks/scan            — the system service token ONLY (the cron)
 // This is not a hole.
 //
 // The MCP server is stdio-only and not exposed over HTTP, so it is unaffected.
@@ -25,10 +26,11 @@ const IN_ROUTE_AUTH_PATHS = new Set([
   "/api/agents/seed",
   "/api/ingest",
   "/api/ingest/x-mention",
-  // Agent task-queue executor: authenticated in-route by the service token
-  // (getServicePrincipal); the sole caller is the task-consumer worker, which
-  // has no Clerk session. Rejects everyone else with 401.
+  // Agent task-queue executor + maintenance scanner: authenticated in-route by
+  // the service token (getServicePrincipal); the sole callers are the
+  // task-consumer worker (queue handler + cron), which has no Clerk session.
   "/api/tasks/run",
+  "/api/tasks/scan",
   // Admin migration: authenticated in-route by the service token OR the site
   // owner's session (it rejects everyone else with 403).
   "/api/admin/migrate",

--- a/workers/task-consumer/README.md
+++ b/workers/task-consumer/README.md
@@ -13,9 +13,32 @@ would transitively pull Clerk/Next + require the OpenNext context it can't
 provide).
 
 **Producers** (who enqueues) live in the main app: the "Ask yoyo to address this"
-button (`/api/wiki/<slug>/discuss/<idx>/ask-yoyo`) today; autonomous maintenance
-crons and batch ingest later. `enqueueTask()` (`src/lib/tasks.ts`) sends to the
-`TASK_QUEUE` producer binding, and no-ops gracefully off the Workers runtime.
+button (`/api/wiki/<slug>/discuss/<idx>/ask-yoyo`), and this worker's **daily
+cron** → `POST /api/tasks/scan` (autonomous maintenance, Q2). `enqueueTask()`
+(`src/lib/tasks.ts`) sends to the `TASK_QUEUE` producer binding, and no-ops
+gracefully off the Workers runtime.
+
+This worker has two triggers: the **queue consumer** (drains `yopedia-tasks`) and
+a **cron** (`scheduled()`, daily) that POSTs `/api/tasks/scan`.
+
+### Autonomous maintenance (Q2)
+
+The cron scans the wiki for upkeep no human reports — a `disputed` page with an
+open thread awaiting a reply → reconcile; an expired page with a `source_url` →
+re-ingest — and enqueues `maintain` tasks. It is **off by default**: the scan
+**dry-runs** (logs what it *would* enqueue, enqueues nothing) until you set
+`AUTONOMOUS_MAINTENANCE="on"` on the **main** worker. So the cron is safe to ship
+before you enable it — watch a few dry-runs in the logs first, then enable:
+
+```sh
+# Inspect what it would do (dry-run, regardless of the flag):
+curl -s -X POST "https://yopedia.<sub>.workers.dev/api/tasks/scan?dry=1" \
+  -H "Authorization: Bearer <YOPEDIA_SERVICE_TOKEN>" | jq
+
+# Enable autonomous maintenance (set on the MAIN worker, then redeploy/restart):
+#   add  "AUTONOMOUS_MAINTENANCE": "on"  to wrangler.jsonc `vars`, or
+pnpm exec wrangler secret put AUTONOMOUS_MAINTENANCE   # value: on
+```
 
 **Ack/retry** maps onto Cloudflare Queues:
 - `2xx` → ack (done).

--- a/workers/task-consumer/index.ts
+++ b/workers/task-consumer/index.ts
@@ -30,6 +30,10 @@ interface MessageBatch<T = unknown> {
   readonly queue: string;
   readonly messages: QueueMessage<T>[];
 }
+interface ScheduledEvent {
+  readonly scheduledTime: number;
+  readonly cron: string;
+}
 
 async function runTask(
   base: string,
@@ -85,6 +89,28 @@ export default {
     // app; serial processing keeps us within provider rate limits.
     for (const message of batch.messages) {
       await runTask(base, token, message);
+    }
+  },
+
+  // Autonomous-maintenance cron (Q2). POSTs the scanner, which enqueues
+  // `maintain` tasks — or dry-runs (logs only) when AUTONOMOUS_MAINTENANCE isn't
+  // "on" in the main app. So this is safe to run on schedule before it's enabled.
+  async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
+    const base = (env.YOPEDIA_URL ?? "").replace(/\/+$/, "");
+    const token = env.YOPEDIA_SERVICE_TOKEN;
+    if (!base || !token) {
+      console.error("task-consumer cron: missing YOPEDIA_URL or YOPEDIA_SERVICE_TOKEN");
+      return;
+    }
+    try {
+      const res = await fetch(`${base}/api/tasks/scan`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const body = (await res.text().catch(() => "")).slice(0, 400);
+      console.log(`task-consumer cron: scan → ${res.status} ${body}`);
+    } catch (err) {
+      console.error("task-consumer cron: scan failed", err);
     }
   },
 

--- a/workers/task-consumer/wrangler.jsonc
+++ b/workers/task-consumer/wrangler.jsonc
@@ -14,6 +14,11 @@
   // fetch() resolve as a normal public request (same as workers/x-ingest).
   "compatibility_flags": ["global_fetch_strictly_public"],
 
+  // Autonomous-maintenance cron (Q2): daily, POSTs /api/tasks/scan. The scan
+  // DRY-RUNS (logs only) until AUTONOMOUS_MAINTENANCE="on" is set on the main
+  // worker — so this trigger is safe to ship before maintenance is enabled.
+  "triggers": { "crons": ["0 6 * * *"] },
+
   // Queue consumer. One-time provisioning of the queue + dead-letter queue:
   //   npx wrangler queues create yopedia-tasks
   //   npx wrangler queues create yopedia-tasks-dlq


### PR DESCRIPTION
The autonomous half of "agents maintain, humans discuss" (Q2). A daily cron scans the wiki's own state and enqueues the upkeep **no human reports** — riding the same Cloudflare Queue + consumer as Q1. **Ships OFF by default.**

## What it does
- `src/lib/maintenance.ts` — `scanForMaintenance`: (1) a `disputed` page with an **open thread whose last comment is from a human** (yoyo hasn't answered) → `maintain:reconcile`; (2) a page past `expiry` with a `source_url` → `maintain:staleness`.
- `src/app/api/tasks/scan/route.ts` — service-token producer. **Off by default: dry-runs** (scans + logs/returns what it *would* enqueue, enqueues nothing) unless `AUTONOMOUS_MAINTENANCE="on"`. `?dry=1` forces dry; `?cap=N`.
- `src/app/api/tasks/run` — `maintain` handlers (reconcile → `reconcileFromTalk`; staleness → `reingest`).
- `workers/task-consumer/` — a `scheduled()` cron (`0 6 * * *`) → `/api/tasks/scan`. Safe to ship before enabling (dry-runs until the flag is on; watch the logs first).

## Guardrails (no human is watching each one)
- **Commons-only** — skips private vault pages entirely (privacy + closes a cost loop; the owner reaches a private page via the on-demand button).
- Skip pages **updated today**; skip disputes **yoyo already answered**; **per-scan cap**.

## Security review — one real issue caught + fixed
The reviewer found that `maintain:staleness` on a **private page owned by someone else** would fork (via the Finding-1 guard) to a new public yoyo-owned page, leave the original expired, and **re-flag it every day** — a cost loop *and* a private-content leak. Fixed by making autonomous maintenance **commons-only** (skip private pages) + a regression test. Everything else (off-by-default gating, the reconcile re-loop guard, the cap, authz, the middleware exemption) verified correct.

## Enabling later (your call, after watching dry-runs)
```sh
# Inspect what it would do:
curl -s -X POST "https://yopedia.<sub>.workers.dev/api/tasks/scan?dry=1" -H "Authorization: Bearer <TOKEN>" | jq
# Enable: set AUTONOMOUS_MAINTENANCE=on on the main worker.
```

## Tests
`maintenance` / `scan-route` + `tasks` / `tasks-route` / `middleware` extensions. **Full suite 2557 green**; tsc clean (6 pre-existing); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)