### PR TITLE
Guarded content-reset endpoint (POST /api/admin/reset)

### DIFF
--- a/src/app/api/admin/reset/route.ts
+++ b/src/app/api/admin/reset/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { getServicePrincipal } from "@/lib/auth";
+import { getStorage } from "@/lib/storage";
+import { rebuildCommonsIndex } from "@/lib/commons";
+import { rebuildDerivedIndexes } from "@/lib/maintenance";
+import { saveVectorStore } from "@/lib/embeddings";
+import { logger } from "@/lib/logger";
+
+/**
+ * POST /api/admin/reset — wipe ALL wiki CONTENT for a from-scratch re-ingest.
+ *
+ * DESTRUCTIVE + IRREVERSIBLE. Service-token only (the same gate as
+ * /api/tasks/run; the middleware write-gate exempts this path so the token
+ * caller reaches the handler). Requires an explicit body to prevent accidents:
+ *   POST { "confirm": "wipe-content" }
+ *
+ * Deletes the content prefixes (wiki/, raw/, discuss/, tenants/) and resets the
+ * derived indexes + embeddings to an empty wiki. INTENTIONALLY KEEPS agent
+ * profiles (agents/), agent credentials (agent-secrets/), and the KV config —
+ * so agents + LLM settings survive; you re-ingest pages (and re-seed agent
+ * content) on a clean slate.
+ */
+const CONTENT_PREFIXES = ["wiki", "raw", "discuss", "tenants"] as const;
+const CONFIRM_PHRASE = "wipe-content";
+
+export async function POST(req: Request) {
+  const principal = getServicePrincipal(req);
+  if (!principal) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let confirm: unknown;
+  try {
+    const body = (await req.json()) as { confirm?: unknown };
+    confirm = body?.confirm;
+  } catch {
+    /* no / invalid body → falls through to the 400 below */
+  }
+  if (confirm !== CONFIRM_PHRASE) {
+    return NextResponse.json(
+      {
+        error: `Destructive content wipe: refusing without confirmation. POST { "confirm": "${CONFIRM_PHRASE}" }.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  logger.warn(
+    "admin",
+    `CONTENT WIPE by ${principal.handle}: deleting ${CONTENT_PREFIXES.join(
+      ", ",
+    )} (keeping agents/, agent-secrets/, config)`,
+  );
+
+  // 1. Delete the content prefixes. agents/ + agent-secrets/ are never touched.
+  const storage = getStorage();
+  const wiped: Record<string, boolean> = {};
+  for (const prefix of CONTENT_PREFIXES) {
+    try {
+      await storage.deleteDirectory(prefix);
+      wiped[prefix] = true;
+    } catch (err) {
+      logger.error("admin", `content wipe failed for "${prefix}":`, err);
+      wiped[prefix] = false;
+    }
+  }
+
+  // 2. Reset derived state to reflect the now-empty wiki (rebuilds scan the
+  //    empty wiki → empty maps; embeddings cleared to an empty store).
+  let commons = true;
+  try {
+    await rebuildCommonsIndex();
+  } catch (err) {
+    commons = false;
+    logger.error("admin", "rebuildCommonsIndex failed:", err);
+  }
+  const indexes = await rebuildDerivedIndexes();
+  let embeddings = true;
+  try {
+    await saveVectorStore({ model: "", entries: [] });
+  } catch (err) {
+    embeddings = false;
+    logger.error("admin", "clear embeddings failed:", err);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    wiped,
+    kept: ["agents/", "agent-secrets/", "config"],
+    derived: { commons, embeddings, ...indexes },
+  });
+}

--- a/src/lib/__tests__/middleware-write-gate.test.ts
+++ b/src/lib/__tests__/middleware-write-gate.test.ts
@@ -23,6 +23,7 @@ describe("write-gate in-route auth exemptions", () => {
     expect(authenticatesInRoute("/api/agents/seed")).toBe(true);
     expect(authenticatesInRoute("/api/agents/alice--yoyo/ingest")).toBe(true);
     expect(authenticatesInRoute("/api/admin/migrate")).toBe(true);
+    expect(authenticatesInRoute("/api/admin/reset")).toBe(true);
     expect(authenticatesInRoute("/api/admin/tenant/alice")).toBe(true);
     // Wiki routes: POST /api/wiki (create) and PUT/PATCH/DELETE /api/wiki/:slug
     expect(authenticatesInRoute("/api/wiki")).toBe(true);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -44,6 +44,9 @@ const IN_ROUTE_AUTH_PATHS = new Set([
   // Admin migration: authenticated in-route by the service token OR the site
   // owner's session (it rejects everyone else with 403).
   "/api/admin/migrate",
+  // Admin content reset (destructive wipe): service-token only, in-route, with
+  // an explicit confirm body. Called with no Clerk session.
+  "/api/admin/reset",
   // Wiki page creation: authenticated in-route via Clerk session OR the
   // service token (agents create pages via REST).
   "/api/wiki",


### PR DESCRIPTION
Service-token-only, confirm-gated endpoint to wipe wiki **content** for a from-scratch re-ingest. Deletes `wiki/`/`raw/`/`discuss/`/`tenants/` + resets the derived indexes + embeddings; **keeps** agent profiles, agent credentials, and config. Requires `{ "confirm": "wipe-content" }`. Added to the middleware exemption list (+ test). Build clean; 2629 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)