### PR TITLE
Hide the whole home Ask console on an empty commons

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -88,10 +88,13 @@ export default async function Home() {
         </p>
       </section>
 
-      {/* Ask console — the star */}
-      <section className="shell" style={{ marginTop: 38, maxWidth: 880 }}>
-        <HomeAsk showExamples={pageCount > 0} />
-      </section>
+      {/* Ask console — the star. Hidden on an empty commons: there's nothing to
+          consult yet, so we lead with onboarding instead. */}
+      {pageCount > 0 && (
+        <section className="shell" style={{ marginTop: 38, maxWidth: 880 }}>
+          <HomeAsk />
+        </section>
+      )}
 
       {pageCount === 0 ? (
         <section className="shell" style={{ marginTop: 64 }}>

--- a/src/components/HomeAsk.tsx
+++ b/src/components/HomeAsk.tsx
@@ -23,7 +23,7 @@ const DEMO_USED_KEY = "yopedia_demo_used";
  * — no LLM cost, served from /api/query/demo) with a simulated stream; the next
  * question enforces sign-in.
  */
-export function HomeAsk({ showExamples = true }: { showExamples?: boolean }) {
+export function HomeAsk() {
   const { isSignedIn } = useUser();
   const { openSignIn } = useClerk();
   const { question, setQuestion, result, streaming, error, submit, isProcessing } =
@@ -175,33 +175,30 @@ export function HomeAsk({ showExamples = true }: { showExamples?: boolean }) {
               flexWrap: "wrap",
             }}
           >
-            {/* Example questions reference existing pages — hide them on an empty
-                commons (they'd ask about content that isn't there yet). */}
             <div
               className="row"
               style={{ gap: 8, flexWrap: "wrap", flex: "1 1 320px", minWidth: 0 }}
             >
-              {showExamples &&
-                EXAMPLES.map((q) => (
-                  <button
-                    type="button"
-                    key={q}
-                    onClick={() => onChip(q)}
-                    disabled={guestBusy}
-                    className="receipt folio-chip disabled:opacity-50"
-                    style={{
-                      fontSize: 11.5,
-                      color: "var(--muted)",
-                      background: "transparent",
-                      whiteSpace: "nowrap",
-                      border: "1px solid var(--rule)",
-                      borderRadius: 999,
-                      padding: "5px 11px",
-                    }}
-                  >
-                    {q}
-                  </button>
-                ))}
+              {EXAMPLES.map((q) => (
+                <button
+                  type="button"
+                  key={q}
+                  onClick={() => onChip(q)}
+                  disabled={guestBusy}
+                  className="receipt folio-chip disabled:opacity-50"
+                  style={{
+                    fontSize: 11.5,
+                    color: "var(--muted)",
+                    background: "transparent",
+                    whiteSpace: "nowrap",
+                    border: "1px solid var(--rule)",
+                    borderRadius: 999,
+                    padding: "5px 11px",
+                  }}
+                >
+                  {q}
+                </button>
+              ))}
             </div>
             {isSignedIn ? (
               <button
@@ -229,7 +226,7 @@ export function HomeAsk({ showExamples = true }: { showExamples?: boolean }) {
         </p>
       </form>
 
-      {showExamples && !isSignedIn && !demo && !demoLoading && !demoError && (
+      {!isSignedIn && !demo && !demoLoading && !demoError && (
         <p className="mt-2 text-xs text-muted">
           Try a sample question for a taste — sign in to ask your own.
         </p>


### PR DESCRIPTION
## What
On an empty commons, hide the entire home **Ask** console (not just the example chips). With nothing ingested there's nothing to consult, so the home leads with the onboarding wizard instead.

- `src/app/page.tsx` — render the Ask `<section>` only when `pageCount > 0`.
- `src/components/HomeAsk.tsx` — revert the now-redundant `showExamples` prop (the component only mounts when content exists).
- `/query` keeps its own example-chip gating — that console must stay since it's the dedicated ask page.

Depends on the commons-index rebuild fix (#409) for `pageCount` to read 0 correctly on a wiped commons.

## Test plan
- `pnpm build` clean
- `pnpm test` — 2618 passed
- Empty commons → home shows hero + onboarding, no Ask console. With content → Ask console returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)