### PR TITLE
yopedia: janitorial maintenance ops + enable autonomous maintenance

### DIFF
--- a/src/app/api/tasks/run/route.ts
+++ b/src/app/api/tasks/run/route.ts
@@ -3,6 +3,7 @@ import { getServicePrincipal } from "@/lib/auth";
 import { parseTask } from "@/lib/tasks";
 import { reconcileFromTalk } from "@/lib/reconcile";
 import { ingest, ingestUrl, reingest } from "@/lib/ingest";
+import { fixLintIssue } from "@/lib/lint-fix";
 import { agentIdFor, DEFAULT_AGENT_NAME } from "@/lib/agents";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
@@ -67,6 +68,17 @@ export async function POST(req: Request) {
           );
         }
         const result = await reconcileFromTalk(task.slug, task.threadIndex);
+        return NextResponse.json({ ok: true, ...result });
+      }
+      if (task.op === "fix") {
+        // Deterministic, no-LLM lint auto-fix (backfill defaults, drop dead refs).
+        if (!task.lintType) {
+          return NextResponse.json(
+            { error: "maintain:fix requires lintType" },
+            { status: 400 },
+          );
+        }
+        const result = await fixLintIssue(task.lintType, task.slug);
         return NextResponse.json({ ok: true, ...result });
       }
       // op === "staleness": refresh an expired page from its source.

