### PR TITLE
Rebuild the commons index in the derived-index sweep

### DIFF
--- a/src/lib/maintenance.ts
+++ b/src/lib/maintenance.ts
@@ -197,6 +197,10 @@ export async function rebuildDerivedIndexes(): Promise<
     // Pages first: listWikiPages' fast path reads this, so the rebuilds below
     // (which list pages) benefit immediately once it's fresh.
     ["pages", async () => (await import("./page-index")).rebuildPageIndex()],
+    // Commons next: it lists pages (via the now-fresh page index) and powers the
+    // homepage's pageCount / commons feed. Without it in the rebuild set, a stale
+    // commons index survives a content wipe and the home keeps showing old pages.
+    ["commons", async () => (await import("./commons")).rebuildCommonsIndex()],
     ["owner-slugs", async () => (await import("./owner-index")).rebuildOwnerIndex()],
     ["backlinks", async () => (await import("./backlink-index")).rebuildBacklinkIndex()],
     ["discuss-stats", async () => (await import("./discuss-stats-index")).rebuildDiscussStatsIndex()],


### PR DESCRIPTION
## Problem
On the wiped/empty commons the home Ask console still showed the hardcoded example-question chips (and the old pages). Root cause was **not** the frontend gate — it was a stale index.

`listCommonsPages()` returns `_idx:commons` when non-empty and only falls back to a live scan when it's empty. But `rebuildDerivedIndexes()` (run by `/api/tasks/scan` and the daily cron) rebuilds `pages, owner-slugs, backlinks, discuss-stats, contributors, recent` — **never `commons`**. So a content wipe deleted the pages but left `_idx:commons` holding the pre-wipe list forever, and the home read `pageCount > 0`.

## Fix
Add `commons` to the rebuild set, immediately after `pages` (it lists pages via the now-fresh page index). `rebuildCommonsIndex()` unconditionally overwrites with the current result, so it self-heals to empty when there's no content. An empty commons index then correctly falls back to the (also empty) scan.

## Test plan
- `pnpm build` clean
- `pnpm test` — 2618 passed
- After deploy, re-run `/api/tasks/scan`: the commons index rebuilds to empty → `pageCount = 0` → chips and stale pages gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)