### PR TITLE
yopedia: Q3 agent task queue — async/batch ingest

### DIFF
--- a/src/app/api/ingest/batch/route.ts
+++ b/src/app/api/ingest/batch/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { ingestUrl } from "@/lib/ingest";
 import { isUrl } from "@/lib/fetch";
 import { getPrincipal, getServicePrincipal } from "@/lib/auth";
+import { enqueueTask } from "@/lib/tasks";
 import { MAX_BATCH_URLS } from "@/lib/constants";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
@@ -59,7 +60,49 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // --- Stream NDJSON results as each URL completes --------------------
+    // --- Async mode: enqueue one ingest task per URL, return immediately ---
+    // Opt-in via `async: true`. The queue (Cloudflare Queues) processes them in
+    // the background — decoupled, retryable, rate-limited — so a big batch
+    // doesn't hold the request open or hammer the LLM. Interactive batches keep
+    // the streaming path below (the default).
+    if (body.async === true) {
+      let queued = 0;
+      let failed = 0;
+      for (let i = 0; i < urls.length; i++) {
+        // Per-URL try/catch: a single send() rejection (backpressure, etc.)
+        // must not abort the batch after partial enqueue — count it and report
+        // honest totals rather than 500-ing with work already queued.
+        try {
+          const ok = await enqueueTask({
+            kind: "ingest",
+            url: (urls[i] as string).trim(),
+            owner: principal.handle,
+            author: principal.handle,
+            ...(Array.isArray(tags) && tags.length > 0 ? { tags } : {}),
+          });
+          if (ok) queued++;
+          else failed++;
+        } catch (err) {
+          logger.warn("ingest", `batch async enqueue failed for ${urls[i]}`, err);
+          failed++;
+        }
+      }
+      if (queued === 0) {
+        // Nothing made it onto the queue (unavailable, or every send rejected).
+        return NextResponse.json(
+          { error: "Task queue unavailable — try the synchronous batch instead." },
+          { status: 503 },
+        );
+      }
+      return NextResponse.json({
+        mode: "async",
+        queued,
+        total: urls.length,
+        ...(failed > 0 ? { failed } : {}),
+      });
+    }
+
+    // --- Stream NDJSON results as each URL completes (default) -----------
     const encoder = new TextEncoder();
     const ingestOptions = {
       ...(Array.isArray(tags) && tags.length > 0 ? { tags } : {}),

--- a/src/app/api/tasks/run/route.ts
+++ b/src/app/api/tasks/run/route.ts
@@ -81,6 +81,7 @@ export async function POST(req: Request) {
     const opts = {
       ...(task.owner ? { owner: task.owner } : {}),
       ...(task.author ? { author: task.author, triggeredBy: task.author } : {}),
+      ...(task.tags && task.tags.length > 0 ? { tags: task.tags } : {}),
     };
     const result = task.url
       ? await ingestUrl(task.url, opts)

--- a/src/components/BatchIngestForm.tsx
+++ b/src/components/BatchIngestForm.tsx
@@ -15,6 +15,12 @@ export function BatchIngestForm() {
   const [items, setItems] = useState<BatchItem[]>([]);
   const [running, setRunning] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
+  // Async (queue) mode: enqueue and return immediately instead of streaming.
+  const [queueMode, setQueueMode] = useState(false);
+  const [queuedInfo, setQueuedInfo] = useState<{
+    queued: number;
+    total: number;
+  } | null>(null);
 
   const parseUrls = useCallback((text: string): string[] => {
     return text
@@ -49,6 +55,36 @@ export function BatchIngestForm() {
     const err = validateUrls(urls);
     if (err) {
       setValidationError(err);
+      return;
+    }
+
+    // Async (queue) mode: enqueue and return — no streaming.
+    if (queueMode) {
+      setRunning(true);
+      try {
+        const res = await fetch("/api/ingest/batch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ urls, async: true }),
+        });
+        const data = (await res.json().catch(() => ({}))) as {
+          queued?: number;
+          total?: number;
+          error?: string;
+        };
+        if (!res.ok) {
+          setValidationError(data.error || "Batch request failed");
+          return;
+        }
+        setQueuedInfo({
+          queued: data.queued ?? urls.length,
+          total: data.total ?? urls.length,
+        });
+      } catch {
+        setValidationError("Network error — could not reach the server");
+      } finally {
+        setRunning(false);
+      }
       return;
     }
 
@@ -173,6 +209,7 @@ export function BatchIngestForm() {
     setItems([]);
     setValidationError(null);
     setRunning(false);
+    setQueuedInfo(null);
   }
 
   const successCount = items.filter((i) => i.status === "success").length;
@@ -182,7 +219,7 @@ export function BatchIngestForm() {
 
   return (
     <div className="space-y-6">
-      {!running && items.length === 0 && (
+      {!running && items.length === 0 && !queuedInfo && (
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
             <label
@@ -205,6 +242,24 @@ export function BatchIngestForm() {
             </p>
           </div>
 
+          {/* Async (queue) toggle — process in the background instead of
+              streaming. Good for large/bulk batches. */}
+          <label className="flex items-start gap-2 text-sm text-foreground/70">
+            <input
+              type="checkbox"
+              checked={queueMode}
+              onChange={(e) => setQueueMode(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              Queue in background
+              <span className="block text-xs text-foreground/40">
+                Enqueue the batch and return immediately — pages appear as they
+                process. Best for large batches; doesn&rsquo;t stream progress.
+              </span>
+            </span>
+          </label>
+
           {validationError && (
             <Alert variant="error">
               {validationError}
@@ -215,9 +270,33 @@ export function BatchIngestForm() {
             type="submit"
             className="inline-block rounded-lg bg-foreground px-6 py-3 text-sm font-medium text-background hover:opacity-90 transition-opacity"
           >
-            Process All
+            {queueMode ? "Queue All" : "Process All"}
           </button>
         </form>
+      )}
+
+      {queuedInfo && (
+        <div className="space-y-4">
+          <Alert variant="success">
+            ✓ Queued {queuedInfo.queued} of {queuedInfo.total}{" "}
+            {queuedInfo.total === 1 ? "URL" : "URLs"} for background ingestion.
+            They&rsquo;ll appear in the wiki as they finish.
+          </Alert>
+          <div className="flex items-center gap-4">
+            <button
+              onClick={reset}
+              className="inline-block rounded-lg bg-foreground px-6 py-3 text-sm font-medium text-background hover:opacity-90 transition-opacity cursor-pointer"
+            >
+              Queue more
+            </button>
+            <Link
+              href="/wiki"
+              className="text-sm text-foreground/60 hover:text-foreground transition-colors"
+            >
+              View wiki →
+            </Link>
+          </div>
+        </div>
       )}
 
       {items.length > 0 && (

--- a/src/lib/__tests__/ingest-routes.test.ts
+++ b/src/lib/__tests__/ingest-routes.test.ts
@@ -27,7 +27,11 @@ vi.mock("@/lib/auth", () => ({
   getServicePrincipal: vi.fn(() => null),
 }));
 
+// The async batch path enqueues; default to "queued" (true).
+vi.mock("@/lib/tasks", () => ({ enqueueTask: vi.fn(async () => true) }));
+
 import { ingest, ingestUrl, reingest } from "@/lib/ingest";
+import { enqueueTask } from "@/lib/tasks";
 import { readWikiPageWithFrontmatter } from "@/lib/wiki";
 import { getPrincipal } from "@/lib/auth";
 import { getServicePrincipal } from "@/lib/auth";
@@ -42,6 +46,7 @@ const mockedReingest = vi.mocked(reingest);
 const mockedReadWikiPage = vi.mocked(readWikiPageWithFrontmatter);
 const mockedGetPrincipal = vi.mocked(getPrincipal);
 const mockedGetServicePrincipal = vi.mocked(getServicePrincipal);
+const mockedEnqueue = vi.mocked(enqueueTask);
 
 function makeRequest(url: string, body: unknown, token?: string): NextRequest {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
@@ -384,6 +389,80 @@ describe("POST /api/ingest — service token auth", () => {
 // ===========================================================================
 // POST /api/ingest/batch — service token auth
 // ===========================================================================
+describe("POST /api/ingest/batch — async (queue) mode", () => {
+  beforeEach(() => {
+    mockedEnqueue.mockClear();
+    mockedIngestUrl.mockClear();
+    mockedEnqueue.mockResolvedValue(true);
+  });
+
+  it("enqueues one ingest task per URL and returns immediately (no streaming)", async () => {
+    const res = await POST_BATCH(
+      makeRequest("http://localhost:3000/api/ingest/batch", {
+        urls: ["https://example.com/a", "https://example.com/b"],
+        tags: ["docs"],
+        async: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toMatchObject({ mode: "async", queued: 2, total: 2 });
+    // Did NOT run the synchronous ingest.
+    expect(mockedIngestUrl).not.toHaveBeenCalled();
+    expect(mockedEnqueue).toHaveBeenCalledTimes(2);
+    expect(mockedEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "ingest",
+        url: "https://example.com/a",
+        owner: "test-user",
+        author: "test-user",
+        tags: ["docs"],
+      }),
+    );
+  });
+
+  it("tolerates a mid-batch enqueue throw — reports queued + failed, not 500", async () => {
+    mockedEnqueue
+      .mockResolvedValueOnce(true)
+      .mockRejectedValueOnce(new Error("queue backpressure"))
+      .mockResolvedValueOnce(true);
+    const res = await POST_BATCH(
+      makeRequest("http://localhost:3000/api/ingest/batch", {
+        urls: [
+          "https://example.com/a",
+          "https://example.com/b",
+          "https://example.com/c",
+        ],
+        async: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ queued: 2, total: 3, failed: 1 });
+  });
+
+  it("503s when the queue is unavailable (nothing enqueued)", async () => {
+    mockedEnqueue.mockResolvedValue(false);
+    const res = await POST_BATCH(
+      makeRequest("http://localhost:3000/api/ingest/batch", {
+        urls: ["https://example.com/a"],
+        async: true,
+      }),
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("still validates URLs before enqueuing", async () => {
+    const res = await POST_BATCH(
+      makeRequest("http://localhost:3000/api/ingest/batch", {
+        urls: ["not-a-url"],
+        async: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedEnqueue).not.toHaveBeenCalled();
+  });
+});
+
 describe("POST /api/ingest/batch — service token auth", () => {
   it("accepts a valid service token when Clerk session is absent", async () => {
     mockedGetPrincipal.mockResolvedValue(null);

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -39,6 +39,7 @@ export type Task =
       content?: string;
       owner?: string;
       author?: string;
+      tags?: string[];
     }
   | {
       /** Autonomous maintenance, enqueued by the scan cron (Q2): `reconcile` a
@@ -118,6 +119,10 @@ export function parseTask(body: unknown): Task | null {
       const hasUrl = typeof t.url === "string" && t.url.trim() !== "";
       const hasContent = typeof t.content === "string" && t.content.trim() !== "";
       if (!hasUrl && !hasContent) return null; // need a source
+      const tags =
+        Array.isArray(t.tags) && t.tags.every((x) => typeof x === "string")
+          ? (t.tags as string[])
+          : undefined;
       return {
         kind: "ingest",
         ...(hasUrl ? { url: t.url as string } : {}),
@@ -125,6 +130,7 @@ export function parseTask(body: unknown): Task | null {
         ...(hasContent ? { content: t.content as string } : {}),
         ...(typeof t.owner === "string" ? { owner: t.owner } : {}),
         ...(typeof t.author === "string" ? { author: t.author } : {}),
+        ...(tags && tags.length > 0 ? { tags } : {}),
       };
     }
     case "maintain": {


### PR DESCRIPTION
The final task-queue phase: bulk ingestion can flow through the Cloudflare Queue instead of blocking. The `ingest` task + `/api/tasks/run` executor already existed (Q0) — Q3 wires up the **producer**.

## What's in this PR
- **`src/app/api/ingest/batch/route.ts`** — opt-in **async mode**: a request body with `async: true` enqueues one `ingest` task per URL (owner/author from the **session** principal, never the body; tags passed through) and returns `{ mode:"async", queued, total[, failed] }` **immediately**. The default (no `async`) keeps the existing **NDJSON streaming** path byte-for-byte unchanged. Per-URL enqueue is fault-tolerant — a mid-batch `send()` rejection counts as `failed` rather than 500-ing after a partial enqueue; `503` only when *nothing* made it onto the queue.
- **`src/components/BatchIngestForm.tsx`** — a **"Queue in background"** toggle: posts `async:true`, shows a "queued N" confirmation instead of streaming. Best for large/bulk batches.
- **`src/lib/tasks.ts`** — `tags?: string[]` on the `ingest` Task + `parseTask` validation; `/api/tasks/run` threads `tags` into ingest opts.

Interactive single ingest stays synchronous (unchanged).

## Review (code-reviewer) — clean except one, now fixed
- Attribution (session-only, anti-spoof), validation-before-enqueue, back-compat with the sync stream, UI state, and `parseTask` tags all verified clean.
- **Fixed:** a mid-batch `queue.send()` throw would return a misleading 500 after partially enqueuing. Now each enqueue is try/caught → reports honest `queued`/`failed` counts; 503 only when zero queued. + a regression test.

## Tests
Async-mode batch tests (enqueues per URL, partial-throw tolerance, 503-when-unavailable, validation-first) in `ingest-routes.test.ts`. **Full suite 2561 green**; tsc clean (6 pre-existing); lint clean.

## The agent task-queue epic is now complete
**Q0** plumbing · **Q1** on-demand reconcile · **Q2** autonomous maintenance · **Q3** async batch ingest — all on one queue + consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)