--- a/src/lib/__tests__/lint-fix.test.ts
+++ b/src/lib/__tests__/lint-fix.test.ts
@@ -154,6 +154,7 @@ describe("fixStaleIndex", () => {
   });
 
   it("returns no-op when slug is not in the index", async () => {
+    mockedReadWikiPage.mockResolvedValue(null); // page file genuinely missing
     mockedListWikiPages.mockResolvedValue([
       { slug: "other", title: "Other", summary: "..." },
     ]);
@@ -172,6 +173,7 @@ describe("fixStaleIndex", () => {
   });
 
   it("removes stale entry from index", async () => {
+    mockedReadWikiPage.mockResolvedValue(null); // page file genuinely missing
     mockedListWikiPages.mockResolvedValue([
       { slug: "good", title: "Good", summary: "keep" },
       { slug: "ghost", title: "Ghost", summary: "remove" },
@@ -765,6 +767,7 @@ describe("fixLintIssue", () => {
   });
 
   it("dispatches stale-index to fixStaleIndex", async () => {
+    mockedReadWikiPage.mockResolvedValue(null); // page file genuinely missing
     mockedListWikiPages.mockResolvedValue([
       { slug: "stale", title: "Stale", summary: "..." },
     ]);
@@ -918,13 +921,21 @@ describe("fixLintIssue", () => {
     );
   });
 
-  it("throws helpful FixValidationError for supersedes-dangling type", async () => {
-    await expect(fixLintIssue("supersedes-dangling", "some-slug")).rejects.toThrow(
-      FixValidationError,
+  it("dispatches supersedes-dangling to fixSupersededDangling (clears the dead ref)", async () => {
+    // Page declares supersedes: "ghost"; "ghost" has no page → dangling.
+    mockedReadWikiPageWithFrontmatter.mockImplementation(async (slug: string) =>
+      slug === "some-slug"
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ({ title: "Some", body: "# Some\n\nBody.", frontmatter: { supersedes: "ghost" } } as any)
+        : null,
     );
-    await expect(fixLintIssue("supersedes-dangling", "some-slug")).rejects.toThrow(
-      "Supersedes-dangling pages require manual review",
-    );
+
+    const result = await fixLintIssue("supersedes-dangling", "some-slug");
+    expect(result.success).toBe(true);
+    expect(mockedWriteWikiPageWithSideEffects).toHaveBeenCalledOnce();
+    // The dangling supersedes was removed from the written frontmatter.
+    const written = mockedWriteWikiPageWithSideEffects.mock.calls[0][0];
+    expect(written.content).not.toContain("supersedes");
   });
 
   it("throws helpful FixValidationError for incomplete-coverage type", async () => {

--- a/src/lib/__tests__/maintenance.test.ts
+++ b/src/lib/__tests__/maintenance.test.ts
@@ -91,6 +91,39 @@ describe("scanForMaintenance", () => {
     expect(await scanForMaintenance()).toHaveLength(0);
   });
 
+  it("enqueues a fix for a legacy page missing all yopedia schema fields", async () => {
+    // Write a page with only owner/visibility/updated — no confidence/authors/expiry.
+    await writeWikiPageWithSideEffects({
+      slug: "legacy",
+      title: "legacy",
+      content: serializeFrontmatter(
+        { owner: "alice", visibility: "public", updated: PAST } as Frontmatter,
+        "# legacy\n\nOld page.",
+      ),
+      summary: "legacy",
+      logOp: "ingest",
+      crossRefSource: null,
+    });
+    const tasks = await scanForMaintenance();
+    expect(tasks).toContainEqual({
+      kind: "maintain",
+      op: "fix",
+      slug: "legacy",
+      lintType: "unmigrated-page",
+    });
+  });
+
+  it("enqueues a fix to clear a dangling supersedes reference", async () => {
+    await seed("rev", { supersedes: "deleted-page" }); // target not seeded → dangling
+    const tasks = await scanForMaintenance();
+    expect(tasks).toContainEqual({
+      kind: "maintain",
+      op: "fix",
+      slug: "rev",
+      lintType: "supersedes-dangling",
+    });
+  });
+
   it("never flags a PRIVATE page (commons-only; avoids the reingest-fork loop)", async () => {
     await seed("priv-stale", {
       visibility: "private",

--- a/src/lib/__tests__/tasks-route.test.ts
+++ b/src/lib/__tests__/tasks-route.test.ts
@@ -7,16 +7,19 @@ vi.mock("@/lib/ingest", () => ({
   ingestUrl: vi.fn(),
   reingest: vi.fn(),
 }));
+vi.mock("@/lib/lint-fix", () => ({ fixLintIssue: vi.fn() }));
 
 import { getServicePrincipal } from "@/lib/auth";
 import { reconcileFromTalk } from "@/lib/reconcile";
 import { ingest, ingestUrl, reingest } from "@/lib/ingest";
+import { fixLintIssue } from "@/lib/lint-fix";
 
 const mockedGetService = vi.mocked(getServicePrincipal);
 const mockedReconcile = vi.mocked(reconcileFromTalk);
 const mockedIngest = vi.mocked(ingest);
 const mockedIngestUrl = vi.mocked(ingestUrl);
 const mockedReingest = vi.mocked(reingest);
+const mockedFixLint = vi.mocked(fixLintIssue);
 
 async function run(body: unknown) {
   const { POST } = await import("@/app/api/tasks/run/route");
@@ -78,6 +81,18 @@ describe("POST /api/tasks/run", () => {
     const res = await run({ kind: "maintain", op: "reconcile", slug: "d", threadIndex: 1 });
     expect(res.status).toBe(200);
     expect(mockedReconcile).toHaveBeenCalledWith("d", 1);
+  });
+
+  it("dispatches maintain:fix via fixLintIssue (deterministic lint fix)", async () => {
+    mockedFixLint.mockResolvedValue({ success: true, slug: "p", message: "fixed" });
+    const res = await run({
+      kind: "maintain",
+      op: "fix",
+      slug: "p",
+      lintType: "unmigrated-page",
+    });
+    expect(res.status).toBe(200);
+    expect(mockedFixLint).toHaveBeenCalledWith("unmigrated-page", "p");
   });
 
   it("dispatches maintain:staleness via reingest", async () => {

--- a/src/lib/__tests__/tasks.test.ts
+++ b/src/lib/__tests__/tasks.test.ts
@@ -92,6 +92,18 @@ describe("parseTask", () => {
     expect(parseTask({ kind: "maintain", op: "staleness", slug: "" })).toBeNull();
   });
 
+  it("accepts maintain:fix only with an allowed (deterministic) lintType", () => {
+    expect(
+      parseTask({ kind: "maintain", op: "fix", slug: "p", lintType: "unmigrated-page" }),
+    ).toEqual({ kind: "maintain", op: "fix", slug: "p", lintType: "unmigrated-page" });
+    expect(
+      parseTask({ kind: "maintain", op: "fix", slug: "p", lintType: "supersedes-dangling" }),
+    ).toMatchObject({ op: "fix", lintType: "supersedes-dangling" });
+    // A non-deterministic / unknown lint type (or none) is rejected.
+    expect(parseTask({ kind: "maintain", op: "fix", slug: "p", lintType: "broken-link" })).toBeNull();
+    expect(parseTask({ kind: "maintain", op: "fix", slug: "p" })).toBeNull();
+  });
+
   it("rejects unknown kinds and non-objects", () => {
     expect(parseTask({ kind: "nope" })).toBeNull();
     expect(parseTask(null)).toBeNull();

--- a/src/lib/lint-fix.ts
+++ b/src/lib/lint-fix.ts
@@ -87,6 +87,17 @@ export async function fixStaleIndex(slug: string): Promise<FixResult> {
     throw new FixValidationError("Missing required field: slug");
   }
 
+  // Re-verify the page file is genuinely missing before dropping its index
+  // entry — never remove a valid entry on a transient read miss or a retry
+  // after the page was (re)created.
+  if (await readWikiPage(slug)) {
+    return {
+      success: false,
+      slug,
+      message: `Page "${slug}" exists — index entry is not stale`,
+    };
+  }
+
   const entries = await listWikiPages();
   const filtered = entries.filter((e) => e.slug !== slug);
 
@@ -570,6 +581,57 @@ export async function fixUnmigratedPage(slug: string): Promise<FixResult> {
   };
 }
 
+/**
+ * Fix a supersedes-dangling issue by CLEARING the dead reference — the page's
+ * `supersedes` points at a slug that no longer exists, so the pointer is stale.
+ * Re-verifies the target is still missing before clearing (idempotent / safe
+ * under queue retry), so a now-valid reference is never dropped.
+ */
+export async function fixSupersededDangling(slug: string): Promise<FixResult> {
+  if (!slug) {
+    throw new FixValidationError("Missing required field: slug");
+  }
+  const page = await readWikiPageWithFrontmatter(slug);
+  if (!page) {
+    throw new FixNotFoundError(`Page not found: ${slug}`);
+  }
+
+  const supersedes = page.frontmatter.supersedes;
+  if (typeof supersedes !== "string" || supersedes === "") {
+    return { success: false, slug, message: `No supersedes field to fix on "${slug}"` };
+  }
+  // Don't clear a reference that has since become valid.
+  if (await readWikiPageWithFrontmatter(supersedes)) {
+    return {
+      success: false,
+      slug,
+      message: `supersedes target "${supersedes}" now exists — nothing to fix`,
+    };
+  }
+
+  const fm = { ...page.frontmatter };
+  delete fm.supersedes;
+  await writeWikiPageWithSideEffects({
+    slug,
+    title: page.title,
+    content: serializeFrontmatter(fm, page.body),
+    summary: (() => {
+      const m = page.body.match(/^#\s+.+\n+(.+)/m);
+      return m ? m[1].slice(0, 120) : slug;
+    })(),
+    logOp: "edit",
+    logDetails: () => `auto-fix: cleared dangling supersedes "${supersedes}"`,
+    crossRefSource: null,
+    author: "lint-fix",
+  });
+
+  return {
+    success: true,
+    slug,
+    message: `Cleared dangling supersedes "${supersedes}" from "${slug}"`,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
@@ -628,9 +690,8 @@ export async function fixLintIssue(
         "Disputed pages cannot be auto-fixed. Review the page content and talk page to resolve the dispute through discussion.",
       );
     case "supersedes-dangling":
-      throw new FixValidationError(
-        "Supersedes-dangling pages require manual review. Update the supersedes field to point to a valid page or remove it.",
-      );
+      // Auto-fixable: clear the dead reference (re-verified missing first).
+      return fixSupersededDangling(slug);
     case "incomplete-coverage":
       throw new FixValidationError(
         "Incomplete coverage cannot be auto-fixed. Re-ingest the source URL to refresh the page content.",

--- a/src/lib/maintenance.ts
+++ b/src/lib/maintenance.ts
@@ -9,6 +9,10 @@
  *     same `reconcileFromTalk` as the on-demand button.
  *   - **staleness**: a page past its `expiry` with a `source_url` → re-ingest
  *     from the source (the reconcile-on-merge step refreshes it).
+ *   - **fix** (deterministic, no LLM): backfill a legacy page missing all
+ *     yopedia schema fields (`unmigrated-page`); clear a dangling `supersedes`
+ *     reference (`supersedes-dangling`); drop an index entry whose page file is
+ *     gone (`stale-index`). These reuse the lint auto-fixes (`lint-fix.ts`).
  *
  * Guardrails (because no human is watching each one):
  *   - **commons-only**: skip PRIVATE pages entirely. Autonomous maintenance
@@ -41,11 +45,25 @@ export async function scanForMaintenance(
   const today = new Date().toISOString().slice(0, 10);
   const tasks: Task[] = [];
   const pages = await listWikiPages();
+  const pageSlugs = new Set(pages.map((p) => p.slug));
 
   for (const entry of pages) {
     if (tasks.length >= cap) break;
+    if (entry.slug === "index" || entry.slug === "log") continue; // infra
+
     const page = await readWikiPageWithFrontmatter(entry.slug);
-    if (!page) continue;
+    if (!page) {
+      // Index entry with no page file → stale-index. The fix re-verifies the
+      // file is genuinely missing before dropping the entry, so a transient
+      // read miss is safe.
+      tasks.push({
+        kind: "maintain",
+        op: "fix",
+        slug: entry.slug,
+        lintType: "stale-index",
+      });
+      continue;
+    }
     const fm = page.frontmatter;
 
     // Commons-only: never autonomously touch a private vault page (privacy +
@@ -71,7 +89,27 @@ export async function scanForMaintenance(
       }
     }
 
-    // (2) Stale (expiry passed) with a source to refresh from → re-ingest.
+    // (2) Deterministic janitorial fixes (no LLM, safe): backfill a legacy page
+    //     missing ALL yopedia schema fields; clear a dangling `supersedes` ref.
+    if (
+      !("confidence" in fm) &&
+      !("authors" in fm) &&
+      !("expiry" in fm)
+    ) {
+      tasks.push({ kind: "maintain", op: "fix", slug: entry.slug, lintType: "unmigrated-page" });
+      continue;
+    }
+    const supersedes = fm.supersedes;
+    if (
+      typeof supersedes === "string" &&
+      supersedes !== "" &&
+      !pageSlugs.has(supersedes)
+    ) {
+      tasks.push({ kind: "maintain", op: "fix", slug: entry.slug, lintType: "supersedes-dangling" });
+      continue;
+    }
+
+    // (3) Stale (expiry passed) with a source to refresh from → re-ingest.
     const expiry = fm.expiry;
     const sourceUrl = fm.source_url;
     if (

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -42,14 +42,29 @@ export type Task =
       tags?: string[];
     }
   | {
-      /** Autonomous maintenance, enqueued by the scan cron (Q2): `reconcile` a
-       *  disputed page from its open thread, or `staleness` re-ingest an expired
-       *  page from its source. `threadIndex` is required for `reconcile`. */
+      /** Autonomous maintenance, enqueued by the scan cron (Q2). `reconcile` a
+       *  disputed page from its open thread; `staleness` re-ingest an expired
+       *  page from its source; `fix` apply a deterministic lint auto-fix
+       *  (`lintType`). `threadIndex` is required for `reconcile`; `lintType` for
+       *  `fix`. */
       kind: "maintain";
-      op: "reconcile" | "staleness";
+      op: "reconcile" | "staleness" | "fix";
       slug: string;
       threadIndex?: number;
+      lintType?: MaintainFixType;
     };
+
+/** Deterministic, no-LLM lint fixes the maintenance scan may auto-apply. */
+export type MaintainFixType =
+  | "unmigrated-page"
+  | "stale-index"
+  | "supersedes-dangling";
+
+const MAINTAIN_FIX_TYPES = new Set<MaintainFixType>([
+  "unmigrated-page",
+  "stale-index",
+  "supersedes-dangling",
+]);
 
 /** Minimal Cloudflare Queue producer binding — we only ever call `send`. */
 interface QueueBinding {
@@ -134,7 +149,6 @@ export function parseTask(body: unknown): Task | null {
       };
     }
     case "maintain": {
-      if (t.op !== "reconcile" && t.op !== "staleness") return null;
       if (typeof t.slug !== "string" || t.slug.trim() === "") return null;
       // `reconcile` needs a thread to reconcile from.
       if (t.op === "reconcile") {
@@ -143,7 +157,20 @@ export function parseTask(body: unknown): Task | null {
         }
         return { kind: "maintain", op: "reconcile", slug: t.slug, threadIndex: t.threadIndex };
       }
-      return { kind: "maintain", op: "staleness", slug: t.slug };
+      if (t.op === "staleness") {
+        return { kind: "maintain", op: "staleness", slug: t.slug };
+      }
+      // `fix` needs an allowed (deterministic) lint type.
+      if (t.op === "fix") {
+        if (!MAINTAIN_FIX_TYPES.has(t.lintType as MaintainFixType)) return null;
+        return {
+          kind: "maintain",
+          op: "fix",
+          slug: t.slug,
+          lintType: t.lintType as MaintainFixType,
+        };
+      }
+      return null;
     }
     default:
       return null;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -69,7 +69,13 @@
   // Public site-owner handle for runtime server gates (owner-only Lint). The
   // authoritative copy for the client is the build-time inline (deploy
   // workflow); this is runtime parity for server reads. Public, not a secret.
+  //
+  // AUTONOMOUS_MAINTENANCE="on" enables the daily maintenance cron to actually
+  // enqueue maintain tasks (reconcile disputes, refresh stale pages, and the
+  // deterministic janitorial fixes). Anything other than "on" = dry-run.
+  // See workers/task-consumer/README.md.
   "vars": {
-    "NEXT_PUBLIC_OWNER_HANDLE": "yuanhao"
+    "NEXT_PUBLIC_OWNER_HANDLE": "yuanhao",
+    "AUTONOMOUS_MAINTENANCE": "on"
   }
 }


### PR DESCRIPTION
Adds three **deterministic, no-LLM** autonomous-maintenance ops and **turns autonomous maintenance on** in prod.

## New ops (`maintain:fix`, reusing the lint auto-fixes)
- **`unmigrated-page`** → backfill missing yopedia schema defaults (`fixUnmigratedPage`)
- **`supersedes-dangling`** → clear a dead `supersedes` reference (new `fixSupersededDangling` — re-verifies the target is still missing first)
- **`stale-index`** → drop an index entry whose page file is gone (`fixStaleIndex`)

## Safety
- **`fixStaleIndex` hardened** — re-verifies the page file is *genuinely* missing before dropping its entry (guards a transient read miss / retry).
- **`parseTask` allowlist** — `maintain:fix` accepts only the 3 deterministic lint types; any other (`broken-link`, `contradiction`, …) is rejected at parse → poison. The heavier/LLM lint-fix branches are unreachable from the maintain path.
- The scan stays **commons-only**, **capped (10/scan)**, one-task-per-page, skip-updated-today. All three new ops **self-terminate** — a fixed page is no longer flagged next scan.

## Enable
`wrangler.jsonc` vars `AUTONOMOUS_MAINTENANCE: "on"` — the daily cron now enqueues real `maintain` tasks (was dry-run). The deterministic janitorial fixes + the existing reconcile/staleness ops go live, bounded by the guardrails above.

## Review (code-reviewer) — clean, no issues
Verified: every guardrail holds, all three ops self-terminate (no re-flag loop), `fixStaleIndex`/`fixSupersededDangling` are correct + idempotent under queue retry, owner/visibility/body preserved, the lintType allowlist can't be bypassed, and enabling is safe.

## Tests
maintenance (unmigrated/supersedes/stale-index), `parseTask` allowlist, `maintain:fix` dispatch, `fixSupersededDangling` + hardened `fixStaleIndex`. **Full suite 2565 green**; tsc clean; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)