### PR TITLE
Redesign /query to the centered Ask-console layout

### DIFF
--- a/src/app/query/page.tsx
+++ b/src/app/query/page.tsx
@@ -176,7 +176,7 @@ export default function QueryPage() {
   }
 
   return (
-    <main className="mx-auto max-w-4xl px-6" style={{ paddingTop: 56, paddingBottom: 80 }}>
+    <main className="mx-auto max-w-4xl px-6" style={{ paddingTop: 64, paddingBottom: 88 }}>
       <p className="fmark" style={{ marginBottom: 18 }}>
         ask the accumulated brain
       </p>
@@ -254,9 +254,9 @@ export default function QueryPage() {
         )}
       </div>
 
-      <div className="mt-8 flex flex-col lg:flex-row gap-8">
-        {/* Main query area */}
-        <div className="flex-1 min-w-0">
+      {/* Centered single column (the right-hand history sidebar moved below). */}
+      <div className="mt-7">
+        <div>
           <form onSubmit={submit}>
             <div
               style={{
@@ -345,10 +345,27 @@ export default function QueryPage() {
               </div>
             </div>
 
+            {/* Why an answer here is trustworthy — grounded, cited, scored. */}
+            <p
+              style={{
+                fontFamily: "var(--font-read)",
+                fontStyle: "italic",
+                fontSize: 21,
+                lineHeight: 1.55,
+                color: "var(--ink-2)",
+                maxWidth: "62ch",
+                margin: "22px 4px 0",
+              }}
+            >
+              Unlike a chat, an answer here is grounded in the commons — it cites
+              the pages it stands on, with each page&apos;s confidence shown, so
+              you can trace and trust it.
+            </p>
+
             {/* Answer format */}
             <fieldset
               className="row"
-              style={{ gap: 8, marginTop: 14, flexWrap: "wrap" }}
+              style={{ gap: 8, marginTop: 18, flexWrap: "wrap" }}
             >
               <legend className="sr-only">Answer format</legend>
               <span className="fmark" style={{ marginRight: 4 }}>
@@ -398,13 +415,15 @@ export default function QueryPage() {
           )}
         </div>
 
-        {/* History sidebar */}
-        <QueryHistorySidebar
-          history={history}
-          loading={historyLoading}
-          currentId={currentHistoryId}
-          onSelect={loadHistoryEntry}
-        />
+        {/* Recent queries — below the answer (was a right-hand sidebar). */}
+        <div style={{ marginTop: 48 }}>
+          <QueryHistorySidebar
+            history={history}
+            loading={historyLoading}
+            currentId={currentHistoryId}
+            onSelect={loadHistoryEntry}
+          />
+        </div>
       </div>
     </main>
   );

--- a/src/components/QueryHistorySidebar.tsx
+++ b/src/components/QueryHistorySidebar.tsx
@@ -25,10 +25,10 @@ function truncate(text: string, maxLen: number): string {
 
 export function QueryHistorySidebar({ history, loading, currentId, onSelect }: Props) {
   return (
-    <aside className="lg:w-72 shrink-0">
-      <h2 className="text-sm font-semibold text-foreground/60 uppercase tracking-wide mb-3">
-        Recent Queries
-      </h2>
+    <aside>
+      <p className="fmark" style={{ marginBottom: 14 }}>
+        recent queries
+      </p>
       {loading ? (
         <p className="text-xs text-foreground/40">Loading…</p>
       ) : history.length === 0 ? (
@@ -36,7 +36,7 @@ export function QueryHistorySidebar({ history, loading, currentId, onSelect }: P
           No queries yet. Ask something!
         </p>
       ) : (
-        <ul className="space-y-2">
+        <ul className="grid gap-2 sm:grid-cols-2">
           {history.map((entry) => (
             <li key={entry.id}>
               <button


### PR DESCRIPTION
## What
Aligns `/query` with the homepage Ask-console design: a centered single column with the `— ask the accumulated brain` label, the Folio Ask card, and a large italic serif descriptor below it.

- **Layout:** dropped the two-column (card + right-hand history sidebar) layout for a centered single column matching the mockup.
- **New:** italic serif descriptor under the card — "Unlike a chat, an answer here is grounded in the commons — it cites the pages it stands on, with each page's confidence shown, so you can trace and trust it."
- **History:** moved below the answer, rendered as a 2-column grid under a `recent queries` folio label (was a fixed-width right sidebar).
- **Kept:** the format options (prose / table / slides) and the Public + your-vaults scope selector (same as Browse), per request — neither is in the mockup but both are preserved.

## Test plan
- `pnpm build` clean
- `pnpm test` — 2618 passed
- `/query` shows the centered card + descriptor; format + scope controls work; history lists below results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)