### PR TITLE
Multi-vault UI + vault Browse/Query/Graph lens (steps 2-3)

### DIFF
--- a/src/app/api/vaults/route.ts
+++ b/src/app/api/vaults/route.ts
@@ -1,20 +1,31 @@
 import { NextResponse } from "next/server";
 import { getPrincipal } from "@/lib/auth";
-import { listVaults, createVault } from "@/lib/vault";
+import { listVaults, createVault, vaultsContaining } from "@/lib/vault";
 
 /**
  * GET /api/vaults  → { vaults: Vault[] } — the signed-in user's own vaults.
+ *   GET /api/vaults?slug=<slug> → { vaults, containing } — also returns the ids
+ *   of the caller's vaults that already reference `slug` (drives the picker's
+ *   checkbox state).
  * POST /api/vaults { name } → { vault } — create a (public, v1) vault.
  *
  * Signed-in only (also enforced by the middleware write-gate for POST). Vaults
  * are always the caller's own — owner is the session principal, never the body.
  */
-export async function GET() {
+export async function GET(req: Request) {
   const principal = await getPrincipal();
   if (!principal) {
     return NextResponse.json({ error: "Sign in required." }, { status: 401 });
   }
-  return NextResponse.json({ vaults: await listVaults(principal.handle) });
+  const vaults = await listVaults(principal.handle);
+  const slug = new URL(req.url).searchParams.get("slug");
+  if (slug) {
+    return NextResponse.json({
+      vaults,
+      containing: await vaultsContaining(principal.handle, slug),
+    });
+  }
+  return NextResponse.json({ vaults });
 }
 
 export async function POST(req: Request) {

--- a/src/app/query/page.tsx
+++ b/src/app/query/page.tsx
@@ -47,10 +47,28 @@ export default function QueryPage() {
     [],
   );
 
-  // Mine|All lens — querying requires sign-in (API write gate), so signed-in
-  // users default to "mine" (their own pages). A `?scope=owner:<h>` deep-link
-  // (from a /u/<handle> silo) takes precedence and pins the query to that silo.
+  // Public + your-vaults lens. Default scope = undefined (the public commons).
+  // A `?scope=owner:<h>` / `agent:<id>` deep-link (e.g. from a /u/<handle> silo)
+  // takes precedence and pins the query to that scope.
   const { isLoaded, isSignedIn } = useUser();
+
+  // The signed-in user's vaults, for the lens selector (fetched on mount).
+  const [myVaults, setMyVaults] = useState<
+    { id: string; name: string }[]
+  >([]);
+  useEffect(() => {
+    if (!isSignedIn) return;
+    let cancelled = false;
+    fetch("/api/vaults")
+      .then((r) => (r.ok ? r.json() : { vaults: [] }))
+      .then((d: { vaults?: { id: string; name: string }[] }) => {
+        if (!cancelled) setMyVaults(d.vaults ?? []);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [isSignedIn]);
 
   const {
     question,
@@ -75,8 +93,8 @@ export default function QueryPage() {
   });
 
   // Set the initial scope once, on first Clerk load: a `?scope=` deep-link wins;
-  // otherwise signed-in users default to "mine". Reads location directly (not
-  // useSearchParams) to avoid a client-side-rendering bailout of the page.
+  // otherwise default = undefined (the public commons). Reads location directly
+  // (not useSearchParams) to avoid a client-side-rendering bailout of the page.
   const didInitScope = useRef(false);
   useEffect(() => {
     if (didInitScope.current || !isLoaded) return;
@@ -84,13 +102,16 @@ export default function QueryPage() {
     const deepLink =
       new URLSearchParams(window.location.search).get("scope") || undefined;
     if (deepLink) setScope(deepLink);
-    else if (isSignedIn) setScope("mine");
-  }, [isLoaded, isSignedIn, setScope]);
+  }, [isLoaded, setScope]);
 
   // A deep-linked owner:<handle> scope renders as a dismissible chip; otherwise
-  // the Mine|All toggle drives `scope` ("mine" vs undefined=All).
+  // the Public + your-vaults selector drives `scope` (undefined=Public vs
+  // `vault:<id>`).
   const scopedHandle = scope?.startsWith("owner:")
     ? scope.slice("owner:".length)
+    : null;
+  const activeVaultId = scope?.startsWith("vault:")
+    ? scope.slice("vault:".length)
     : null;
 
   // Fetch history on mount
@@ -134,16 +155,28 @@ export default function QueryPage() {
         ask the accumulated brain
       </p>
 
-      {/* Scope lens — pinned silo (deep-link) renders as a chip; otherwise a
-          Mine|All toggle. "Mine" is shown only when signed in. */}
-      <div className="mt-4">
+      {/* Scope lens — a pinned silo/agent (deep-link) renders as a dismissible
+          chip; otherwise a Public + your-vaults selector. */}
+      <div style={{ marginTop: 16 }}>
         {scopedHandle ? (
-          <div className="inline-flex items-center gap-2 rounded-lg border border-foreground/10 bg-foreground/5 px-3 py-1.5 text-sm">
-            <span className="text-foreground/70">
+          <div
+            className="row"
+            style={{
+              display: "inline-flex",
+              gap: 8,
+              alignItems: "center",
+              border: "1px solid var(--rule)",
+              background: "var(--paper-2)",
+              borderRadius: 999,
+              padding: "5px 12px",
+              fontSize: 13,
+            }}
+          >
+            <span style={{ color: "var(--muted)" }}>
               Answering from{" "}
               <Link
                 href={`/u/${scopedHandle}`}
-                className="font-medium text-foreground hover:underline"
+                style={{ color: "var(--ink)", fontWeight: 600, textDecoration: "none" }}
               >
                 @{scopedHandle}
               </Link>
@@ -152,7 +185,7 @@ export default function QueryPage() {
             <button
               type="button"
               onClick={() => setScope(undefined)}
-              className="text-foreground/50 hover:text-foreground"
+              style={{ color: "var(--muted)", background: "transparent", border: 0, cursor: "pointer" }}
               aria-label="Clear scope and search all content"
             >
               ✕
@@ -162,32 +195,35 @@ export default function QueryPage() {
           <div
             role="group"
             aria-label="Query scope"
-            className="inline-flex items-center gap-1 rounded-lg border border-foreground/10 p-1"
+            className="row"
+            style={{ gap: 6, flexWrap: "wrap" }}
           >
-            {isSignedIn && (
+            {[
+              { scope: undefined as string | undefined, label: "Public", active: !activeVaultId },
+              ...myVaults.map((v) => ({
+                scope: `vault:${v.id}` as string | undefined,
+                label: v.name,
+                active: activeVaultId === v.id,
+              })),
+            ].map((o) => (
               <button
+                key={o.scope ?? "all"}
                 type="button"
-                onClick={() => setScope("mine")}
-                className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
-                  scope === "mine"
-                    ? "bg-foreground/10 font-semibold text-foreground"
-                    : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
-                }`}
+                onClick={() => setScope(o.scope)}
+                style={{
+                  fontSize: 13,
+                  padding: "5px 12px",
+                  borderRadius: 999,
+                  whiteSpace: "nowrap",
+                  cursor: "pointer",
+                  border: `1px solid ${o.active ? "var(--ink)" : "var(--rule)"}`,
+                  background: o.active ? "var(--ink)" : "transparent",
+                  color: o.active ? "var(--paper)" : "var(--ink-2)",
+                }}
               >
-                Mine
+                {o.label}
               </button>
-            )}
-            <button
-              type="button"
-              onClick={() => setScope(undefined)}
-              className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
-                scope === undefined
-                  ? "bg-foreground/10 font-semibold text-foreground"
-                  : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
-              }`}
-            >
-              All
-            </button>
+            ))}
           </div>
         )}
       </div>

--- a/src/app/vault/agents/page.tsx
+++ b/src/app/vault/agents/page.tsx
@@ -1,16 +1,15 @@
 import Link from "next/link";
 import { SignInButton } from "@clerk/nextjs";
 import { getPrincipal } from "@/lib/auth";
-import { listVaults } from "@/lib/vault";
-import { VaultManager } from "@/components/VaultManager";
+import { listAgentsForOwner } from "@/lib/agents";
+import { AgentManager } from "@/components/AgentManager";
 
 /**
- * `/vault` — the signed-in user's vault management surface: a list of their
- * named vaults (each a curated reference lens over the commons) with create /
- * rename / delete / view. Agents moved to `/vault/agents`. Signed-out visitors
- * see only a sign-in prompt — no data is fetched or leaked.
+ * `/vault/agents` — the signed-in user's agent management surface (moved off
+ * `/vault`): list their agents with inline edit / token / delete, plus a create
+ * form. Signed-out visitors see only a sign-in prompt — no data is fetched.
  */
-export default async function VaultPage() {
+export default async function VaultAgentsPage() {
   const principal = await getPrincipal();
 
   if (!principal) {
@@ -21,13 +20,13 @@ export default async function VaultPage() {
           style={{ paddingTop: 120, paddingBottom: 120, textAlign: "center" }}
         >
           <p className="fmark" style={{ justifyContent: "center" }}>
-            your vaults
+            your agents
           </p>
           <h1
             className="display"
             style={{ fontSize: "clamp(34px,4.6vw,58px)", margin: "16px 0 12px" }}
           >
-            Vaults
+            Agents
           </h1>
           <p
             style={{
@@ -38,48 +37,51 @@ export default async function VaultPage() {
               lineHeight: 1.55,
             }}
           >
-            Sign in to create and manage your vaults — curated reference lenses
-            over the commons.
+            Sign in to create and manage agents that ingest and maintain pages
+            on your behalf.
           </p>
           <SignInButton mode="modal">
-            <button className="btn primary">Sign in to view your vaults</button>
+            <button className="btn primary">Sign in to view your agents</button>
           </SignInButton>
         </section>
       </div>
     );
   }
 
-  const vaults = await listVaults(principal.handle);
+  const handle = principal.handle;
+  const agents = await listAgentsForOwner(handle);
 
   return (
     <div className="fade">
       {/* Header */}
       <section className="shell" style={{ paddingTop: 56 }}>
-        <p className="fmark" style={{ marginBottom: 18 }}>
-          your vaults
-        </p>
         <div
           className="spread"
           style={{ gap: 20, alignItems: "flex-end", flexWrap: "wrap" }}
         >
-          <h1
-            className="display"
-            style={{ fontSize: "clamp(34px,4.6vw,58px)", margin: 0 }}
-          >
-            Vaults
-          </h1>
+          <div>
+            <p className="fmark" style={{ marginBottom: 18 }}>
+              your agents
+            </p>
+            <h1
+              className="display"
+              style={{ fontSize: "clamp(34px,4.6vw,58px)", margin: 0 }}
+            >
+              Agents
+            </h1>
+          </div>
           <Link
-            href="/vault/agents"
+            href="/vault"
             className="receipt"
             style={{
               fontSize: 13,
-              color: "var(--agent)",
+              color: "var(--muted)",
               textDecoration: "none",
               paddingBottom: 8,
               whiteSpace: "nowrap",
             }}
           >
-            Agents →
+            ← Vaults
           </Link>
         </div>
         <p
@@ -91,12 +93,11 @@ export default async function VaultPage() {
             maxWidth: "56ch",
           }}
         >
-          Each vault is a curated set of live references into the commons — save
-          pages to a vault, then browse, query, and graph through that lens.
+          Agents that ingest and maintain pages on your behalf.
         </p>
       </section>
 
-      {/* Vaults */}
+      {/* Agents */}
       <section
         className="shell"
         style={{
@@ -105,7 +106,7 @@ export default async function VaultPage() {
           borderTop: "1px solid var(--rule)",
         }}
       >
-        <VaultManager vaults={vaults} />
+        <AgentManager handle={handle} agents={agents} />
       </section>
     </div>
   );

--- a/src/app/wiki/graph/page.tsx
+++ b/src/app/wiki/graph/page.tsx
@@ -10,13 +10,30 @@ export default function GraphPage() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const router = useRouter();
 
-  // Mine|All lens (consistent with /wiki and /query). A `?scope=owner:<h>`
-  // deep-link (from a /u/<handle> silo) pins the graph to that silo.
+  // Public + your-vaults lens (consistent with /wiki and /query). Default scope
+  // = undefined (the public commons). A `?scope=owner:<h>` / `agent:<id>`
+  // deep-link pins the graph to that scope.
   const { isLoaded, isSignedIn } = useUser();
   const [scope, setScope] = useState<string | undefined>(undefined);
 
+  // The signed-in user's vaults, for the lens selector (fetched on mount).
+  const [myVaults, setMyVaults] = useState<{ id: string; name: string }[]>([]);
+  useEffect(() => {
+    if (!isSignedIn) return;
+    let cancelled = false;
+    fetch("/api/vaults")
+      .then((r) => (r.ok ? r.json() : { vaults: [] }))
+      .then((d: { vaults?: { id: string; name: string }[] }) => {
+        if (!cancelled) setMyVaults(d.vaults ?? []);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [isSignedIn]);
+
   // Initial scope once, on first Clerk load: a `?scope=` deep-link wins, else
-  // signed-in users default to "mine". Reads location directly (not
+  // default = undefined (the public commons). Reads location directly (not
   // useSearchParams) to avoid a client-side-rendering bailout of the page.
   const didInit = useRef(false);
   useEffect(() => {
@@ -25,11 +42,13 @@ export default function GraphPage() {
     const deepLink =
       new URLSearchParams(window.location.search).get("scope") || undefined;
     if (deepLink) setScope(deepLink);
-    else if (isSignedIn) setScope("mine");
-  }, [isLoaded, isSignedIn]);
+  }, [isLoaded]);
 
   const scopedHandle = scope?.startsWith("owner:")
     ? scope.slice("owner:".length)
+    : null;
+  const activeVaultId = scope?.startsWith("vault:")
+    ? scope.slice("vault:".length)
     : null;
 
   const {
@@ -43,12 +62,24 @@ export default function GraphPage() {
   } = useGraphSimulation(canvasRef, router, scope);
 
   const lens = scopedHandle ? (
-    <div className="inline-flex items-center gap-2 rounded-lg border border-foreground/10 bg-foreground/5 px-3 py-1.5 text-sm">
-      <span className="text-foreground/70">
+    <div
+      className="row"
+      style={{
+        display: "inline-flex",
+        gap: 8,
+        alignItems: "center",
+        border: "1px solid var(--rule)",
+        background: "var(--paper-2)",
+        borderRadius: 999,
+        padding: "5px 12px",
+        fontSize: 13,
+      }}
+    >
+      <span style={{ color: "var(--muted)" }}>
         Graphing{" "}
         <Link
           href={`/u/${scopedHandle}`}
-          className="font-medium text-foreground hover:underline"
+          style={{ color: "var(--ink)", fontWeight: 600, textDecoration: "none" }}
         >
           @{scopedHandle}
         </Link>
@@ -57,7 +88,7 @@ export default function GraphPage() {
       <button
         type="button"
         onClick={() => setScope(undefined)}
-        className="text-foreground/50 hover:text-foreground"
+        style={{ color: "var(--muted)", background: "transparent", border: 0, cursor: "pointer" }}
         aria-label="Clear scope and show the full commons graph"
       >
         ✕
@@ -67,32 +98,35 @@ export default function GraphPage() {
     <div
       role="group"
       aria-label="Graph scope"
-      className="inline-flex items-center gap-1 rounded-lg border border-foreground/10 p-1"
+      className="row"
+      style={{ gap: 6, flexWrap: "wrap" }}
     >
-      {isSignedIn && (
+      {[
+        { scope: undefined as string | undefined, label: "Public", active: !activeVaultId },
+        ...myVaults.map((v) => ({
+          scope: `vault:${v.id}` as string | undefined,
+          label: v.name,
+          active: activeVaultId === v.id,
+        })),
+      ].map((o) => (
         <button
+          key={o.scope ?? "all"}
           type="button"
-          onClick={() => setScope("mine")}
-          className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
-            scope === "mine"
-              ? "bg-foreground/10 font-semibold text-foreground"
-              : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
-          }`}
+          onClick={() => setScope(o.scope)}
+          style={{
+            fontSize: 13,
+            padding: "5px 12px",
+            borderRadius: 999,
+            whiteSpace: "nowrap",
+            cursor: "pointer",
+            border: `1px solid ${o.active ? "var(--ink)" : "var(--rule)"}`,
+            background: o.active ? "var(--ink)" : "transparent",
+            color: o.active ? "var(--paper)" : "var(--ink-2)",
+          }}
         >
-          Mine
+          {o.label}
         </button>
-      )}
-      <button
-        type="button"
-        onClick={() => setScope(undefined)}
-        className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
-          scope === undefined
-            ? "bg-foreground/10 font-semibold text-foreground"
-            : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
-        }`}
-      >
-        All
-      </button>
+      ))}
     </div>
   );
 
@@ -111,8 +145,8 @@ export default function GraphPage() {
         <p className="text-foreground/60">
           {scopedHandle
             ? `No pages in @${scopedHandle}’s silo yet.`
-            : scope === "mine"
-              ? "You haven’t added any pages yet."
+            : activeVaultId
+              ? "This vault has no pages yet."
               : "No wiki pages yet. Ingest some content to see the graph!"}
         </p>
       ) : (

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -1,7 +1,8 @@
 import { listReadableWikiPages } from "@/lib/wiki";
 import { listCommonsPages } from "@/lib/commons";
 import type { IndexEntry } from "@/lib/types";
-import { slugsForOwner } from "@/lib/search";
+import { getVault } from "@/lib/vault";
+import { listVaults } from "@/lib/vault";
 import { getDiscussionStatsForSlugs } from "@/lib/talk";
 import { getPrincipal } from "@/lib/auth";
 import { BrowseClient } from "@/components/BrowseClient";
@@ -15,28 +16,33 @@ export default async function WikiIndex({
   const principal = await getPrincipal();
   const myHandle = principal?.handle ?? null;
 
-  // Effective scope: explicit ?scope wins; otherwise signed-in users default to
-  // their own content ("Mine"), guests to the full public commons ("All").
-  // This is a soft VIEW filter over public content — not access control.
-  const effectiveScope = scopeParam ?? (myHandle ? "mine" : "all");
-  const ownerHandle =
-    effectiveScope === "mine"
-      ? myHandle
-      : effectiveScope.startsWith("owner:")
-        ? effectiveScope.slice("owner:".length)
-        : null;
-  const showingMine = ownerHandle !== null;
+  // Default scope = the public commons ("Public") for everyone — a soft VIEW
+  // filter over public content, not access control. A `vault:<id>` scope is a
+  // curated reference lens (public vaults only resolve via scope).
+  const effectiveScope = scopeParam ?? "all";
+  const vaultId = effectiveScope.startsWith("vault:")
+    ? effectiveScope.slice("vault:".length)
+    : null;
+
+  // The signed-in user's own vaults drive the lens pills (and the per-row Remove
+  // when viewing one of their own vaults).
+  const myVaults = myHandle ? await listVaults(myHandle) : [];
 
   let pages: IndexEntry[];
-  if (ownerHandle) {
-    // "Mine"/owner scope: the user's own pages (public + their private),
-    // filtered to what the viewer may read.
-    const mine = new Set(await slugsForOwner(ownerHandle));
-    pages = (await listReadableWikiPages(principal)).filter((p) =>
-      mine.has(p.slug),
-    );
+  if (vaultId) {
+    // Vault lens: a public vault's referenced commons pages, intersected with
+    // what the viewer may read. Private vaults never resolve via scope.
+    const vault = await getVault(vaultId);
+    if (!vault || vault.visibility !== "public") {
+      pages = [];
+    } else {
+      const refs = new Set(vault.slugs);
+      pages = (await listReadableWikiPages(principal)).filter((p) =>
+        refs.has(p.slug),
+      );
+    }
   } else {
-    // "All" scope = the public commons (read from the commons index).
+    // "Public" scope = the public commons (read from the commons index).
     pages = await listCommonsPages();
   }
 
@@ -49,7 +55,12 @@ export default async function WikiIndex({
     <BrowseClient
       pages={pages}
       myHandle={myHandle}
-      showingMine={showingMine}
+      activeScope={effectiveScope}
+      myVaults={myVaults.map((v) => ({
+        id: v.id,
+        name: v.name,
+        visibility: v.visibility,
+      }))}
       discussionStats={discussionStats}
     />
   );

--- a/src/components/ArticleActions.tsx
+++ b/src/components/ArticleActions.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
 import { useUser } from "@clerk/nextjs";
 import { editPath, rawPath } from "@/lib/links";
 import { ReingestButton } from "@/components/ReingestButton";
@@ -70,27 +69,6 @@ export function ArticleActions({
   const canCurate =
     isLoaded && !!isSignedIn && isCommonsPage && !ownsOrContributes;
 
-  // Fetch vault membership only when the curate button would actually show.
-  const [inVault, setInVault] = useState<boolean | null>(null);
-  useEffect(() => {
-    if (!canCurate) {
-      setInVault(null);
-      return;
-    }
-    let cancelled = false;
-    fetch(`/api/vault/status?slug=${encodeURIComponent(slug)}`)
-      .then((r) => (r.ok ? r.json() : { inVault: false }))
-      .then((d: { inVault?: boolean }) => {
-        if (!cancelled) setInVault(!!d.inVault);
-      })
-      .catch(() => {
-        if (!cancelled) setInVault(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [canCurate, slug]);
-
   return (
     <div className="mt-12 border-t border-rule pt-6 flex flex-wrap items-center gap-3">
       <Link href={editPath(tenant, slug)} className="btn">
@@ -102,9 +80,7 @@ export function ArticleActions({
         </Link>
       )}
       {hasSourceUrl && ownsOrContributes && <ReingestButton slug={slug} />}
-      {canCurate && inVault !== null && (
-        <SaveToVaultButton slug={slug} initiallyInVault={inVault} />
-      )}
+      {canCurate && <SaveToVaultButton slug={slug} />}
       {isOwner && <DeletePageButton slug={slug} />}
     </div>
   );

--- a/src/components/BrowseClient.tsx
+++ b/src/components/BrowseClient.tsx
@@ -7,13 +7,23 @@ import { formatRelativeTime } from "@/lib/format";
 import { commonsPath, pagePath, ownerToTenant } from "@/lib/links";
 import { Icon } from "@/components/folio/icons";
 import { Confidence, Mark } from "@/components/folio/primitives";
+import { RemoveFromVaultButton } from "@/components/RemoveFromVaultButton";
 
 type Sort = "recent" | "confidence" | "sources";
+
+interface VaultLite {
+  id: string;
+  name: string;
+  visibility: "public" | "private";
+}
 
 interface BrowseClientProps {
   pages: IndexEntry[];
   myHandle: string | null;
-  showingMine: boolean;
+  /** The active lens scope: `"all"` (Public) or `"vault:<id>"`. */
+  activeScope: string;
+  /** The signed-in user's own vaults — one lens pill each. */
+  myVaults: VaultLite[];
   discussionStats?: Record<string, { total: number; open: number }>;
 }
 
@@ -21,9 +31,12 @@ interface BrowseClientProps {
 function PageRow({
   page,
   discussion,
+  removeVaultId,
 }: {
   page: IndexEntry;
   discussion?: { total: number; open: number };
+  /** When set, render a per-row "Remove" to curate the page out of this vault. */
+  removeVaultId?: string;
 }) {
   const owner = page.owner && page.owner !== "system" ? page.owner : null;
   const agentOwned = !!owner && owner.includes("--");
@@ -39,7 +52,7 @@ function PageRow({
     : pagePath(ownerToTenant(page.owner), page.slug);
 
   return (
-    <li>
+    <li style={{ borderTop: "1px solid var(--rule)" }}>
       <Link
         href={href}
         style={{
@@ -47,8 +60,7 @@ function PageRow({
           gridTemplateColumns: "1fr auto",
           gap: 22,
           alignItems: "baseline",
-          padding: "22px 0",
-          borderTop: "1px solid var(--rule)",
+          padding: removeVaultId ? "22px 0 12px" : "22px 0",
           textDecoration: "none",
         }}
       >
@@ -124,6 +136,11 @@ function PageRow({
           </div>
         )}
       </Link>
+      {removeVaultId && (
+        <div className="row" style={{ paddingBottom: 18 }}>
+          <RemoveFromVaultButton slug={page.slug} vaultId={removeVaultId} />
+        </div>
+      )}
     </li>
   );
 }
@@ -172,9 +189,20 @@ function FilterRow({
 export function BrowseClient({
   pages,
   myHandle,
-  showingMine,
+  activeScope,
+  myVaults,
   discussionStats,
 }: BrowseClientProps) {
+  // The active vault id (if the lens is a vault scope) and whether it's one of
+  // the viewer's OWN vaults — only then do rows get a per-row Remove control.
+  const activeVaultId = activeScope.startsWith("vault:")
+    ? activeScope.slice("vault:".length)
+    : null;
+  const activeVault = activeVaultId
+    ? myVaults.find((v) => v.id === activeVaultId)
+    : null;
+  const ownVaultLens = activeVault ?? null;
+
   const [q, setQ] = useState("");
   const [sort, setSort] = useState<Sort>("recent");
   const [tag, setTag] = useState<string | null>(null);
@@ -208,7 +236,7 @@ export function BrowseClient({
     return r;
   }, [pages, q, sort, tag]);
 
-  // Lens links switch the All/Mine scope only (a server navigation that
+  // Lens links switch the Public/vault scope only (a server navigation that
   // re-fetches the page set). The active topic is local UI state, so it
   // intentionally resets when the scope changes.
   const lensHref = (scope: string) =>
@@ -218,7 +246,9 @@ export function BrowseClient({
     <div className="fade">
       <section className="shell" style={{ paddingTop: 64 }}>
         <p className="fmark" style={{ marginBottom: 20 }}>
-          {showingMine ? "your pages · private + public" : "the commons · public"}
+          {activeVault
+            ? `vault · ${activeVault.name}`
+            : "the commons · public"}
         </p>
         <div
           className="browse-head"
@@ -317,8 +347,12 @@ export function BrowseClient({
               <span className="fmark">lens</span>
               <div className="row" style={{ gap: 6, flexWrap: "wrap" }}>
                 {[
-                  { scope: "all", label: "All", active: !showingMine },
-                  { scope: "mine", label: "Mine", active: showingMine },
+                  { scope: "all", label: "Public", active: !activeVaultId },
+                  ...myVaults.map((v) => ({
+                    scope: `vault:${v.id}`,
+                    label: v.name,
+                    active: activeVaultId === v.id,
+                  })),
                 ].map((o) => (
                   <Link
                     key={o.scope}
@@ -418,6 +452,7 @@ export function BrowseClient({
                   key={p.slug}
                   page={p}
                   discussion={discussionStats?.[p.slug]}
+                  removeVaultId={ownVaultLens ? ownVaultLens.id : undefined}
                 />
               ))}
             </ul>

--- a/src/components/RemoveFromVaultButton.tsx
+++ b/src/components/RemoveFromVaultButton.tsx
@@ -5,15 +5,20 @@ import { useRouter } from "next/navigation";
 
 interface RemoveFromVaultButtonProps {
   slug: string;
+  /** The vault to remove the reference from (id = `<ownerTenant>--<nameSlug>`). */
+  vaultId: string;
 }
 
 /**
- * Remove a curated commons reference from your vault — the inverse of
- * {@link SaveToVaultButton}, scoped to the owner's own management surface
- * (`/vault`). Removing drops the *reference* only; the underlying commons page
- * is untouched. The server re-checks ownership of the vault on the request.
+ * Remove a curated commons reference from a specific vault — the inverse of the
+ * vault picker, used to curate-out from the lens view (`/wiki?scope=vault:<id>`).
+ * Removing drops the *reference* only; the underlying commons page is untouched.
+ * The server re-checks ownership of the vault on the request.
  */
-export function RemoveFromVaultButton({ slug }: RemoveFromVaultButtonProps) {
+export function RemoveFromVaultButton({
+  slug,
+  vaultId,
+}: RemoveFromVaultButtonProps) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +27,7 @@ export function RemoveFromVaultButton({ slug }: RemoveFromVaultButtonProps) {
     setBusy(true);
     setError(null);
     try {
-      const res = await fetch("/api/vault", {
+      const res = await fetch(`/api/vaults/${vaultId}/pages`, {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ slug }),
@@ -47,7 +52,7 @@ export function RemoveFromVaultButton({ slug }: RemoveFromVaultButtonProps) {
         disabled={busy}
         className="btn ghost"
         style={{ opacity: busy ? 0.5 : 1 }}
-        title="Remove this curated reference from your vault"
+        title="Remove this reference from the vault"
       >
         {busy ? "Removing…" : "Remove"}
       </button>

--- a/src/components/SaveToVaultButton.tsx
+++ b/src/components/SaveToVaultButton.tsx
@@ -1,35 +1,90 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Icon } from "@/components/folio/icons";
 
 interface SaveToVaultButtonProps {
   slug: string;
-  /** Whether this page is already curated into the viewer's vault. */
-  initiallyInVault: boolean;
+}
+
+interface VaultLite {
+  id: string;
+  name: string;
+  visibility: "public" | "private";
 }
 
 /**
- * Curate / uncurate a commons page into your vault — a personal reference lens
- * over the commons. "Curate" adds a *reference*, not a copy: the page stays a
- * single collective commons page; your vault just points at it (always live).
- * Rendered only to signed-in viewers on commons (public, non-agent) pages; the
- * server re-checks both on the request.
+ * Save a commons page to one of your vaults — a personal reference lens over the
+ * commons. "Saving" adds a *reference*, not a copy: the page stays a single
+ * collective commons page; your vault just points at it (always live).
+ *
+ * A "Save to vault ▾" button opens a Folio popover that fetches the viewer's
+ * vaults (`GET /api/vaults?slug=`) and shows a checkbox per vault (checked = the
+ * page is already referenced). Toggling a checkbox POSTs/DELETEs the membership
+ * (`/api/vaults/[id]/pages`); an inline "+ New vault" creates one and adds the
+ * page. Rendered only to signed-in viewers on commons pages; the server
+ * re-checks both on every request.
  */
-export function SaveToVaultButton({
-  slug,
-  initiallyInVault,
-}: SaveToVaultButtonProps) {
-  const router = useRouter();
-  const [inVault, setInVault] = useState(initiallyInVault);
-  const [busy, setBusy] = useState(false);
+export function SaveToVaultButton({ slug }: SaveToVaultButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [vaults, setVaults] = useState<VaultLite[]>([]);
+  const [containing, setContaining] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [newName, setNewName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const wrapRef = useRef<HTMLSpanElement>(null);
 
-  async function toggle() {
-    setBusy(true);
+  const load = useCallback(async () => {
+    setLoading(true);
     setError(null);
     try {
-      const res = await fetch("/api/vault", {
+      const res = await fetch(`/api/vaults?slug=${encodeURIComponent(slug)}`);
+      if (!res.ok) throw new Error(`request failed (${res.status})`);
+      const data = (await res.json()) as {
+        vaults?: VaultLite[];
+        containing?: string[];
+      };
+      setVaults(data.vaults ?? []);
+      setContaining(new Set(data.containing ?? []));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load vaults");
+    } finally {
+      setLoading(false);
+    }
+  }, [slug]);
+
+  // Fetch vaults each time the popover opens (cheap; keeps state fresh).
+  useEffect(() => {
+    if (open) load();
+  }, [open, load]);
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  async function toggle(vaultId: string) {
+    const inVault = containing.has(vaultId);
+    setBusyId(vaultId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/vaults/${vaultId}/pages`, {
         method: inVault ? "DELETE" : "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ slug }),
@@ -38,32 +93,222 @@ export function SaveToVaultButton({
         const body = (await res.json().catch(() => ({}))) as { error?: string };
         throw new Error(body.error ?? `request failed (${res.status})`);
       }
-      setInVault(!inVault);
-      router.refresh();
+      setContaining((prev) => {
+        const next = new Set(prev);
+        if (inVault) next.delete(vaultId);
+        else next.add(vaultId);
+        return next;
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
-      setBusy(false);
+      setBusyId(null);
     }
   }
 
+  async function createAndAdd() {
+    if (!newName.trim()) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/vaults", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: newName }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `request failed (${res.status})`);
+      }
+      const { vault } = (await res.json()) as { vault: VaultLite };
+      // Add the page to the freshly created vault, then reflect locally.
+      const add = await fetch(`/api/vaults/${vault.id}/pages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug }),
+      });
+      if (!add.ok) {
+        const body = (await add.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `request failed (${add.status})`);
+      }
+      setVaults((prev) =>
+        prev.some((v) => v.id === vault.id) ? prev : [...prev, vault],
+      );
+      setContaining((prev) => new Set(prev).add(vault.id));
+      setNewName("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  const savedCount = containing.size;
+
   return (
-    <span className="inline-flex items-center gap-2">
+    <span ref={wrapRef} style={{ position: "relative", display: "inline-block" }}>
       <button
         type="button"
-        onClick={toggle}
-        disabled={busy}
-        className="rounded-md border border-foreground/20 px-4 py-2 text-sm font-medium text-foreground hover:bg-foreground/5 transition-colors disabled:opacity-50"
-        title={
-          inVault
-            ? "Remove this page from your vault"
-            : "Save this page to your vault (a live reference, not a copy)"
-        }
+        className="btn"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="true"
+        aria-expanded={open}
       >
-        {inVault ? "✓ In your vault" : "Save to vault"}
+        {savedCount > 0 ? `In ${savedCount} vault${savedCount === 1 ? "" : "s"}` : "Save to vault"}
+        <span style={{ marginLeft: 6, fontSize: 11, opacity: 0.7 }}>▾</span>
       </button>
-      {error && (
-        <span className="text-xs text-red-600 dark:text-red-400">{error}</span>
+
+      {open && (
+        <div
+          role="menu"
+          style={{
+            position: "absolute",
+            top: "calc(100% + 8px)",
+            left: 0,
+            zIndex: 30,
+            width: 280,
+            background: "var(--paper-2)",
+            border: "1px solid var(--rule-strong)",
+            borderRadius: 14,
+            boxShadow: "var(--shadow)",
+            padding: 14,
+          }}
+        >
+          <p className="fmark" style={{ marginBottom: 10 }}>
+            save to vault
+          </p>
+
+          {loading ? (
+            <p
+              className="receipt"
+              style={{ fontSize: 12.5, color: "var(--muted)", margin: 0 }}
+            >
+              Loading…
+            </p>
+          ) : vaults.length === 0 ? (
+            <p
+              className="receipt"
+              style={{ fontSize: 12.5, color: "var(--muted)", margin: 0 }}
+            >
+              No vaults yet — create one below.
+            </p>
+          ) : (
+            <ul
+              className="stack"
+              style={{ listStyle: "none", margin: 0, padding: 0, gap: 2 }}
+            >
+              {vaults.map((v) => {
+                const checked = containing.has(v.id);
+                return (
+                  <li key={v.id}>
+                    <button
+                      type="button"
+                      onClick={() => toggle(v.id)}
+                      disabled={busyId === v.id}
+                      className="row"
+                      style={{
+                        width: "100%",
+                        gap: 10,
+                        alignItems: "center",
+                        padding: "8px 8px",
+                        borderRadius: 8,
+                        border: "none",
+                        background: "transparent",
+                        cursor: "pointer",
+                        textAlign: "left",
+                        opacity: busyId === v.id ? 0.5 : 1,
+                      }}
+                    >
+                      <span
+                        aria-hidden
+                        style={{
+                          flex: "0 0 auto",
+                          width: 18,
+                          height: 18,
+                          borderRadius: 5,
+                          border: `1px solid ${checked ? "var(--accent)" : "var(--rule-strong)"}`,
+                          background: checked ? "var(--accent)" : "transparent",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          color: "var(--paper)",
+                        }}
+                      >
+                        {checked && <Icon.check width="12" height="12" />}
+                      </span>
+                      <span
+                        style={{
+                          flex: 1,
+                          minWidth: 0,
+                          fontSize: 14,
+                          color: "var(--ink)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {v.name}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          <div
+            className="stack"
+            style={{
+              gap: 8,
+              marginTop: 12,
+              paddingTop: 12,
+              borderTop: "1px solid var(--rule)",
+            }}
+          >
+            <input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  createAndAdd();
+                }
+              }}
+              placeholder="+ New vault"
+              style={{
+                width: "100%",
+                border: "1px solid var(--rule-strong)",
+                borderRadius: 10,
+                background: "var(--paper)",
+                padding: "9px 12px",
+                fontSize: 13.5,
+                color: "var(--ink)",
+                outline: "none",
+                fontFamily: "var(--font-read)",
+              }}
+            />
+            {newName.trim() && (
+              <button
+                type="button"
+                className="btn ghost"
+                onClick={createAndAdd}
+                disabled={creating}
+                style={{ alignSelf: "flex-start" }}
+              >
+                {creating ? "Creating…" : "Create & save"}
+              </button>
+            )}
+          </div>
+
+          {error && (
+            <p
+              className="receipt"
+              style={{ fontSize: 11.5, color: "var(--rust)", margin: "10px 0 0" }}
+            >
+              {error}
+            </p>
+          )}
+        </div>
       )}
     </span>
   );

--- a/src/components/VaultManager.tsx
+++ b/src/components/VaultManager.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Vault } from "@/lib/vault";
+
+interface VaultManagerProps {
+  vaults: Vault[];
+}
+
+/** Folio text input — mirrors the AgentManager / Ask console input field. */
+function FInput({
+  value,
+  onChange,
+  placeholder,
+  onEnter,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+  onEnter?: () => void;
+}) {
+  return (
+    <input
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && onEnter) {
+          e.preventDefault();
+          onEnter();
+        }
+      }}
+      placeholder={placeholder}
+      style={{
+        width: "100%",
+        border: "1px solid var(--rule-strong)",
+        borderRadius: 12,
+        background: "var(--paper-2)",
+        padding: "12px 16px",
+        fontSize: 15,
+        color: "var(--ink)",
+        outline: "none",
+        fontFamily: "var(--font-read)",
+      }}
+    />
+  );
+}
+
+function ErrorLine({ message }: { message: string }) {
+  return (
+    <span className="receipt" style={{ fontSize: 12, color: "var(--rust)" }}>
+      {message}
+    </span>
+  );
+}
+
+/** A visibility chip — public = accent, private = rust. */
+function VisibilityChip({ visibility }: { visibility: Vault["visibility"] }) {
+  const isPublic = visibility === "public";
+  return (
+    <span
+      className="receipt"
+      style={{
+        fontSize: 10.5,
+        textTransform: "uppercase",
+        letterSpacing: ".06em",
+        padding: "2px 8px",
+        borderRadius: 999,
+        background: isPublic ? "var(--accent-soft)" : "var(--rust-soft)",
+        color: isPublic ? "var(--accent)" : "var(--rust)",
+      }}
+    >
+      {visibility}
+    </span>
+  );
+}
+
+/** The "New vault" create form. */
+function CreateVault() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function create() {
+    if (!name.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/vaults", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `request failed (${res.status})`);
+      }
+      setName("");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        background: "var(--paper-2)",
+        border: "1px solid var(--rule)",
+        borderRadius: 16,
+        padding: 20,
+      }}
+    >
+      <div className="stack" style={{ gap: 12 }}>
+        <FInput
+          value={name}
+          onChange={setName}
+          placeholder="New vault name (e.g. Reading List)"
+          onEnter={create}
+        />
+        <div
+          className="row"
+          style={{ gap: 12, flexWrap: "wrap", alignItems: "baseline" }}
+        >
+          <button
+            type="button"
+            className="btn primary"
+            onClick={create}
+            disabled={busy || !name.trim()}
+          >
+            {busy ? "Creating…" : "New vault"}
+          </button>
+          <span
+            className="receipt"
+            style={{ fontSize: 11.5, color: "var(--faint)" }}
+          >
+            new vaults are public
+          </span>
+          {error && <ErrorLine message={error} />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** A single vault management card. */
+function VaultCard({ vault }: { vault: Vault }) {
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(vault.name);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function saveRename() {
+    if (!name.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/vaults/${vault.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `request failed (${res.status})`);
+      }
+      setEditing(false);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove() {
+    if (
+      !window.confirm(
+        `Delete vault "${vault.name}"? The referenced commons pages are untouched.`,
+      )
+    )
+      return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/vaults/${vault.id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `request failed (${res.status})`);
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+      setBusy(false);
+    }
+  }
+
+  const count = vault.slugs.length;
+
+  return (
+    <div
+      style={{
+        background: "var(--paper-2)",
+        border: "1px solid var(--rule)",
+        borderRadius: 16,
+        padding: 20,
+      }}
+    >
+      <div
+        className="row"
+        style={{ gap: 10, flexWrap: "wrap", alignItems: "baseline" }}
+      >
+        <h3
+          style={{
+            margin: 0,
+            fontSize: 19,
+            fontWeight: 600,
+            letterSpacing: "-.02em",
+            color: "var(--ink)",
+          }}
+        >
+          {vault.name}
+        </h3>
+        <VisibilityChip visibility={vault.visibility} />
+        <span
+          className="receipt"
+          style={{ fontSize: 11.5, color: "var(--faint)" }}
+        >
+          {count} {count === 1 ? "page" : "pages"}
+        </span>
+      </div>
+
+      <div className="row" style={{ gap: 6, flexWrap: "wrap", marginTop: 16 }}>
+        <Link className="btn ghost" href={`/wiki?scope=vault:${vault.id}`}>
+          View
+        </Link>
+        <button
+          type="button"
+          className="btn ghost"
+          onClick={() => {
+            setName(vault.name);
+            setEditing((e) => !e);
+          }}
+        >
+          {editing ? "Cancel" : "Rename"}
+        </button>
+        <button
+          type="button"
+          className="btn ghost"
+          onClick={remove}
+          disabled={busy}
+          style={{ color: "var(--rust)" }}
+        >
+          Delete
+        </button>
+        {error && <ErrorLine message={error} />}
+      </div>
+
+      {editing && (
+        <div className="stack" style={{ gap: 12, marginTop: 16 }}>
+          <FInput
+            value={name}
+            onChange={setName}
+            placeholder="Vault name"
+            onEnter={saveRename}
+          />
+          <div className="row" style={{ gap: 8 }}>
+            <button
+              type="button"
+              className="btn primary"
+              onClick={saveRename}
+              disabled={busy || !name.trim()}
+            >
+              {busy ? "Saving…" : "Save changes"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The owner's vault management surface on `/vault`: a create form plus a card
+ * per vault with view / rename / delete. All actions hit the `/api/vaults`
+ * endpoints and refresh the server tree on success. (V1: created vaults are
+ * public — no visibility selector yet.)
+ */
+export function VaultManager({ vaults }: VaultManagerProps) {
+  return (
+    <div className="stack" style={{ gap: 16 }}>
+      <CreateVault />
+      {vaults.length === 0 ? (
+        <p style={{ margin: 0, color: "var(--muted)", fontSize: 14.5 }}>
+          No vaults yet. Create one above to start curating a reference lens over
+          the commons.
+        </p>
+      ) : (
+        vaults.map((v) => <VaultCard key={v.id} vault={v} />)
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -30,6 +30,7 @@ import {
 import type { SearchScope } from "../search";
 import type { Principal } from "../auth";
 import { registerAgent, ensureAgentsDir } from "../agents";
+import { createVault, addToVault, vaultIdFor } from "../vault";
 import { serializeFrontmatter } from "../frontmatter";
 import { isAgentScopedType } from "../wiki";
 import type { AgentProfile } from "../types";
@@ -784,6 +785,31 @@ describe("resolveScope", () => {
 
   it("returns null for an empty owner handle", async () => {
     expect(await resolveScope("owner:")).toBeNull();
+  });
+
+  it("resolves 'vault:<id>' for a PUBLIC vault to its member slugs", async () => {
+    await ensureDirectories();
+    const vault = await createVault("alice", "Reading List", "public");
+    await addToVault(vault.id, "page-a");
+    await addToVault(vault.id, "page-b");
+
+    const result = await resolveScope(`vault:${vault.id}`);
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe(vault.id);
+    expect(result!.slugs).toEqual(["page-a", "page-b"]);
+  });
+
+  it("returns null for a PRIVATE vault (never exposed via scope)", async () => {
+    await ensureDirectories();
+    const vault = await createVault("alice", "Secret", "private");
+    await addToVault(vault.id, "page-a");
+
+    expect(await resolveScope(`vault:${vault.id}`)).toBeNull();
+  });
+
+  it("returns null for a vault that does not exist", async () => {
+    await ensureDirectories();
+    expect(await resolveScope(`vault:${vaultIdFor("alice", "ghost")}`)).toBeNull();
   });
 
   it("combines all three page arrays from agent profile", async () => {

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -19,6 +19,7 @@ import { canReadFrontmatter } from "./authz";
 import type { Principal } from "./auth";
 import { isEnoent } from "./errors";
 import { getAgent, resolveAgentPages } from "./agents";
+import { getVault } from "./vault";
 import { getStorage } from "./storage";
 import { getOwnerIndex } from "./owner-index";
 import { getBacklinkIndex } from "./backlink-index";
@@ -657,6 +658,19 @@ export async function resolveScope(
     const handle = ownerMatch[1]?.trim();
     if (!handle) return null;
     return { agentId: handle, slugs: await slugsForOwner(handle) };
+  }
+
+  // vault:<id> — a curated reference lens over the commons. Only PUBLIC vaults
+  // resolve via scope (a public view filter); PRIVATE vaults are owner-only
+  // (V2) and return null here so they're never exposed through a scope param.
+  const vaultMatch = scopeParam.match(/^vault:(.+)$/);
+  if (vaultMatch) {
+    const vaultId = vaultMatch[1]?.trim();
+    if (!vaultId) return null;
+    const vault = await getVault(vaultId);
+    if (!vault) return null;
+    if (vault.visibility !== "public") return null;
+    return { agentId: vaultId, slugs: vault.slugs };
   }
 
   const match = scopeParam.match(/^agent:(.+)$/);


### PR DESCRIPTION
Builds on the merged data model (#404).

**Step 2 — UI:** `/vault` is now a vault **list + create** (rename/delete each, visibility chip, page count, View → `?scope=vault:<id>`); agents moved to **`/vault/agents`**; `SaveToVaultButton` is a **vault picker** (checkbox per vault + inline create) wired to `/api/vaults/[id]/pages`.

**Step 3 — lens:** `resolveScope` adds `vault:<id>` (**public vaults only**; private → null, never exposed). Browse/Query/Graph replace **All|Mine** with **Public + your vaults**; default scope = Public (Mine dropped); per-row **Remove** when viewing your own vault.

Owner-gating unchanged (the `/api/vaults*` routes 403 non-owners); private vaults never resolve via scope. Build clean; 2634 tests. Folio-styled throughout.

Remaining (follow-up): Step 4 (MCP vault tools) + retire the old single-vault `/api/vault` + `QueryResultPanel`/`/u` curated section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)