### PR TITLE
Index the homepage Trail (_idx:recent) — close the home perf gap

### DIFF
--- a/src/lib/__tests__/recent-index.test.ts
+++ b/src/lib/__tests__/recent-index.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  getRecentIndex,
+  pushRecentEvent,
+  removeRecentForSlug,
+} from "../recent-index";
+import { getTrail, type TrailEvent } from "../trail";
+import { getStorage, _resetStorage } from "../storage";
+import { _resetLocks } from "../lock";
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "recent-index-test-"));
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetLocks();
+  _resetStorage();
+});
+
+afterEach(async () => {
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function ev(over: Partial<TrailEvent> = {}): TrailEvent {
+  return {
+    ts: 1000,
+    when: "2026-06-06T00:00:00.000Z",
+    actor: "alice",
+    isAgent: false,
+    action: "edited",
+    slug: "page-a",
+    title: "Page A",
+    tenant: "alice",
+    ...over,
+  };
+}
+
+/** Seed an empty-but-present index so incremental hooks apply (not no-op). */
+async function seedEmpty() {
+  await getStorage().putIndex("recent", []);
+}
+
+describe("recent-index", () => {
+  it("getRecentIndex returns null when the key is absent (not seeded)", async () => {
+    expect(await getRecentIndex()).toBeNull();
+  });
+
+  it("pushRecentEvent NO-OPS until the index is seeded", async () => {
+    await pushRecentEvent(ev());
+    // Still absent — a single write must not fabricate a partial recent list.
+    expect(await getRecentIndex()).toBeNull();
+  });
+
+  it("removeRecentForSlug no-ops until seeded", async () => {
+    await removeRecentForSlug("page-a");
+    expect(await getRecentIndex()).toBeNull();
+  });
+
+  it("after seeding, push prepends newest-first and dedups", async () => {
+    await seedEmpty();
+    expect(await getRecentIndex()).toEqual([]);
+
+    await pushRecentEvent(ev({ ts: 1000, slug: "page-a" }));
+    await pushRecentEvent(ev({ ts: 2000, slug: "page-b", title: "Page B" }));
+    const idx = await getRecentIndex();
+    expect(idx?.map((e) => e.slug)).toEqual(["page-b", "page-a"]); // newest first
+
+    // Near-duplicate (same slug+actor+action within the window) collapses.
+    await pushRecentEvent(ev({ ts: 2050, slug: "page-b", title: "Page B" }));
+    const idx2 = await getRecentIndex();
+    expect(idx2?.filter((e) => e.slug === "page-b")).toHaveLength(1);
+  });
+
+  it("removeRecentForSlug drops all events for a slug", async () => {
+    await seedEmpty();
+    await pushRecentEvent(ev({ ts: 1000, slug: "page-a" }));
+    await pushRecentEvent(ev({ ts: 2000, slug: "page-b" }));
+    await removeRecentForSlug("page-a");
+    const idx = await getRecentIndex();
+    expect(idx?.map((e) => e.slug)).toEqual(["page-b"]);
+  });
+
+  it("getTrail serves the index for anonymous reads, capped to limit", async () => {
+    await seedEmpty();
+    await pushRecentEvent(ev({ ts: 1000, slug: "page-a" }));
+    await pushRecentEvent(ev({ ts: 2000, slug: "page-b" }));
+    await pushRecentEvent(ev({ ts: 3000, slug: "page-c" }));
+    const trail = await getTrail(2, null);
+    expect(trail.map((e) => e.slug)).toEqual(["page-c", "page-b"]);
+  });
+
+  it("getTrail falls back to the scan when the index is unseeded", async () => {
+    // No index seeded → getTrail scans; an empty wiki yields no events (and
+    // crucially does not throw).
+    const trail = await getTrail(10, null);
+    expect(Array.isArray(trail)).toBe(true);
+    expect(trail).toEqual([]);
+  });
+});

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -26,6 +26,8 @@ import { syncCommonsForPage, removeCommonsEntryBySlug, belongsInCommons } from "
 import { syncOwnerIndexForPage, removeOwnerIndexForSlug } from "./owner-index";
 import { syncBacklinksForPage, removeBacklinksForSlug } from "./backlink-index";
 import { recordEditForAuthor } from "./contributor-index";
+import { pushRecentEvent, removeRecentForSlug } from "./recent-index";
+import { isAgentHandle } from "./agents";
 import { addVaultRef } from "./vault";
 import { parseFrontmatter } from "./frontmatter";
 import type { LogOperation } from "./wiki";
@@ -427,6 +429,38 @@ async function runPageLifecycleOp(
     }
   } catch (err) {
     logger.warn("contributor-index", `contributor index sync skipped for "${slug}":`, err);
+  }
+
+  // 3b-v. Recent-activity index (the homepage Trail). PUBLIC, non-agent pages
+  //        only — the public trail never surfaces private activity. No-op until
+  //        the daily rebuild has seeded the index. Fail-soft.
+  try {
+    if (op.kind === "delete") {
+      await removeRecentForSlug(slug);
+    } else if (op.author) {
+      const fm = parseFrontmatter(op.content).data;
+      const isCommons = belongsInCommons({
+        visibility: typeof fm.visibility === "string" ? fm.visibility : undefined,
+        type: typeof fm.type === "string" ? fm.type : undefined,
+      });
+      if (isCommons) {
+        const now = Date.now();
+        await pushRecentEvent({
+          ts: now,
+          when: new Date(now).toISOString(),
+          actor: op.author,
+          isAgent: isAgentHandle(op.author),
+          action: logOp === "ingest" ? "ingested" : "edited",
+          slug,
+          title: op.title,
+          tenant: tenantForOwner(
+            typeof fm.owner === "string" ? fm.owner : undefined,
+          ),
+        });
+      }
+    }
+  } catch (err) {
+    logger.warn("recent-index", `recent index sync skipped for "${slug}":`, err);
   }
 
   // 3c. Mirror the page into its per-tenant silo — a live, self-contained vault

--- a/src/lib/maintenance.ts
+++ b/src/lib/maintenance.ts
@@ -181,14 +181,14 @@ export async function scanForMaintenance(
 // Precomputed-index self-heal (Phase 2)
 // ---------------------------------------------------------------------------
 //
-// The four derived KV indexes (owner-slugs, backlinks, discuss-stats,
+// The five derived KV indexes (owner-slugs, backlinks, discuss-stats,
 // contributors) are maintained incrementally on the write/talk paths. Drift can
 // still creep in (a failed fail-soft update, an out-of-band edit, the coarse
-// contributor fields left to rebuild). This rebuilds all four from ground truth
+// contributor fields left to rebuild). This rebuilds all five from ground truth
 // in one daily pass so any drift self-corrects. Fully fail-soft — each rebuild
 // is independent and a failure never aborts the others or the maintenance scan.
 
-/** Rebuild all four precomputed indexes. Returns a per-index ok/error summary. */
+/** Rebuild all five precomputed indexes. Returns a per-index ok/error summary. */
 export async function rebuildDerivedIndexes(): Promise<
   Record<string, { ok: boolean; error?: string }>
 > {
@@ -198,6 +198,7 @@ export async function rebuildDerivedIndexes(): Promise<
     ["backlinks", async () => (await import("./backlink-index")).rebuildBacklinkIndex()],
     ["discuss-stats", async () => (await import("./discuss-stats-index")).rebuildDiscussStatsIndex()],
     ["contributors", async () => (await import("./contributor-index")).rebuildContributorIndex()],
+    ["recent", async () => (await import("./recent-index")).rebuildRecentIndex()],
   ];
   for (const [name, run] of steps) {
     try {

--- a/src/lib/recent-index.ts
+++ b/src/lib/recent-index.ts
@@ -1,0 +1,87 @@
+/**
+ * `_idx:recent` — a precomputed list of the most recent public activity events
+ * (the homepage Trail). Replaces `getTrail`'s O(pages) scan with one KV read.
+ *
+ * Mirrors the other derived indexes (see `commons.ts`): fail-soft reader that
+ * returns `null` when the key is ABSENT (so reads fall back to the scan), an
+ * incremental push that NO-OPS until a rebuild seeds it (never fabricate a
+ * partial recent list from a single write), and a `rebuildRecentIndex()` that
+ * reconstructs the list from the authoritative {@link scanTrail}. Visibility is
+ * baked in by building from public pages only — `getTrail` serves this to
+ * anonymous readers, and signed-in readers scan instead.
+ */
+import { getStorage } from "./storage";
+import { withFileLock } from "./lock";
+import { logger } from "./logger";
+import { scanTrail, type TrailEvent } from "./trail";
+
+const RECENT_KEY = "recent";
+const RECENT_LOCK = "recent-index";
+/** How many events to retain — comfortably over-fills the ~10-12 the UI shows. */
+const MAX_RECENT = 60;
+/** Collapse near-duplicate events (same actor+action+page within ~2 min). */
+const DEDUP_WINDOW_MS = 120_000;
+
+/**
+ * The recent-activity list, newest-first — or `null` when the index has never
+ * been seeded (caller should fall back to {@link scanTrail}). Distinguishing
+ * "absent" (`null`) from "seeded but empty" (`[]`) is what prevents a single
+ * write from seeding a misleading partial list.
+ */
+export async function getRecentIndex(): Promise<TrailEvent[] | null> {
+  try {
+    const idx = await getStorage().getIndex<TrailEvent[]>(RECENT_KEY);
+    if (!Array.isArray(idx)) return null;
+    return idx;
+  } catch (err) {
+    logger.warn("recent-index", "read failed; falling back to scan", err);
+    return null;
+  }
+}
+
+async function putRecentIndex(events: TrailEvent[]): Promise<void> {
+  await getStorage().putIndex(RECENT_KEY, events.slice(0, MAX_RECENT));
+}
+
+/**
+ * Push a new activity event to the front. NO-OP until the index is seeded (the
+ * daily rebuild seeds it) — we never fabricate a partial recent list from one
+ * write, which would hide all prior activity until the next rebuild.
+ */
+export async function pushRecentEvent(event: TrailEvent): Promise<void> {
+  await withFileLock(RECENT_LOCK, async () => {
+    const idx = await getRecentIndex();
+    if (idx === null) return; // not seeded yet — daily rebuild will seed it
+    const deduped = idx.filter(
+      (d) =>
+        !(
+          d.slug === event.slug &&
+          d.actor === event.actor &&
+          d.action === event.action &&
+          Math.abs(d.ts - event.ts) < DEDUP_WINDOW_MS
+        ),
+    );
+    deduped.unshift(event);
+    deduped.sort((a, b) => b.ts - a.ts);
+    await putRecentIndex(deduped);
+  });
+}
+
+/** Drop every event for a slug (page deleted). No-op until seeded. */
+export async function removeRecentForSlug(slug: string): Promise<void> {
+  await withFileLock(RECENT_LOCK, async () => {
+    const idx = await getRecentIndex();
+    if (idx === null) return;
+    const next = idx.filter((e) => e.slug !== slug);
+    if (next.length !== idx.length) await putRecentIndex(next);
+  });
+}
+
+/** Reconstruct the recent list from the authoritative scan (daily self-heal). */
+export async function rebuildRecentIndex(): Promise<number> {
+  const events = await scanTrail(MAX_RECENT, null);
+  await withFileLock(RECENT_LOCK, async () => {
+    await putRecentIndex(events);
+  });
+  return Math.min(events.length, MAX_RECENT);
+}

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -32,12 +32,34 @@ export interface TrailEvent {
 const MAX_PAGES_SCANNED = 30;
 
 /**
+ * The public activity trail. For anonymous reads (`principal == null` — the
+ * homepage path) it serves the precomputed `_idx:recent` index in O(1), falling
+ * back to {@link scanTrail} when the index isn't seeded yet. A signed-in caller
+ * always scans, so its own private-page activity is included (the index is
+ * built public-only — same anonymous-vs-scan split as the contributor index).
+ */
+export async function getTrail(
+  limit = 12,
+  principal: Principal | null = null,
+): Promise<TrailEvent[]> {
+  if (!principal) {
+    const { getRecentIndex } = await import("./recent-index");
+    const idx = await getRecentIndex();
+    if (idx !== null) return idx.slice(0, limit);
+  }
+  return scanTrail(limit, principal);
+}
+
+/**
  * Build the activity trail by merging recent ingests (from each page's
  * `sources[]` provenance) and edits (from revision metadata) into one
  * time-sorted feed. Agent-scoped pages are excluded; agent *actors* are kept
  * and flagged via {@link isAgentHandle} so the UI can mark them distinctly.
+ *
+ * This is the O(pages) scan — the fallback and the source for the `_idx:recent`
+ * rebuild. {@link getTrail} serves the index for anonymous reads.
  */
-export async function getTrail(
+export async function scanTrail(
   limit = 12,
   principal: Principal | null = null,
 ): Promise<TrailEvent[]> {


### PR DESCRIPTION
After seeding the Phase-2 indexes, contributors dropped to ~0.14s but the **home stayed ~3.8s** because `getTrail` still scanned ~30 pages' content + revisions on every load — Phase 2 didn't index it. This adds the missing recent-activity index.

- **`src/lib/recent-index.ts`** (`_idx:recent`): newest-first `TrailEvent[]`, following the now-hardened index pattern — reader returns `null` when **absent**, `pushRecentEvent`/`removeRecentForSlug` **no-op until a rebuild seeds it**, daily `rebuildRecentIndex()` reconstructs from `scanTrail` (public, non-agent only).
- **`trail.ts`**: split the O(pages) scan into `scanTrail()`; `getTrail()` serves the index for **anonymous** reads (the homepage path) in O(1), falling back to `scanTrail` when unseeded. Signed-in callers always scan (their own private activity included) — same anonymous-vs-scan split as the contributor index.
- **`lifecycle.ts`**: push a recent event on each public-page write (commons only), remove on delete. Fail-soft.
- **`maintenance.ts`**: `rebuildRecentIndex` wired into the daily rebuild.

Expected: uncached anonymous home drops from ~3.8s toward ~0.2s once seeded.

`pnpm build` clean; `pnpm test` 98 files / **2624** passing (added `recent-index` suite: no-op-until-seeded, push/dedup/remove, getTrail fast-path + fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)