### PR TITLE
Fix perf-1+2 review findings (partial-index guard + attribution + canonical)

### DIFF
--- a/src/app/u/[handle]/[slug]/page.tsx
+++ b/src/app/u/[handle]/[slug]/page.tsx
@@ -19,8 +19,13 @@ interface WikiPageProps {
 /**
  * Per-page Open Graph / Twitter metadata for the owner-scoped (private/owned)
  * URL. Private pages the viewer can't read get a neutral title so existence
- * isn't leaked. Canonical stays `/u/<tenant>/<slug>`; for PUBLIC pages this
- * route 308-redirects to the global `/wiki/<slug>` so the canonical there wins.
+ * isn't leaked.
+ *
+ * For PUBLIC commons pages the canonical + OG url point at the GLOBAL
+ * `/wiki/<slug>`: the page-body `permanentRedirect` does NOT produce a true HTTP
+ * redirect on OpenNext-Cloudflare (the public page renders at 200 here), so
+ * pointing the canonical at the commons URL avoids duplicate-content/SEO issues.
+ * Private/owned pages stay canonical at `/u/<tenant>/<slug>`.
  */
 export async function generateMetadata({
   params,
@@ -41,7 +46,19 @@ export async function generateMetadata({
     typeof page.frontmatter.summary === "string"
       ? page.frontmatter.summary
       : undefined;
-  const url = pagePath(tenant, slug);
+  // Public commons pages are canonical at the global `/wiki/<slug>` (see the
+  // function doc): point canonical + OG url there. Private pages canonical here.
+  const inCommons = belongsInCommons({
+    visibility:
+      typeof page.frontmatter.visibility === "string"
+        ? page.frontmatter.visibility
+        : undefined,
+    type:
+      typeof page.frontmatter.type === "string"
+        ? page.frontmatter.type
+        : undefined,
+  });
+  const url = inCommons ? commonsPath(slug) : pagePath(tenant, slug);
   return {
     title: page.title, // layout template appends " · yopedia"
     ...(description ? { description } : {}),

--- a/src/components/ArticleActions.tsx
+++ b/src/components/ArticleActions.tsx
@@ -48,11 +48,23 @@ export function ArticleActions({
   hasSourceUrl,
 }: ArticleActionsProps) {
   const { isLoaded, isSignedIn, user } = useUser();
-  const username = user?.username ?? null;
+  // Resolve the viewer's handle the SAME way the server does (auth.ts
+  // resolveHandle): prefer the Clerk username, else the username on the X/Twitter
+  // external account (Twitter-SSO users often have no Clerk username set).
+  const handle =
+    user?.username ??
+    user?.externalAccounts?.find(
+      (a) => typeof a.provider === "string" && /(^|_)(x|twitter)$/i.test(a.provider),
+    )?.username ??
+    null;
+  // Owner/contributor gating is case-insensitive (owner/contributors are stored
+  // lowercased server-side).
+  const handleLc = handle?.toLowerCase() ?? null;
 
-  const isOwner = !!username && username === owner;
+  const isOwner = !!handleLc && handleLc === owner.toLowerCase();
   const ownsOrContributes =
-    !!username && (isOwner || contributors.includes(username));
+    !!handleLc &&
+    (isOwner || contributors.some((c) => c.toLowerCase() === handleLc));
   // Curate is for pulling in OTHERS' commons pages (your own are implicitly in
   // your vault), so it shows only to signed-in non-owner/contributor viewers.
   const canCurate =

--- a/src/lib/__tests__/backlink-index.test.ts
+++ b/src/lib/__tests__/backlink-index.test.ts
@@ -52,12 +52,42 @@ async function createPage(slug: string, body: string, frontmatter = "") {
   );
 }
 
-describe("syncBacklinksForPage", () => {
+/** Seed an empty-but-present index so incremental hooks apply (not no-op). */
+async function seedEmptyIndex() {
+  await rebuildBacklinkIndex(); // no pages → writes `{}` (present, empty)
+}
+
+describe("no-op until seeded", () => {
+  it("getBacklinkIndex returns null when absent", async () => {
+    expect(await getBacklinkIndex()).toBeNull();
+  });
+
+  it("syncBacklinksForPage no-ops before any rebuild (reader stays null)", async () => {
+    await syncBacklinksForPage("src", "see [T](target.md)");
+    expect(await getBacklinkIndex()).toBeNull(); // not fabricated from one write
+  });
+
+  it("removeBacklinksForSlug no-ops before any rebuild", async () => {
+    await removeBacklinksForSlug("a");
+    expect(await getBacklinkIndex()).toBeNull();
+  });
+
+  it("rebuild seeds an empty-but-present index, then incremental updates apply", async () => {
+    await seedEmptyIndex();
+    expect(await getBacklinkIndex()).toEqual({});
+    await syncBacklinksForPage("src", "see [T](target.md)");
+    expect((await getBacklinkIndex())?.target).toEqual(["src"]);
+  });
+});
+
+describe("syncBacklinksForPage (after seeding)", () => {
+  beforeEach(seedEmptyIndex);
+
   it("adds the source for each newly-linked target", async () => {
     await syncBacklinksForPage("src", "see [T](target.md) and [U](other.md)");
     const idx = await getBacklinkIndex();
-    expect(idx.target).toEqual(["src"]);
-    expect(idx.other).toEqual(["src"]);
+    expect(idx?.target).toEqual(["src"]);
+    expect(idx?.other).toEqual(["src"]);
   });
 
   it("diffs against previous content: removed link drops the source", async () => {
@@ -65,26 +95,28 @@ describe("syncBacklinksForPage", () => {
     // New content no longer links to `other`.
     await syncBacklinksForPage("src", "[T](target.md)", "[T](target.md) [U](other.md)");
     const idx = await getBacklinkIndex();
-    expect(idx.target).toEqual(["src"]);
-    expect(idx.other).toBeUndefined();
+    expect(idx?.target).toEqual(["src"]);
+    expect(idx?.other).toBeUndefined();
   });
 
   it("ignores self-links", async () => {
     await syncBacklinksForPage("src", "[me](src.md) [T](target.md)");
     const idx = await getBacklinkIndex();
-    expect(idx.src).toBeUndefined();
-    expect(idx.target).toEqual(["src"]);
+    expect(idx?.src).toBeUndefined();
+    expect(idx?.target).toEqual(["src"]);
   });
 });
 
-describe("removeBacklinksForSlug", () => {
+describe("removeBacklinksForSlug (after seeding)", () => {
+  beforeEach(seedEmptyIndex);
+
   it("drops the slug as a target key and as a source everywhere", async () => {
     await syncBacklinksForPage("a", "[X](x.md)");
     await syncBacklinksForPage("b", "[A](a.md)"); // b → a
     await removeBacklinksForSlug("a");
     const idx = await getBacklinkIndex();
-    expect(idx.a).toBeUndefined(); // a removed as a target key (b→a gone)
-    expect(idx.x).toBeUndefined(); // a was x's only source → key pruned
+    expect(idx?.a).toBeUndefined(); // a removed as a target key (b→a gone)
+    expect(idx?.x).toBeUndefined(); // a was x's only source → key pruned
   });
 });
 
@@ -107,7 +139,7 @@ describe("findBacklinks read parity (fast path vs fallback)", () => {
     await createPage("target", "the target");
 
     // No index → fallback O(pages²) scan.
-    expect(await getBacklinkIndex()).toEqual({});
+    expect(await getBacklinkIndex()).toBeNull();
     const fallback = (await findBacklinks("target")).map((b) => b.slug).sort();
     expect(fallback).toEqual(["a", "b"]);
 
@@ -126,7 +158,7 @@ describe("findBacklinks read parity (fast path vs fallback)", () => {
 
     // The index records BOTH sources (no visibility encoded).
     const idx = await getBacklinkIndex();
-    expect(idx.target.sort()).toEqual(["priv", "pub"]);
+    expect(idx?.target.sort()).toEqual(["priv", "pub"]);
 
     // But an anonymous read filters out the private linker.
     const anon = await findBacklinks("target", null);

--- a/src/lib/__tests__/contributors.test.ts
+++ b/src/lib/__tests__/contributors.test.ts
@@ -110,6 +110,40 @@ describe("contributors data layer", () => {
       const contributors = await listContributors();
       expect(contributors.map((c) => c.handle)).toEqual(["alice"]);
     });
+
+    it("takes the contributor-index fast path ONLY for an anonymous viewer; a non-null principal uses the per-principal scan (sees their own private pages)", async () => {
+      // A PUBLIC page edited by alice (visible to everyone, in the anon index).
+      await createPage(
+        "pub",
+        "Pub",
+        "---\nowner: alice\nvisibility: public\n---\n\n# Pub\n\nc.",
+      );
+      await saveRevision("pub", "# Pub\n\nv1", "alice");
+
+      // A PRIVATE page owned+edited by bob (invisible to anon → NOT in index).
+      await createPage(
+        "priv",
+        "Priv",
+        "---\nowner: bob\nvisibility: private\n---\n\n# Priv\n\nc.",
+      );
+      await saveRevision("priv", "# Priv\n\nv1", "bob");
+
+      // Build the index from the ANONYMOUS scan: only alice/pub.
+      const { rebuildContributorIndex, getContributorIndex } = await import(
+        "../contributor-index"
+      );
+      await rebuildContributorIndex();
+      expect(await getContributorIndex()).not.toBeNull();
+
+      // Anonymous: fast path → index only → bob (private) absent.
+      const anon = await listContributors(null);
+      expect(anon.map((c) => c.handle)).toEqual(["alice"]);
+
+      // bob as principal: must NOT take the anon fast path; the per-principal
+      // scan sees bob's own private page, so bob shows up.
+      const asBob = await listContributors({ id: "bob", handle: "bob" });
+      expect(asBob.map((c) => c.handle).sort()).toEqual(["alice", "bob"]);
+    });
   });
 
   describe("buildContributorProfile", () => {

--- a/src/lib/__tests__/discuss-stats-index.test.ts
+++ b/src/lib/__tests__/discuss-stats-index.test.ts
@@ -48,41 +48,73 @@ function thread(status: TalkThread["status"]): TalkThread {
   return { pageSlug: "p", title: "t", status, created: "", updated: "", comments: [] };
 }
 
-describe("syncDiscussStatsForSlug / removeDiscussStatsForSlug", () => {
+/** Seed an empty-but-present index so incremental hooks apply (not no-op). */
+async function seedEmptyIndex() {
+  await rebuildDiscussStatsIndex(); // no discuss files → writes `{}` (present, empty)
+}
+
+describe("no-op until seeded", () => {
+  it("getDiscussStatsIndex returns null when absent", async () => {
+    expect(await getDiscussStatsIndex()).toBeNull();
+  });
+
+  it("syncDiscussStatsForSlug no-ops before any rebuild (reader stays null)", async () => {
+    await syncDiscussStatsForSlug("p", [thread("open")]);
+    expect(await getDiscussStatsIndex()).toBeNull(); // not fabricated from one write
+  });
+
+  it("removeDiscussStatsForSlug no-ops before any rebuild", async () => {
+    await removeDiscussStatsForSlug("p");
+    expect(await getDiscussStatsIndex()).toBeNull();
+  });
+
+  it("rebuild seeds an empty-but-present index, then incremental updates apply", async () => {
+    await seedEmptyIndex();
+    expect(await getDiscussStatsIndex()).toEqual({});
+    await syncDiscussStatsForSlug("p", [thread("open")]);
+    expect((await getDiscussStatsIndex())?.p).toEqual({ total: 1, open: 1 });
+  });
+});
+
+describe("syncDiscussStatsForSlug / removeDiscussStatsForSlug (after seeding)", () => {
+  beforeEach(seedEmptyIndex);
+
   it("upserts {total, open} from the in-memory threads", async () => {
     await syncDiscussStatsForSlug("p", [thread("open"), thread("resolved")]);
-    expect((await getDiscussStatsIndex()).p).toEqual({ total: 2, open: 1 });
+    expect((await getDiscussStatsIndex())?.p).toEqual({ total: 2, open: 1 });
   });
 
   it("updates in place on re-sync", async () => {
     await syncDiscussStatsForSlug("p", [thread("open")]);
     await syncDiscussStatsForSlug("p", [thread("open"), thread("open")]);
-    expect((await getDiscussStatsIndex()).p).toEqual({ total: 2, open: 2 });
+    expect((await getDiscussStatsIndex())?.p).toEqual({ total: 2, open: 2 });
   });
 
   it("remove drops the entry", async () => {
     await syncDiscussStatsForSlug("p", [thread("open")]);
     await removeDiscussStatsForSlug("p");
-    expect((await getDiscussStatsIndex()).p).toBeUndefined();
+    expect((await getDiscussStatsIndex())?.p).toBeUndefined();
   });
 });
 
-describe("talk mutations maintain the index", () => {
+describe("talk mutations maintain the index (after seeding)", () => {
+  beforeEach(seedEmptyIndex);
+
   it("createThread / addComment / resolveThread keep stats fresh", async () => {
     await createThread("p", "Title", "alice", "first");
-    expect((await getDiscussStatsIndex()).p).toEqual({ total: 1, open: 1 });
+    expect((await getDiscussStatsIndex())?.p).toEqual({ total: 1, open: 1 });
 
     await addComment("p", 0, "bob", "reply");
-    expect((await getDiscussStatsIndex()).p).toEqual({ total: 1, open: 1 });
+    expect((await getDiscussStatsIndex())?.p).toEqual({ total: 1, open: 1 });
 
     await resolveThread("p", 0, "resolved");
-    expect((await getDiscussStatsIndex()).p).toEqual({ total: 1, open: 0 });
+    expect((await getDiscussStatsIndex())?.p).toEqual({ total: 1, open: 0 });
   });
 
   it("deleteDiscussions removes the slug entry", async () => {
     await createThread("p", "Title", "alice", "first");
     await deleteDiscussions("p");
-    expect((await getDiscussStatsIndex()).p).toBeUndefined();
+    expect((await getDiscussStatsIndex())?.p).toBeUndefined();
   });
 });
 
@@ -93,8 +125,8 @@ describe("rebuildDiscussStatsIndex", () => {
     await resolveThread("b", 0, "resolved");
     await rebuildDiscussStatsIndex();
     const idx = await getDiscussStatsIndex();
-    expect(idx.a).toEqual({ total: 1, open: 1 });
-    expect(idx.b).toEqual({ total: 1, open: 0 });
+    expect(idx?.a).toEqual({ total: 1, open: 1 });
+    expect(idx?.b).toEqual({ total: 1, open: 0 });
   });
 });
 
@@ -116,15 +148,15 @@ describe("getDiscussionStatsForSlugs read parity (fast path vs fallback)", () =>
       "utf-8",
     );
 
-    // Index is empty → read falls back to the directory scan.
-    expect(await getDiscussStatsIndex()).toEqual({});
+    // Index is absent → read falls back to the directory scan.
+    expect(await getDiscussStatsIndex()).toBeNull();
     const fallback = await getDiscussionStatsForSlugs(["a", "missing"]);
     expect(fallback.get("a")).toEqual({ total: 2, open: 1 });
     expect(fallback.get("missing")).toEqual({ total: 0, open: 0 });
 
     // Rebuild → fast path → SAME result.
     await rebuildDiscussStatsIndex();
-    expect(Object.keys(await getDiscussStatsIndex()).length).toBeGreaterThan(0);
+    expect(Object.keys((await getDiscussStatsIndex())!).length).toBeGreaterThan(0);
     const fast = await getDiscussionStatsForSlugs(["a", "missing"]);
     expect(fast.get("a")).toEqual(fallback.get("a"));
     expect(fast.get("missing")).toEqual(fallback.get("missing"));

--- a/src/lib/__tests__/owner-index.test.ts
+++ b/src/lib/__tests__/owner-index.test.ts
@@ -52,43 +52,75 @@ async function createPage(slug: string, frontmatter: string, title = slug) {
   );
 }
 
-describe("syncOwnerIndexForPage", () => {
+/** Seed an empty-but-present index so incremental hooks apply (not no-op). */
+async function seedEmptyIndex() {
+  await rebuildOwnerIndex(); // no pages → writes `{}` (present, empty)
+}
+
+describe("no-op until seeded", () => {
+  it("getOwnerIndex returns null when absent", async () => {
+    expect(await getOwnerIndex()).toBeNull();
+  });
+
+  it("syncOwnerIndexForPage no-ops before any rebuild (reader stays null)", async () => {
+    await syncOwnerIndexForPage("p", "alice");
+    expect(await getOwnerIndex()).toBeNull(); // not fabricated from one write
+  });
+
+  it("removeOwnerIndexForSlug no-ops before any rebuild", async () => {
+    await removeOwnerIndexForSlug("p");
+    expect(await getOwnerIndex()).toBeNull();
+  });
+
+  it("rebuild seeds an empty-but-present index, then incremental updates apply", async () => {
+    await seedEmptyIndex();
+    expect(await getOwnerIndex()).toEqual({});
+    await syncOwnerIndexForPage("p", "alice");
+    expect((await getOwnerIndex())?.alice).toEqual(["p"]);
+  });
+});
+
+describe("syncOwnerIndexForPage (after seeding)", () => {
+  beforeEach(seedEmptyIndex);
+
   it("adds the slug to the owner tenant bucket", async () => {
     await syncOwnerIndexForPage("p", "alice");
-    expect((await getOwnerIndex()).alice).toEqual(["p"]);
+    expect((await getOwnerIndex())?.alice).toEqual(["p"]);
   });
 
   it("adds the slug to owner AND every contributor tenant", async () => {
     await syncOwnerIndexForPage("p", "alice", ["bob", "Carol"]);
     const idx = await getOwnerIndex();
-    expect(idx.alice).toEqual(["p"]);
-    expect(idx.bob).toEqual(["p"]);
-    expect(idx.carol).toEqual(["p"]); // tenant is lowercased
+    expect(idx?.alice).toEqual(["p"]);
+    expect(idx?.bob).toEqual(["p"]);
+    expect(idx?.carol).toEqual(["p"]); // tenant is lowercased
   });
 
   it("ownerless pages land in the default (yopedia) tenant", async () => {
     await syncOwnerIndexForPage("o");
-    expect((await getOwnerIndex()).yopedia).toEqual(["o"]);
+    expect((await getOwnerIndex())?.yopedia).toEqual(["o"]);
   });
 
   it("removes the slug from a stale bucket when owner/contributors change", async () => {
     await syncOwnerIndexForPage("p", "alice", ["bob"]);
-    expect((await getOwnerIndex()).bob).toEqual(["p"]);
+    expect((await getOwnerIndex())?.bob).toEqual(["p"]);
     // bob no longer a contributor → drop from bob's bucket.
     await syncOwnerIndexForPage("p", "alice", []);
     const idx = await getOwnerIndex();
-    expect(idx.alice).toEqual(["p"]);
-    expect(idx.bob).toBeUndefined();
+    expect(idx?.alice).toEqual(["p"]);
+    expect(idx?.bob).toBeUndefined();
   });
 
   it("is idempotent (no duplicate slugs)", async () => {
     await syncOwnerIndexForPage("p", "alice");
     await syncOwnerIndexForPage("p", "alice");
-    expect((await getOwnerIndex()).alice).toEqual(["p"]);
+    expect((await getOwnerIndex())?.alice).toEqual(["p"]);
   });
 });
 
-describe("removeOwnerIndexForSlug", () => {
+describe("removeOwnerIndexForSlug (after seeding)", () => {
+  beforeEach(seedEmptyIndex);
+
   it("removes the slug from all buckets", async () => {
     await syncOwnerIndexForPage("p", "alice", ["bob"]);
     await removeOwnerIndexForSlug("p");
@@ -115,13 +147,13 @@ describe("slugsForOwner read parity (fast path vs fallback)", () => {
     await createPage("b", "owner: bob\ncontributors: [alice]");
 
     // No index yet → fallback scan.
-    expect(await getOwnerIndex()).toEqual({});
+    expect(await getOwnerIndex()).toBeNull();
     const fallback = (await slugsForOwner("alice")).sort();
     expect(fallback).toEqual(["a", "b"]);
 
     // Populate the index → fast path → SAME result.
     await rebuildOwnerIndex();
-    expect(Object.keys(await getOwnerIndex()).length).toBeGreaterThan(0);
+    expect(Object.keys((await getOwnerIndex())!).length).toBeGreaterThan(0);
     const fastPath = (await slugsForOwner("alice")).sort();
     expect(fastPath).toEqual(fallback);
   });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -42,22 +42,8 @@ function resolveHandle(user: {
  */
 export async function getPrincipal(): Promise<Principal | null> {
   try {
-    const { userId, sessionClaims } = await auth();
+    const { userId } = await auth();
     if (!userId) return null;
-
-    // Fast path: resolve the handle straight from the session claims (the JWT)
-    // when present, avoiding the extra `currentUser()` round-trip to Clerk's API.
-    // Configure `YOPEDIA_HANDLE_CLAIM` to read a custom claim; otherwise we look
-    // at the standard `username` claim. Only fall back to `currentUser()` when
-    // claims don't carry a usable handle. Same return shape, same fail-closed
-    // behavior — a no-op (correct fallback) when claims never carry a handle.
-    const claimKey = process.env.YOPEDIA_HANDLE_CLAIM || "username";
-    const claims = sessionClaims as Record<string, unknown> | null | undefined;
-    const claimHandle = claims?.[claimKey];
-    if (typeof claimHandle === "string" && claimHandle.trim() !== "") {
-      return { id: userId, handle: claimHandle };
-    }
-
     const user = await currentUser();
     return { id: userId, handle: resolveHandle(user) ?? userId };
   } catch {

--- a/src/lib/backlink-index.ts
+++ b/src/lib/backlink-index.ts
@@ -10,7 +10,8 @@
  * are resolved/enforced on READ. The index never encodes who can see what; a
  * private linker is filtered out at read time, so the index can be shared/cached
  * without leaking. Behavior-preserving: the read site falls back to the live
- * O(pages²) scan whenever the index is empty.
+ * O(pages²) scan whenever the index is ABSENT (reader returns `null`). An
+ * empty-but-present index (`{}`) is a valid seeded state.
  */
 
 import { getStorage } from "./storage";
@@ -31,16 +32,19 @@ const BACKLINK_INDEX_LOCK = "backlinks-index";
 export type BacklinkIndex = Record<string, string[]>;
 
 /**
- * Read the full backlink index (empty object when absent). Fail-soft: a missing
- * or corrupt index returns `{}` so the read site falls back to the live scan.
+ * Read the full backlink index, or `null` when absent/corrupt. Returns `null`
+ * (not an empty object) so callers can distinguish "no index → fall back to the
+ * live scan" from "index present but empty → genuinely no backlinks". Fail-soft:
+ * a missing or corrupt index returns `null`.
  */
-export async function getBacklinkIndex(): Promise<BacklinkIndex> {
+export async function getBacklinkIndex(): Promise<BacklinkIndex | null> {
   try {
     const idx = await getStorage().getIndex<BacklinkIndex>(BACKLINK_INDEX_KEY);
-    return idx && typeof idx === "object" ? idx : {};
+    if (!idx || typeof idx !== "object") return null;
+    return idx;
   } catch (err) {
-    logger.warn("backlink-index", "backlink index unreadable; treating as empty:", err);
-    return {};
+    logger.warn("backlink-index", "backlink index unreadable; treating as absent:", err);
+    return null;
   }
 }
 
@@ -79,6 +83,7 @@ export async function syncBacklinksForPage(
 
   await withFileLock(BACKLINK_INDEX_LOCK, async () => {
     const idx = await getBacklinkIndex();
+    if (!idx) return; // No index yet → daily rebuild seeds it; don't fabricate one.
     let changed = false;
 
     for (const target of added) {
@@ -111,6 +116,7 @@ export async function syncBacklinksForPage(
 export async function removeBacklinksForSlug(slug: string): Promise<void> {
   await withFileLock(BACKLINK_INDEX_LOCK, async () => {
     const idx = await getBacklinkIndex();
+    if (!idx) return; // No index yet → daily rebuild seeds it; don't fabricate one.
     let changed = false;
 
     if (slug in idx) {

--- a/src/lib/contributors.ts
+++ b/src/lib/contributors.ts
@@ -303,16 +303,22 @@ export async function listContributors(
   principal: Principal | null = null,
 ): Promise<ContributorProfile[]> {
   // Fast path: build profiles from the precomputed contributor index (O(1) read)
-  // instead of re-scanning every page's revisions + every talk thread. Falls back
-  // to the full scan below when the index is absent — behavior-preserving.
-  try {
-    const { getContributorIndex, profilesFromIndex } = await import(
-      "./contributor-index"
-    );
-    const idx = await getContributorIndex();
-    if (idx) return profilesFromIndex(idx);
-  } catch {
-    // Fall through to the live scan — the index is purely an accelerator.
+  // instead of re-scanning every page's revisions + every talk thread. The index
+  // is built from `computeScanData(null)` (ANONYMOUS visibility), so it is only
+  // valid for an anonymous viewer. A non-null principal can see its own private
+  // pages, so it MUST use the per-principal scan below to match the fallback;
+  // taking the anonymous fast path would under-count the viewer's activity.
+  // Falls back to the full scan when the index is absent — behavior-preserving.
+  if (principal == null) {
+    try {
+      const { getContributorIndex, profilesFromIndex } = await import(
+        "./contributor-index"
+      );
+      const idx = await getContributorIndex();
+      if (idx) return profilesFromIndex(idx);
+    } catch {
+      // Fall through to the live scan — the index is purely an accelerator.
+    }
   }
 
   const data = await computeScanData(principal);

--- a/src/lib/discuss-stats-index.ts
+++ b/src/lib/discuss-stats-index.ts
@@ -7,7 +7,8 @@
  * bypass the page lifecycle op), and rebuilt daily as self-heal.
  *
  * Behavior-preserving: the read site falls back to the live directory scan
- * whenever the index is empty/missing.
+ * whenever the index is ABSENT (reader returns `null`). An empty-but-present
+ * index (`{}`) is a valid seeded state.
  */
 
 import { getStorage } from "./storage";
@@ -32,17 +33,19 @@ export interface DiscussStat {
 export type DiscussStatsIndex = Record<string, DiscussStat>;
 
 /**
- * Read the full discuss-stats index (empty object when absent). Fail-soft: a
- * missing or corrupt index returns `{}` so the read site falls back to the live
- * directory scan.
+ * Read the full discuss-stats index, or `null` when absent/corrupt. Returns
+ * `null` (not an empty object) so callers can distinguish "no index → fall back
+ * to the live directory scan" from "index present but empty → genuinely no
+ * discussions". Fail-soft: a missing or corrupt index returns `null`.
  */
-export async function getDiscussStatsIndex(): Promise<DiscussStatsIndex> {
+export async function getDiscussStatsIndex(): Promise<DiscussStatsIndex | null> {
   try {
     const idx = await getStorage().getIndex<DiscussStatsIndex>(DISCUSS_STATS_KEY);
-    return idx && typeof idx === "object" ? idx : {};
+    if (!idx || typeof idx !== "object") return null;
+    return idx;
   } catch (err) {
-    logger.warn("discuss-stats", "discuss-stats index unreadable; treating as empty:", err);
-    return {};
+    logger.warn("discuss-stats", "discuss-stats index unreadable; treating as absent:", err);
+    return null;
   }
 }
 
@@ -70,6 +73,7 @@ export async function syncDiscussStatsForSlug(
   const stat = statsFromThreads(threads);
   await withFileLock(DISCUSS_STATS_LOCK, async () => {
     const idx = await getDiscussStatsIndex();
+    if (!idx) return; // No index yet → daily rebuild seeds it; don't fabricate one.
     const cur = idx[slug];
     if (cur && cur.total === stat.total && cur.open === stat.open) return;
     idx[slug] = stat;
@@ -81,6 +85,7 @@ export async function syncDiscussStatsForSlug(
 export async function removeDiscussStatsForSlug(slug: string): Promise<void> {
   await withFileLock(DISCUSS_STATS_LOCK, async () => {
     const idx = await getDiscussStatsIndex();
+    if (!idx) return; // No index yet → daily rebuild seeds it; don't fabricate one.
     if (!(slug in idx)) return;
     delete idx[slug];
     await putDiscussStatsIndex(idx);

--- a/src/lib/owner-index.ts
+++ b/src/lib/owner-index.ts
@@ -8,7 +8,8 @@
  * path and rebuilt daily as self-heal.
  *
  * Behavior-preserving: the read site falls back to the live scan whenever the
- * index is empty/missing, so the index is purely an accelerator.
+ * index is ABSENT (reader returns `null`), so the index is purely an
+ * accelerator. An empty-but-present index (`{}`) is a valid seeded state.
  */
 
 import { getStorage } from "./storage";
@@ -29,17 +30,19 @@ const OWNER_INDEX_LOCK = "owner-slugs-index";
 export type OwnerIndex = Record<string, string[]>;
 
 /**
- * Read the full owner index (empty object when absent). Fail-soft: a missing or
- * corrupt index returns `{}` so the read site falls back to the live scan
- * rather than crashing a page render.
+ * Read the full owner index, or `null` when absent/corrupt. Returns `null` (not
+ * an empty object) so callers can distinguish "no index → fall back to the live
+ * scan" from "index present but empty → genuinely no owned pages". Fail-soft: a
+ * missing or corrupt index returns `null` rather than crashing a page render.
  */
-export async function getOwnerIndex(): Promise<OwnerIndex> {
+export async function getOwnerIndex(): Promise<OwnerIndex | null> {
   try {
     const idx = await getStorage().getIndex<OwnerIndex>(OWNER_INDEX_KEY);
-    return idx && typeof idx === "object" ? idx : {};
+    if (!idx || typeof idx !== "object") return null;
+    return idx;
   } catch (err) {
-    logger.warn("owner-index", "owner index unreadable; treating as empty:", err);
-    return {};
+    logger.warn("owner-index", "owner index unreadable; treating as absent:", err);
+    return null;
   }
 }
 
@@ -71,6 +74,7 @@ export async function syncOwnerIndexForPage(
   const wanted = tenantsForPage(owner, contributors);
   await withFileLock(OWNER_INDEX_LOCK, async () => {
     const idx = await getOwnerIndex();
+    if (!idx) return; // No index yet → daily rebuild seeds it; don't fabricate one.
     let changed = false;
 
     // Add to every wanted bucket.
@@ -103,6 +107,7 @@ export async function syncOwnerIndexForPage(
 export async function removeOwnerIndexForSlug(slug: string): Promise<void> {
   await withFileLock(OWNER_INDEX_LOCK, async () => {
     const idx = await getOwnerIndex();
+    if (!idx) return; // No index yet → daily rebuild seeds it; don't fabricate one.
     let changed = false;
     for (const tenant of Object.keys(idx)) {
       const bucket = idx[tenant];

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -156,9 +156,10 @@ export async function findBacklinks(
     // Fast path: the precomputed reverse-link index gives the source slugs that
     // link TO targetSlug in O(1). We then intersect with the readable set (the
     // SAME filter the scan applies) and resolve titles from it. Falls back to
-    // the O(pages²) scan below when the index is empty/missing.
+    // the O(pages²) scan below only when the index is ABSENT (reader → null);
+    // an empty-but-present index is authoritative.
     const backlinkIdx = await getBacklinkIndex();
-    if (Object.keys(backlinkIdx).length > 0) {
+    if (backlinkIdx !== null) {
       const sources = backlinkIdx[targetSlug];
       if (!sources || sources.length === 0) return [];
       const readable = new Map(pages.map((p) => [p.slug, p.title]));
@@ -575,10 +576,10 @@ export async function slugsForOwner(handle: string): Promise<string[]> {
   const wantTenant = tenantForOwner(handle);
 
   // Fast path: read the precomputed owner→slugs index (O(1)). Falls through to
-  // the live frontmatter scan below when the index is empty/missing — keeps
-  // this behavior-preserving and safe to roll out.
+  // the live frontmatter scan below only when the index is ABSENT (reader →
+  // null); an empty-but-present index is authoritative. Behavior-preserving.
   const ownerIdx = await getOwnerIndex();
-  if (Object.keys(ownerIdx).length > 0) {
+  if (ownerIdx !== null) {
     return ownerIdx[wantTenant] ?? [];
   }
 

--- a/src/lib/talk.ts
+++ b/src/lib/talk.ts
@@ -307,12 +307,12 @@ export async function getDiscussionStatsForSlugs(
   }
 
   // Fast path: project the requested slugs out of the precomputed discuss-stats
-  // index (O(1)). Falls through to the directory scan below when the index is
-  // empty/missing — keeps this behavior-preserving and safe to roll out.
+  // index (O(1)). Falls through to the directory scan below only when the index
+  // is ABSENT (reader → null); an empty-but-present index is authoritative.
   try {
     const { getDiscussStatsIndex } = await import("./discuss-stats-index");
     const idx = await getDiscussStatsIndex();
-    if (Object.keys(idx).length > 0) {
+    if (idx !== null) {
       for (const slug of slugs) {
         const stat = idx[slug];
         if (stat) result.set(slug, { total: stat.total, open: stat.open });


### PR DESCRIPTION
Post-merge review of #393 (two reviewers, full diff) surfaced real issues. Fixes:

- **CRITICAL — partial-index corruption (live):** `owner`/`backlink`/`discuss-stats` indexes self-seeded from a single write, so on the empty rollout the first write created a 1-entry index and the read fast-path served results from only that page until the daily rebuild. Now they match the contributor index: reader returns `null` when the key is **absent**, incremental `sync`/`remove` **no-op until a rebuild seeds it**, and read sites (`findBacklinks`, `slugsForOwner`, `getDiscussionStatsForSlugs`) branch on `!== null` and otherwise use the scan fallback. Safe regardless of seeding.
- **listContributors parity:** anonymous index fast-path only when `principal == null`; signed-in callers scan (private contributions still counted).
- **ArticleActions owner-gating:** resolve the viewer handle like server `resolveHandle` (X external-account fallback) + case-insensitive compare — Twitter-SSO owners keep Delete/Reingest on their own page.
- **Reverted the `getPrincipal` session-claim optimization** — it risked returning a handle that disagrees with `resolveHandle`'s X-handle fallback, silently misattributing writes.
- **Canonical:** `/u/<tenant>/<slug>` public pages now set canonical/OG to `/wiki/<slug>`.

Security boundary unchanged (private pages still 404 at `/wiki`, backlinks re-filter on read, vault API session-scoped — both reviewers confirmed).

`pnpm build` clean; `pnpm test` 97 files / **2617** passing (added no-op-until-seeded + principal-parity tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)