### PR TITLE
Render homepage anonymously — fix cold-start Loading + signed-in slowness

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,6 @@ import { listCommonsPages } from "@/lib/commons";
 import { listContributors } from "@/lib/contributors";
 import { getContributorIndex } from "@/lib/contributor-index";
 import { getTrail } from "@/lib/trail";
-import { getPrincipal } from "@/lib/auth";
 
 const HOW_IT_WORKS: [string, string][] = [
   ["Ingest", "A source — URL, PDF, tweet — is synthesized into a cited page."],
@@ -16,13 +15,18 @@ const HOW_IT_WORKS: [string, string][] = [
 ];
 
 export default async function Home() {
-  const principal = await getPrincipal();
+  // The homepage is a PUBLIC landing surface (no per-user content; the nav
+  // handles auth client-side). Rendering it anonymously — never calling
+  // getPrincipal — keeps it context-free (cacheable), skips Clerk's server-side
+  // init on cold starts, and makes listContributors/getTrail take their O(1)
+  // anonymous index fast-path for EVERY visitor (a signed-in principal would
+  // force the slow per-page scan here).
   const [commonsPages, contributors, trail] = await Promise.all([
-    // The homepage is the public commons — read it from the commons index
-    // (falls back to deriving the public set when the index is empty).
+    // Read the public commons from the commons index (falls back to deriving
+    // the public set when the index is empty).
     listCommonsPages(),
-    listContributors(principal),
-    getTrail(10, principal),
+    listContributors(null),
+    getTrail(10, null),
   ]);
 
   // listCommonsPages already excludes private + agent-scoped pages.


### PR DESCRIPTION
The home server-renders fast **warm** (~0.15s) but shows the `loading.tsx` fallback for ~1.5s on a **cold** worker: it `await getPrincipal()` first, and on a cold isolate Clerk's server SDK initializes on that call, blocking the render. The home is a **public** landing surface (no Mine/All; the nav does auth client-side), so it never needs the principal.

Drop `getPrincipal` from `src/app/page.tsx`; pass `null` to `listContributors`/`getTrail`. Effects: (1) no Clerk server init on the home hot path → faster cold; (2) both calls always take their O(1) anonymous index fast-path — a **signed-in** visitor previously forced the slow per-page scan on the home even warm; (3) home is now context-free → cacheable later.

Build clean; 2629 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)