### PR TITLE
Page-index review follow-ups (observability + sync symmetry)

### DIFF
--- a/src/lib/lint-fix.ts
+++ b/src/lib/lint-fix.ts
@@ -110,6 +110,9 @@ export async function fixStaleIndex(slug: string): Promise<FixResult> {
   }
 
   await updateIndex(filtered);
+  // Keep the page-metadata index in sync (this removes index.md membership
+  // outside the lifecycle op). Harmless if absent — the entry is just dropped.
+  await (await import("./page-index")).removePageIndexForSlug(slug);
   await appendToLog(
     "edit",
     slug,

--- a/src/lib/maintenance.ts
+++ b/src/lib/maintenance.ts
@@ -209,7 +209,9 @@ export async function rebuildDerivedIndexes(): Promise<
       results[name] = { ok: true };
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
-      logger.warn("maintenance", `index rebuild failed for "${name}":`, error);
+      // error-level: a persistent rebuild failure means the read fast-path
+      // serves indefinitely-stale data, so surface it (not just a warn).
+      logger.error("maintenance", `index rebuild failed for "${name}":`, error);
       results[name] = { ok: false, error };
     }
   }

--- a/src/lib/page-index.ts
+++ b/src/lib/page-index.ts
@@ -28,6 +28,11 @@ export type PageMetaIndex = Record<string, IndexEntry>;
 export async function getPageIndex(): Promise<PageMetaIndex | null> {
   try {
     const idx = await getStorage().getIndex<PageMetaIndex>(PAGE_INDEX_KEY);
+    // Presence check only — per-entry shape is TRUSTED, not validated. Safe
+    // because `listWikiPages` drives membership + title/slug/summary from
+    // index.md and only pulls enriched (optional) fields from here, so a
+    // malformed entry can at worst mis-enrich, never drop or leak a page; the
+    // daily rebuild overwrites it.
     if (!idx || typeof idx !== "object") return null;
     return idx;
   } catch (err) {

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -440,7 +440,10 @@ async function readIndexBaseEntries(): Promise<IndexEntry[]> {
     raw = await getStorage().readFile(storagePath);
   } catch (err: unknown) {
     if (!isEnoent(err)) {
-      logger.warn("wiki", "listWikiPages failed to read index.md:", err);
+      // A transient read failure on index.md makes the WHOLE wiki look empty to
+      // every list surface — surface it at error level (ENOENT = genuinely no
+      // index yet, which is the normal empty-state and stays quiet).
+      logger.error("wiki", "listWikiPages failed to read index.md:", err);
     }
     return [];
   }


### PR DESCRIPTION
Tightenings from the #396 review (parity confirmed; no correctness issues). Rebuild-failure + index.md-read-failure now log at error level (a persistent failure = silently-stale fast path / empty-looking wiki); `getPageIndex` documents its trusted-shape assumption; `fixStaleIndex` also drops the `_idx:pages` entry for symmetry. Build clean; 2629 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)