### PR TITLE
Multi-vault data model + APIs (step 1 of named vaults)

### DIFF
--- a/src/app/api/vaults/[id]/pages/route.ts
+++ b/src/app/api/vaults/[id]/pages/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { getPrincipal } from "@/lib/auth";
+import { addToVault, removeFromVault, vaultOwnedBy, getVault } from "@/lib/vault";
+import { readWikiPageWithFrontmatter } from "@/lib/wiki";
+import { belongsInCommons } from "@/lib/commons";
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+async function authorizeOwner(vaultId: string) {
+  const principal = await getPrincipal();
+  if (!principal) {
+    return { error: NextResponse.json({ error: "Sign in required." }, { status: 401 }) };
+  }
+  if (!vaultOwnedBy(vaultId, principal.handle)) {
+    return { error: NextResponse.json({ error: "Not your vault." }, { status: 403 }) };
+  }
+  return { principal };
+}
+
+async function readSlug(req: Request): Promise<string | null> {
+  try {
+    const slug = ((await req.json()) as { slug?: unknown })?.slug;
+    return typeof slug === "string" && slug.trim() ? slug : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * POST /api/vaults/[id]/pages { slug } — add a page reference to a vault.
+ *
+ * v1 (public vaults): only a readable PUBLIC commons page can be referenced
+ * (re-checked here, mirroring the old /api/vault curate gate).
+ */
+export async function POST(req: Request, { params }: Params) {
+  const { id } = await params;
+  const auth = await authorizeOwner(id);
+  if (auth.error) return auth.error;
+  if (!(await getVault(id))) {
+    return NextResponse.json({ error: "Vault not found." }, { status: 404 });
+  }
+  const slug = await readSlug(req);
+  if (!slug) {
+    return NextResponse.json({ error: "Missing or invalid 'slug'." }, { status: 400 });
+  }
+  const page = await readWikiPageWithFrontmatter(slug);
+  if (!page) {
+    return NextResponse.json({ error: "Page not found." }, { status: 404 });
+  }
+  const isCommons = belongsInCommons({
+    visibility:
+      typeof page.frontmatter.visibility === "string"
+        ? page.frontmatter.visibility
+        : undefined,
+    type: typeof page.frontmatter.type === "string" ? page.frontmatter.type : undefined,
+  });
+  if (!isCommons) {
+    return NextResponse.json(
+      { error: "Only public commons pages can be added to a public vault." },
+      { status: 400 },
+    );
+  }
+  await addToVault(id, slug);
+  return NextResponse.json({ ok: true, added: slug });
+}
+
+/** DELETE /api/vaults/[id]/pages { slug } — remove a page reference. */
+export async function DELETE(req: Request, { params }: Params) {
+  const { id } = await params;
+  const auth = await authorizeOwner(id);
+  if (auth.error) return auth.error;
+  const slug = await readSlug(req);
+  if (!slug) {
+    return NextResponse.json({ error: "Missing or invalid 'slug'." }, { status: 400 });
+  }
+  await removeFromVault(id, slug);
+  return NextResponse.json({ ok: true, removed: slug });
+}

--- a/src/app/api/vaults/[id]/route.ts
+++ b/src/app/api/vaults/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { getPrincipal } from "@/lib/auth";
+import { getVault, renameVault, deleteVault, vaultOwnedBy } from "@/lib/vault";
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+/** Resolve the signed-in owner of `vaultId`, or an error Response. */
+async function authorizeOwner(vaultId: string) {
+  const principal = await getPrincipal();
+  if (!principal) {
+    return { error: NextResponse.json({ error: "Sign in required." }, { status: 401 }) };
+  }
+  if (!vaultOwnedBy(vaultId, principal.handle)) {
+    return { error: NextResponse.json({ error: "Not your vault." }, { status: 403 }) };
+  }
+  return { principal };
+}
+
+/** PATCH /api/vaults/[id] { name } — rename (id stays stable). */
+export async function PATCH(req: Request, { params }: Params) {
+  const { id } = await params;
+  const auth = await authorizeOwner(id);
+  if (auth.error) return auth.error;
+  if (!(await getVault(id))) {
+    return NextResponse.json({ error: "Vault not found." }, { status: 404 });
+  }
+  let name: unknown;
+  try {
+    name = ((await req.json()) as { name?: unknown })?.name;
+  } catch {
+    /* 400 below */
+  }
+  if (typeof name !== "string" || !name.trim()) {
+    return NextResponse.json({ error: "Missing or invalid 'name'." }, { status: 400 });
+  }
+  await renameVault(id, name.trim());
+  return NextResponse.json({ ok: true });
+}
+
+/** DELETE /api/vaults/[id] — delete the vault (its referenced pages are untouched). */
+export async function DELETE(_req: Request, { params }: Params) {
+  const { id } = await params;
+  const auth = await authorizeOwner(id);
+  if (auth.error) return auth.error;
+  await deleteVault(id);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/vaults/route.ts
+++ b/src/app/api/vaults/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { getPrincipal } from "@/lib/auth";
+import { listVaults, createVault } from "@/lib/vault";
+
+/**
+ * GET /api/vaults  → { vaults: Vault[] } — the signed-in user's own vaults.
+ * POST /api/vaults { name } → { vault } — create a (public, v1) vault.
+ *
+ * Signed-in only (also enforced by the middleware write-gate for POST). Vaults
+ * are always the caller's own — owner is the session principal, never the body.
+ */
+export async function GET() {
+  const principal = await getPrincipal();
+  if (!principal) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+  return NextResponse.json({ vaults: await listVaults(principal.handle) });
+}
+
+export async function POST(req: Request) {
+  const principal = await getPrincipal();
+  if (!principal) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+  let name: unknown;
+  try {
+    name = ((await req.json()) as { name?: unknown })?.name;
+  } catch {
+    /* invalid body → 400 below */
+  }
+  if (typeof name !== "string" || !name.trim()) {
+    return NextResponse.json(
+      { error: "Missing or invalid 'name'." },
+      { status: 400 },
+    );
+  }
+  // v1: public vaults only (private is paid/clone-to-private, future).
+  const vault = await createVault(principal.handle, name.trim(), "public");
+  return NextResponse.json({ vault }, { status: 201 });
+}

--- a/src/lib/__tests__/vault-autoref.test.ts
+++ b/src/lib/__tests__/vault-autoref.test.ts
@@ -8,7 +8,7 @@ import {
   serializeFrontmatter,
   type Frontmatter,
 } from "../wiki";
-import { getVaultRefs } from "../vault";
+import { getVaultRefs, listVaults } from "../vault";
 import { _resetStorage } from "../storage";
 
 let tmpDir: string;
@@ -54,36 +54,20 @@ async function write(slug: string, over: Partial<Frontmatter> = {}) {
   });
 }
 
-describe("vault auto-ref on commons write (lifecycle step 3d)", () => {
-  it("adds an owner's new public commons page to their vault", async () => {
+// In the multi-vault model membership is EXPLICIT: writing/ingesting a page no
+// longer auto-joins any vault (the old lifecycle "auto-ref" step was removed).
+// Pages join a vault only via ingest-into-vault / curate-into-vault.
+describe("no vault auto-membership on write (auto-ref removed)", () => {
+  it("does NOT add an owner's new public commons page to any vault", async () => {
     await write("transformers", { owner: "alice" });
-    expect(await getVaultRefs("alice")).toContain("transformers");
+    expect(await getVaultRefs("alice")).toEqual([]); // legacy single-vault store
+    expect(await listVaults("alice")).toEqual([]); // no named vaults either
   });
 
-  it("is idempotent across re-writes", async () => {
+  it("leaves the vault empty across re-writes", async () => {
     await write("transformers", { owner: "alice" });
     await write("transformers", { owner: "alice" });
-    expect(await getVaultRefs("alice")).toEqual(["transformers"]);
-  });
-
-  it("does NOT auto-ref a private page", async () => {
-    await write("secret", { owner: "alice", visibility: "private" });
     expect(await getVaultRefs("alice")).toEqual([]);
-  });
-
-  it("does NOT auto-ref an agent-scoped page", async () => {
-    await write("agent-note", { owner: "alice", type: "agent-knowledge" });
-    expect(await getVaultRefs("alice")).toEqual([]);
-  });
-
-  it("does NOT auto-ref a system-owned (seed) page", async () => {
-    await write("seed-page", { owner: "system" });
-    expect(await getVaultRefs("system")).toEqual([]);
-  });
-
-  it("does NOT auto-ref an agent-owned (handle--name) page", async () => {
-    await write("learned", { owner: "alice--yoyo" });
-    expect(await getVaultRefs("alice--yoyo")).toEqual([]);
-    expect(await getVaultRefs("alice")).toEqual([]);
+    expect(await listVaults("alice")).toEqual([]);
   });
 });

--- a/src/lib/__tests__/vault-multi.test.ts
+++ b/src/lib/__tests__/vault-multi.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  vaultIdFor,
+  vaultOwnedBy,
+  createVault,
+  listVaults,
+  getVault,
+  vaultSlugs,
+  vaultsContaining,
+  addToVault,
+  removeFromVault,
+  renameVault,
+  deleteVault,
+} from "../vault";
+import { _resetStorage } from "../storage";
+import { _resetLocks } from "../lock";
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-multi-test-"));
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetLocks();
+  _resetStorage();
+});
+
+afterEach(async () => {
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("multi-vault model", () => {
+  it("vaultIdFor encodes the owner tenant as the `--` prefix", () => {
+    expect(vaultIdFor("Alice", "Reading List")).toBe("alice--reading-list");
+    expect(vaultOwnedBy("alice--reading-list", "alice")).toBe(true);
+    expect(vaultOwnedBy("alice--reading-list", "bob")).toBe(false);
+  });
+
+  it("creates, lists, and reads a vault (public by default, empty)", async () => {
+    const v = await createVault("alice", "Reading List");
+    expect(v).toMatchObject({
+      id: "alice--reading-list",
+      owner: "alice",
+      name: "Reading List",
+      visibility: "public",
+      slugs: [],
+    });
+    expect(await listVaults("alice")).toHaveLength(1);
+    expect(await getVault("alice--reading-list")).toMatchObject({ name: "Reading List" });
+    expect(await getVault("alice--nope")).toBeNull();
+  });
+
+  it("create is idempotent on (owner, name)", async () => {
+    const a = await createVault("alice", "ML");
+    const b = await createVault("alice", "ML");
+    expect(b.id).toBe(a.id);
+    expect(await listVaults("alice")).toHaveLength(1);
+  });
+
+  it("adds/removes page refs (idempotent) and reports membership", async () => {
+    const v = await createVault("alice", "ML");
+    await addToVault(v.id, "transformers");
+    await addToVault(v.id, "transformers"); // idempotent
+    await addToVault(v.id, "attention");
+    expect(await vaultSlugs(v.id)).toEqual(["transformers", "attention"]);
+    expect(await vaultsContaining("alice", "transformers")).toEqual([v.id]);
+
+    await removeFromVault(v.id, "transformers");
+    expect(await vaultSlugs(v.id)).toEqual(["attention"]);
+    expect(await vaultsContaining("alice", "transformers")).toEqual([]);
+  });
+
+  it("renames (id stays stable) and deletes", async () => {
+    const v = await createVault("alice", "ML");
+    await addToVault(v.id, "x");
+    await renameVault(v.id, "Machine Learning");
+    expect((await getVault(v.id))?.name).toBe("Machine Learning");
+    expect((await getVault(v.id))?.slugs).toEqual(["x"]); // members preserved
+
+    await deleteVault(v.id);
+    expect(await getVault(v.id)).toBeNull();
+    expect(await listVaults("alice")).toEqual([]);
+  });
+
+  it("vaults are owner-scoped (different owners don't collide)", async () => {
+    await createVault("alice", "ML");
+    await createVault("bob", "ML");
+    expect(await listVaults("alice")).toHaveLength(1);
+    expect(await listVaults("bob")).toHaveLength(1);
+    expect((await listVaults("alice"))[0].id).toBe("alice--ml");
+    expect((await listVaults("bob"))[0].id).toBe("bob--ml");
+  });
+});

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -30,7 +30,6 @@ import { syncBacklinksForPage, removeBacklinksForSlug } from "./backlink-index";
 import { recordEditForAuthor } from "./contributor-index";
 import { pushRecentEvent, removeRecentForSlug } from "./recent-index";
 import { isAgentHandle } from "./agents";
-import { addVaultRef } from "./vault";
 import { parseFrontmatter } from "./frontmatter";
 import type { LogOperation } from "./wiki";
 import { logger } from "./logger";
@@ -498,26 +497,10 @@ async function runPageLifecycleOp(
     logger.warn("silo", `silo mirror skipped for "${slug}":`, err);
   }
 
-  // 3d. Auto-add the page into its owner's vault — the commons-first reference
-  //     lens. A contributor's own commons pages show in their vault without a
-  //     manual curate (ingest-into-my-vault). Owner-keyed, commons-only (public,
-  //     non-agent), humans-only (skip "system" and agent-owned `a--b` handles).
-  //     Idempotent + fail-soft — a vault error must never break the write.
-  try {
-    if (op.kind !== "delete") {
-      const fm = parseFrontmatter(op.content).data;
-      const owner = typeof fm.owner === "string" ? fm.owner.trim() : "";
-      const isCommons = belongsInCommons({
-        visibility: typeof fm.visibility === "string" ? fm.visibility : undefined,
-        type: typeof fm.type === "string" ? fm.type : undefined,
-      });
-      if (owner && owner !== "system" && !owner.includes("--") && isCommons) {
-        await addVaultRef(owner, slug);
-      }
-    }
-  } catch (err) {
-    logger.warn("vault", `vault auto-ref skipped for "${slug}":`, err);
-  }
+  // 3d. (removed) Pages no longer auto-join a vault. In the multi-vault model
+  //     vault membership is EXPLICIT — a page joins a vault only via an
+  //     ingest-into-vault or curate-into-vault action. Plain ingest lands in the
+  //     commons only.
 
   // 4. Cross-reference other pages.
   //    - write: discover related pages and add backlinks TO this slug.

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -16,6 +16,7 @@
 import { getStorage } from "./storage";
 import { withFileLock } from "./lock";
 import { tenantForOwner } from "./wiki";
+import { slugify } from "./slugify";
 import { logger } from "./logger";
 
 /** The stored shape of one user's vault. */
@@ -79,4 +80,174 @@ export async function removeVaultRef(
       await getStorage().putIndex<VaultIndex>(vaultKey(handle), { slugs: next });
     }
   });
+}
+
+// ===========================================================================
+// Multiple named vaults (commons-first, v1: public)
+//
+// A user has several named vaults; each is a collection of page references.
+// Strict visibility: a PUBLIC vault references public commons pages (live); a
+// PRIVATE vault holds owner-only pages (curating into private = clone — v2).
+// Membership is explicit (no auto-add). Stored per owner under `vaults:<tenant>`
+// as a `Vault[]` with membership inline.
+//
+// The id is `<tenant>--<name-slug>` so the OWNER TENANT is recoverable from the
+// id alone (split on the first `--`) — needed to resolve a `vault:<id>` scope to
+// its storage key without a directory scan.
+// ===========================================================================
+
+export type VaultVisibility = "public" | "private";
+
+export interface Vault {
+  /** `<ownerTenant>--<nameSlug>` — owner tenant recoverable as the `--` prefix. */
+  id: string;
+  /** Original-case owner handle (display + attribution). */
+  owner: string;
+  /** Human display name. */
+  name: string;
+  visibility: VaultVisibility;
+  /** Member page slugs, insertion-ordered (most-recent last). */
+  slugs: string[];
+  created: string;
+}
+
+/** Stable vault id from `(owner, name)`. Prefix = the owner's storage tenant. */
+export function vaultIdFor(owner: string, name: string): string {
+  return `${tenantForOwner(owner)}--${slugify(name)}`;
+}
+
+/** The owner tenant encoded in a vault id (everything before the first `--`). */
+function tenantOfVaultId(vaultId: string): string {
+  const i = vaultId.indexOf("--");
+  return i === -1 ? vaultId : vaultId.slice(0, i);
+}
+
+/** Whether `handle` owns `vaultId` — an O(1) check on the id's tenant prefix.
+ *  Routes use this to authorize vault mutations (no storage read needed). */
+export function vaultOwnedBy(vaultId: string, handle: string): boolean {
+  return tenantOfVaultId(vaultId) === tenantForOwner(handle);
+}
+
+const vaultsKey = (tenant: string) => `vaults:${tenant}`;
+
+/** All vaults owned by a handle (empty when none). Fail-soft. */
+export async function listVaults(owner: string): Promise<Vault[]> {
+  try {
+    const idx = await getStorage().getIndex<Vault[]>(
+      vaultsKey(tenantForOwner(owner)),
+    );
+    return Array.isArray(idx) ? idx : [];
+  } catch (err) {
+    logger.warn("vault", "vaults index unreadable; treating as empty:", err);
+    return [];
+  }
+}
+
+/** One vault by id (or null). Resolves the owner tenant from the id. */
+export async function getVault(vaultId: string): Promise<Vault | null> {
+  try {
+    const idx = await getStorage().getIndex<Vault[]>(
+      vaultsKey(tenantOfVaultId(vaultId)),
+    );
+    return (Array.isArray(idx) ? idx : []).find((v) => v.id === vaultId) ?? null;
+  } catch (err) {
+    logger.warn("vault", `getVault failed for "${vaultId}":`, err);
+    return null;
+  }
+}
+
+/** Member slugs of a vault (empty when absent). */
+export async function vaultSlugs(vaultId: string): Promise<string[]> {
+  return (await getVault(vaultId))?.slugs ?? [];
+}
+
+/** Vault ids (owned by `owner`) that contain `slug` — drives the picker state. */
+export async function vaultsContaining(
+  owner: string,
+  slug: string,
+): Promise<string[]> {
+  return (await listVaults(owner))
+    .filter((v) => v.slugs.includes(slug))
+    .map((v) => v.id);
+}
+
+/**
+ * Create a named vault. Idempotent on `(owner, name)`; if the id collides with a
+ * different existing vault, a numeric suffix is appended to keep ids unique.
+ * Returns the created (or existing) vault.
+ */
+export async function createVault(
+  owner: string,
+  name: string,
+  visibility: VaultVisibility = "public",
+): Promise<Vault> {
+  const tenant = tenantForOwner(owner);
+  return withFileLock(vaultsKey(tenant), async () => {
+    const vaults = await listVaults(owner);
+    let id = vaultIdFor(owner, name);
+    const existing = vaults.find((v) => v.id === id);
+    if (existing) return existing;
+    // Uniquify on the rare slug collision (different display name, same slug).
+    if (vaults.some((v) => v.id === id)) {
+      let n = 2;
+      while (vaults.some((v) => v.id === `${id}-${n}`)) n++;
+      id = `${id}-${n}`;
+    }
+    const vault: Vault = {
+      id,
+      owner,
+      name,
+      visibility,
+      slugs: [],
+      created: new Date().toISOString(),
+    };
+    await getStorage().putIndex<Vault[]>(vaultsKey(tenant), [...vaults, vault]);
+    return vault;
+  });
+}
+
+/** Mutate one vault in its owner's list (no-op if absent). */
+async function mutateVault(
+  vaultId: string,
+  fn: (v: Vault) => Vault | null,
+): Promise<void> {
+  const tenant = tenantOfVaultId(vaultId);
+  await withFileLock(vaultsKey(tenant), async () => {
+    const idx = await getStorage().getIndex<Vault[]>(vaultsKey(tenant));
+    const vaults = Array.isArray(idx) ? idx : [];
+    const i = vaults.findIndex((v) => v.id === vaultId);
+    if (i === -1) return;
+    const next = fn({ ...vaults[i], slugs: [...vaults[i].slugs] });
+    if (next === null) vaults.splice(i, 1);
+    else vaults[i] = next;
+    await getStorage().putIndex<Vault[]>(vaultsKey(tenant), vaults);
+  });
+}
+
+/** Rename a vault (id stays stable). */
+export async function renameVault(vaultId: string, name: string): Promise<void> {
+  await mutateVault(vaultId, (v) => ({ ...v, name }));
+}
+
+/** Delete a vault. */
+export async function deleteVault(vaultId: string): Promise<void> {
+  await mutateVault(vaultId, () => null);
+}
+
+/** Add a page reference to a vault (idempotent). */
+export async function addToVault(vaultId: string, slug: string): Promise<void> {
+  await mutateVault(vaultId, (v) =>
+    v.slugs.includes(slug) ? v : { ...v, slugs: [...v.slugs, slug] },
+  );
+}
+
+/** Remove a page reference from a vault (no-op if absent). */
+export async function removeFromVault(
+  vaultId: string,
+  slug: string,
+): Promise<void> {
+  await mutateVault(vaultId, (v) => ({
+    ...v,
+    slugs: v.slugs.filter((s) => s !== slug),
+  }));
 }


### PR DESCRIPTION
Foundation for **multiple named vaults** (commons-first; public V1, private V2). No user-visible UI yet — the model + APIs + removal of the vault auto-add.

- **`vault.ts`**: `Vault { id, owner, name, visibility, slugs[], created }`; id = `<ownerTenant>--<nameSlug>` (owner tenant recoverable from the id, for the upcoming `vault:<id>` scope). CRUD + membership fns, stored per-owner under `vaults:<tenant>`. Old single-vault fns kept until the UI migrates (step 2).
- **APIs** (owner-gated via `vaultOwnedBy`): `/api/vaults` (list/create), `/api/vaults/[id]` (rename/delete), `/api/vaults/[id]/pages` (add/remove ref; add re-checks `belongsInCommons`).
- **Removed the lifecycle auto-add** — membership is explicit now.
- Tests: multi-vault model suite + inverted the auto-ref test.

Build clean; 2631 tests. Steps 2-4 (the /vault UI + /vault/agents + the Browse/Query/Graph vault lens + MCP) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)