### PR TITLE
Index page metadata (_idx:pages): make listWikiPages O(1) — fixes article+silo

### DIFF
--- a/src/lib/__tests__/page-index.test.ts
+++ b/src/lib/__tests__/page-index.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  getPageIndex,
+  syncPageIndexForPage,
+  removePageIndexForSlug,
+  rebuildPageIndex,
+} from "../page-index";
+import {
+  listWikiPages,
+  scanWikiPagesUncached,
+  ensureDirectories,
+  writeWikiPage,
+} from "../wiki";
+import { _resetLocks } from "../lock";
+import { _resetStorage } from "../storage";
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "page-index-test-"));
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetLocks();
+  _resetStorage();
+});
+
+afterEach(async () => {
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+/** Create a page with frontmatter + register it in index.md. */
+async function createPage(slug: string, frontmatter: string, title = slug) {
+  await ensureDirectories();
+  await writeWikiPage(slug, `---\n${frontmatter}\n---\n\n# ${title}\n\nBody.`);
+  const indexPath = path.join(process.env.WIKI_DIR!, "index.md");
+  let existing = "";
+  try {
+    existing = await fs.readFile(indexPath, "utf-8");
+  } catch {
+    /* none */
+  }
+  const line = `- [${title}](${slug}.md) — ${title} summary`;
+  await fs.writeFile(
+    indexPath,
+    existing ? `${existing.trimEnd()}\n${line}\n` : `# Wiki Index\n\n${line}\n`,
+    "utf-8",
+  );
+}
+
+describe("page-index", () => {
+  it("getPageIndex returns null when the key is absent (not seeded)", async () => {
+    await createPage("a", "owner: alice\ntags: [x]");
+    expect(await getPageIndex()).toBeNull();
+  });
+
+  it("syncPageIndexForPage / remove NO-OP until the index is seeded", async () => {
+    await createPage("a", "owner: alice");
+    await syncPageIndexForPage({ slug: "a", title: "A", summary: "s", owner: "alice" });
+    await removePageIndexForSlug("a");
+    expect(await getPageIndex()).toBeNull();
+  });
+
+  it("listWikiPages fast-path (seeded) equals the per-page scan", async () => {
+    await createPage("a", "owner: alice\ntags: [ml, ai]\ntype: note", "Alpha");
+    await createPage("b", "owner: bob\nvisibility: private\nconfidence: 0.5", "Beta");
+
+    const scan = await scanWikiPagesUncached();
+    await rebuildPageIndex();
+    expect(await getPageIndex()).not.toBeNull();
+
+    const fast = await listWikiPages();
+    // Same entries (order by index.md), same enriched fields.
+    expect(fast).toEqual(scan);
+    // Spot-check enrichment came through the index, not just base fields.
+    const beta = fast.find((e) => e.slug === "b");
+    expect(beta?.visibility).toBe("private");
+    expect(beta?.owner).toBe("bob");
+    expect(beta?.confidence).toBe(0.5);
+  });
+
+  it("falls back to the scan when the index is unseeded (identical result)", async () => {
+    await createPage("a", "owner: alice\ntags: [x]", "Alpha");
+    // No rebuild → index absent → listWikiPages must equal the scan.
+    expect(await getPageIndex()).toBeNull();
+    expect(await listWikiPages()).toEqual(await scanWikiPagesUncached());
+  });
+
+  it("after seeding, sync upserts and remove drops an entry", async () => {
+    await createPage("a", "owner: alice", "Alpha");
+    await rebuildPageIndex();
+
+    await syncPageIndexForPage({ slug: "a", title: "Alpha", summary: "s", owner: "carol" });
+    expect((await getPageIndex())?.["a"]?.owner).toBe("carol");
+
+    await removePageIndexForSlug("a");
+    expect((await getPageIndex())?.["a"]).toBeUndefined();
+  });
+});

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -14,7 +14,9 @@ import {
   appendToLog,
   wikiRelPath,
   tenantForOwner,
+  enrichEntry,
 } from "./wiki";
+import { syncPageIndexForPage, removePageIndexForSlug } from "./page-index";
 import { syncSiloForPage, removeSiloForPage } from "./silo";
 import { getStorage } from "./storage";
 import { withFileLock } from "./lock";
@@ -461,6 +463,23 @@ async function runPageLifecycleOp(
     }
   } catch (err) {
     logger.warn("recent-index", `recent index sync skipped for "${slug}":`, err);
+  }
+
+  // 3b-vi. Page-metadata index (_idx:pages) — the enriched IndexEntry per slug,
+  //         so listWikiPages enriches with one KV read instead of reading every
+  //         page file. Holds ALL pages (visibility filtering is on the read side).
+  //         No-op until the daily rebuild has seeded it. Fail-soft.
+  try {
+    if (op.kind === "delete") {
+      await removePageIndexForSlug(slug);
+    } else {
+      const fm = parseFrontmatter(op.content).data;
+      await syncPageIndexForPage(
+        enrichEntry({ title: op.title, slug, summary: op.summary }, fm),
+      );
+    }
+  } catch (err) {
+    logger.warn("page-index", `page index sync skipped for "${slug}":`, err);
   }
 
   // 3c. Mirror the page into its per-tenant silo — a live, self-contained vault

--- a/src/lib/maintenance.ts
+++ b/src/lib/maintenance.ts
@@ -194,6 +194,9 @@ export async function rebuildDerivedIndexes(): Promise<
 > {
   const results: Record<string, { ok: boolean; error?: string }> = {};
   const steps: Array<[string, () => Promise<unknown>]> = [
+    // Pages first: listWikiPages' fast path reads this, so the rebuilds below
+    // (which list pages) benefit immediately once it's fresh.
+    ["pages", async () => (await import("./page-index")).rebuildPageIndex()],
     ["owner-slugs", async () => (await import("./owner-index")).rebuildOwnerIndex()],
     ["backlinks", async () => (await import("./backlink-index")).rebuildBacklinkIndex()],
     ["discuss-stats", async () => (await import("./discuss-stats-index")).rebuildDiscussStatsIndex()],

--- a/src/lib/page-index.ts
+++ b/src/lib/page-index.ts
@@ -1,0 +1,71 @@
+/**
+ * `_idx:pages` — a precomputed map of every page's enriched {@link IndexEntry}
+ * metadata (tags / owner / type / visibility / updated / sourceCount / …). It
+ * lets {@link listWikiPages} enrich entries with ONE KV read instead of reading
+ * every page file (the O(pages) loop that dominated the article + silo pages).
+ *
+ * Same hardened pattern as the other derived indexes (`commons.ts`): fail-soft
+ * reader that returns `null` when the key is ABSENT (callers fall back to the
+ * per-page scan), incremental sync that NO-OPS until a rebuild seeds it (never
+ * fabricate a partial map from one write), and a `rebuildPageIndex()` that
+ * reconstructs from the authoritative {@link scanWikiPagesUncached}.
+ *
+ * This index holds ALL pages (public, private, agent-scoped) — it's the raw
+ * metadata layer; visibility filtering happens in `listReadableWikiPages`.
+ */
+import { getStorage } from "./storage";
+import { withFileLock } from "./lock";
+import { logger } from "./logger";
+import type { IndexEntry } from "./types";
+
+const PAGE_INDEX_KEY = "pages";
+const PAGE_INDEX_LOCK = "page-index";
+
+export type PageMetaIndex = Record<string, IndexEntry>;
+
+/** The metadata map, or `null` when the index has never been seeded (caller
+ *  should fall back to {@link scanWikiPagesUncached}). */
+export async function getPageIndex(): Promise<PageMetaIndex | null> {
+  try {
+    const idx = await getStorage().getIndex<PageMetaIndex>(PAGE_INDEX_KEY);
+    if (!idx || typeof idx !== "object") return null;
+    return idx;
+  } catch (err) {
+    logger.warn("page-index", "read failed; falling back to scan", err);
+    return null;
+  }
+}
+
+/** Upsert one page's enriched entry. NO-OP until the index is seeded. */
+export async function syncPageIndexForPage(entry: IndexEntry): Promise<void> {
+  await withFileLock(PAGE_INDEX_LOCK, async () => {
+    const idx = await getPageIndex();
+    if (idx === null) return; // not seeded — daily rebuild will seed it
+    idx[entry.slug] = entry;
+    await getStorage().putIndex(PAGE_INDEX_KEY, idx);
+  });
+}
+
+/** Drop one page's entry (page deleted). NO-OP until seeded. */
+export async function removePageIndexForSlug(slug: string): Promise<void> {
+  await withFileLock(PAGE_INDEX_LOCK, async () => {
+    const idx = await getPageIndex();
+    if (idx === null) return;
+    if (slug in idx) {
+      delete idx[slug];
+      await getStorage().putIndex(PAGE_INDEX_KEY, idx);
+    }
+  });
+}
+
+/** Rebuild the whole map from the authoritative per-page scan (daily self-heal). */
+export async function rebuildPageIndex(): Promise<number> {
+  const { scanWikiPagesUncached } = await import("./wiki");
+  const all = await scanWikiPagesUncached();
+  const map: PageMetaIndex = {};
+  for (const entry of all) map[entry.slug] = entry;
+  await withFileLock(PAGE_INDEX_LOCK, async () => {
+    await getStorage().putIndex(PAGE_INDEX_KEY, map);
+  });
+  return all.length;
+}

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -365,14 +365,75 @@ export async function writeWikiPage(
 // Index management
 // ---------------------------------------------------------------------------
 
-/**
- * Parse `wiki/index.md` and return its entries.
- * Returns an empty array when the file doesn't exist.
- *
- * Expected format per line:
- *   - [Title](slug.md) — summary
- */
-export async function listWikiPages(): Promise<IndexEntry[]> {
+/** Build an enriched {@link IndexEntry} from a base (title/slug/summary) + the
+ *  page's frontmatter. The single source of the enrichment rules — used by the
+ *  per-page scan AND the `_idx:pages` rebuild so they can't drift. */
+export function enrichEntry(
+  base: IndexEntry,
+  fm: Frontmatter,
+): IndexEntry {
+  const tags = Array.isArray(fm.tags)
+    ? fm.tags.filter((t): t is string => typeof t === "string" && t.length > 0)
+    : undefined;
+
+  const updated =
+    typeof fm.updated === "string" && fm.updated.length > 0 ? fm.updated : undefined;
+
+  // source_count may be a number (new behavior) or a string (legacy).
+  const sourceCountRaw = fm.source_count;
+  const sourceCountNum =
+    typeof sourceCountRaw === "number"
+      ? sourceCountRaw
+      : typeof sourceCountRaw === "string" && sourceCountRaw.length > 0
+        ? Number.parseInt(sourceCountRaw, 10)
+        : NaN;
+  const sourceCount =
+    Number.isFinite(sourceCountNum) && sourceCountNum >= 0 ? sourceCountNum : undefined;
+
+  const sourceUrl =
+    typeof fm.source_url === "string" && fm.source_url.length > 0
+      ? fm.source_url
+      : undefined;
+
+  const owner =
+    typeof fm.owner === "string" && fm.owner.length > 0 ? fm.owner : undefined;
+
+  const pageType =
+    typeof fm.type === "string" && fm.type.length > 0 ? fm.type : undefined;
+
+  // Only "private" is meaningful for read-gating; everything else is public.
+  const visibility =
+    typeof fm.visibility === "string" && fm.visibility === "private"
+      ? "private"
+      : undefined;
+
+  const confidenceRaw = fm.confidence;
+  const confidenceNum =
+    typeof confidenceRaw === "number"
+      ? confidenceRaw
+      : typeof confidenceRaw === "string" && confidenceRaw.length > 0
+        ? Number.parseFloat(confidenceRaw)
+        : NaN;
+  const confidence =
+    Number.isFinite(confidenceNum) && confidenceNum >= 0 && confidenceNum <= 1
+      ? confidenceNum
+      : undefined;
+
+  return {
+    ...base,
+    ...(tags && tags.length > 0 ? { tags } : {}),
+    ...(updated ? { updated } : {}),
+    ...(sourceCount !== undefined ? { sourceCount } : {}),
+    ...(sourceUrl ? { sourceUrl } : {}),
+    ...(confidence !== undefined ? { confidence } : {}),
+    ...(owner ? { owner } : {}),
+    ...(pageType ? { type: pageType } : {}),
+    ...(visibility ? { visibility } : {}),
+  };
+}
+
+/** Parse the ordered base entries (title/slug/summary) from `wiki/index.md`. */
+async function readIndexBaseEntries(): Promise<IndexEntry[]> {
   const storagePath = wikiRelPath("index.md");
   let raw: string;
   try {
@@ -383,95 +444,29 @@ export async function listWikiPages(): Promise<IndexEntry[]> {
     }
     return [];
   }
-
   const baseEntries: IndexEntry[] = [];
   const lineRe = /^-\s+\[(.+?)]\((.+?)\.md\)\s*—\s*(.+)$/;
-
   for (const line of raw.split("\n")) {
     const m = line.match(lineRe);
-    if (m) {
-      baseEntries.push({ title: m[1], slug: m[2], summary: m[3].trim() });
-    }
+    if (m) baseEntries.push({ title: m[1], slug: m[2], summary: m[3].trim() });
   }
+  return baseEntries;
+}
 
-  // Enrich every entry in parallel with frontmatter-derived metadata
-  // (tags / updated / source_count). If any individual page fails to
-  // parse, we log a warning and fall back to the plain entry so that
-  // one malformed page never breaks the whole index.
-  const enriched = await Promise.all(
+/**
+ * The O(pages) scan: read `index.md` then EACH page's frontmatter to enrich.
+ * The fallback for {@link listWikiPages} and the source for the `_idx:pages`
+ * rebuild. A page that fails to parse falls back to its plain index entry so one
+ * malformed page never breaks the whole list.
+ */
+export async function scanWikiPagesUncached(): Promise<IndexEntry[]> {
+  const baseEntries = await readIndexBaseEntries();
+  return Promise.all(
     baseEntries.map(async (entry): Promise<IndexEntry> => {
       try {
         const page = await readWikiPageWithFrontmatter(entry.slug);
         if (!page) return entry;
-        const fm = page.frontmatter;
-
-        const tags =
-          Array.isArray(fm.tags)
-            ? fm.tags.filter((t): t is string => typeof t === "string" && t.length > 0)
-            : undefined;
-
-        const updated =
-          typeof fm.updated === "string" && fm.updated.length > 0
-            ? fm.updated
-            : undefined;
-
-        // source_count may be a number (new behavior) or a string (legacy); parse defensively.
-        const sourceCountRaw = fm.source_count;
-        const sourceCountNum =
-          typeof sourceCountRaw === "number"
-            ? sourceCountRaw
-            : typeof sourceCountRaw === "string" && sourceCountRaw.length > 0
-              ? Number.parseInt(sourceCountRaw, 10)
-              : NaN;
-        const sourceCount = Number.isFinite(sourceCountNum) && sourceCountNum >= 0
-          ? sourceCountNum
-          : undefined;
-
-        const sourceUrl =
-          typeof fm.source_url === "string" && fm.source_url.length > 0
-            ? fm.source_url
-            : undefined;
-
-        const owner =
-          typeof fm.owner === "string" && fm.owner.length > 0
-            ? fm.owner
-            : undefined;
-
-        const pageType =
-          typeof fm.type === "string" && fm.type.length > 0
-            ? fm.type
-            : undefined;
-
-        // Only "private" is meaningful for read-gating; everything else is public.
-        const visibility =
-          typeof fm.visibility === "string" && fm.visibility === "private"
-            ? "private"
-            : undefined;
-
-        // Parse confidence (0–1 number from frontmatter)
-        const confidenceRaw = fm.confidence;
-        const confidenceNum =
-          typeof confidenceRaw === "number"
-            ? confidenceRaw
-            : typeof confidenceRaw === "string" && confidenceRaw.length > 0
-              ? Number.parseFloat(confidenceRaw)
-              : NaN;
-        const confidence =
-          Number.isFinite(confidenceNum) && confidenceNum >= 0 && confidenceNum <= 1
-            ? confidenceNum
-            : undefined;
-
-        return {
-          ...entry,
-          ...(tags && tags.length > 0 ? { tags } : {}),
-          ...(updated ? { updated } : {}),
-          ...(sourceCount !== undefined ? { sourceCount } : {}),
-          ...(sourceUrl ? { sourceUrl } : {}),
-          ...(confidence !== undefined ? { confidence } : {}),
-          ...(owner ? { owner } : {}),
-          ...(pageType ? { type: pageType } : {}),
-          ...(visibility ? { visibility } : {}),
-        };
+        return enrichEntry(entry, page.frontmatter);
       } catch (err) {
         logger.warn(
           "wiki",
@@ -482,8 +477,31 @@ export async function listWikiPages(): Promise<IndexEntry[]> {
       }
     }),
   );
+}
 
-  return enriched;
+/**
+ * Parse `wiki/index.md` and return its entries with enriched metadata.
+ *
+ * Fast path: read the ordered base from `index.md` (1 read) and enrich from the
+ * `_idx:pages` metadata index (1 KV read) — O(1) instead of reading every page
+ * file. Falls back to the per-page {@link scanWikiPagesUncached} when the index
+ * isn't seeded, so behavior is identical with or without the index.
+ *
+ * Expected `index.md` line format: `- [Title](slug.md) — summary`
+ */
+export async function listWikiPages(): Promise<IndexEntry[]> {
+  const { getPageIndex } = await import("./page-index");
+  const meta = await getPageIndex();
+  if (meta === null) return scanWikiPagesUncached();
+
+  const baseEntries = await readIndexBaseEntries();
+  return baseEntries.map((b) => {
+    const m = meta[b.slug];
+    // index.md stays authoritative for title/summary; the metadata index
+    // supplies the enriched fields. A slug missing from the index (just added,
+    // pre-rebuild) falls back to its plain base entry.
+    return m ? { ...m, title: b.title, slug: b.slug, summary: b.summary } : b;
+  });
 }
 
 /**


### PR DESCRIPTION
The indexes made home/browse/contributors ~0.15s, but **article + silo stayed ~1.6s**. Root cause: `listWikiPages` parses `index.md` (title/slug/summary) then **reads every page file** to enrich (tags/owner/type/visibility/...). That O(pages) loop feeds both the silo (`listReadableWikiPages`) and the article (`buildSlugTenantMap`).

**Framework-agnostic fix** — the same portable `src/lib` + KV index pattern (no Next-specific ISR/caching, so it survives a framework switch):
- **`src/lib/page-index.ts`** (`_idx:pages`): `Record<slug, enriched IndexEntry>`. Reader returns `null` when **absent**; sync **no-ops until a rebuild seeds it**; daily `rebuildPageIndex()` reconstructs from the authoritative scan.
- **`wiki.ts`**: extracted `enrichEntry()` (single source of the enrichment rules) and `scanWikiPagesUncached()` (the per-page scan = fallback + rebuild source). `listWikiPages` now reads `index.md` for order + `_idx:pages` for metadata (**1+1 reads** vs 1+N), falling back to the scan when the index is absent. **Identical output with or without the index** (parity-tested).
- **`lifecycle.ts`**: upsert/remove the page's enriched entry on write/delete (fail-soft). **`maintenance.ts`**: `rebuildPageIndex` runs first in the daily rebuild.

Safe by construction: unseeded → scan fallback; iteration is over `index.md` so a stale index entry can't create phantom pages; the lifecycle sync uses the same `op.summary`/`op.title` as the `index.md` write.

`pnpm build` clean; `pnpm test` 99 files / **2629** passing (added page-index parity + fallback suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)