### PR TITLE
Render the home per request (force-dynamic)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,13 @@ const HOW_IT_WORKS: [string, string][] = [
   ["Ask", "Query the commons; answers cite the pages they stand on."],
 ];
 
+// Render per request, not at build time. The home's pageCount / trail /
+// contributors reflect the commons live, so a build-time static snapshot would
+// keep showing the empty-state (onboarding, no Ask console) until the next
+// deploy even after content is ingested. It's still fast — every read takes the
+// O(1) anonymous KV-index fast-path below.
+export const dynamic = "force-dynamic";
+
 export default async function Home() {
   // The homepage is a PUBLIC landing surface (no per-user content; the nav
   // handles auth client-side). Rendering it anonymously — never calling


### PR DESCRIPTION
## Why
The home was `○ Static` — prerendered at build time, so `pageCount` / trail / contributors were a deploy-time snapshot, served with `cache-control: s-maxage=31536000`. After ingesting content the front page would keep showing the empty-state (onboarding + hidden Ask console) until the next deploy, even though `/wiki` (dynamic) already showed the new pages.

## What
`export const dynamic = "force-dynamic"` on `src/app/page.tsx` → the home renders per request from the commons (now `ƒ`). Still fast: every read takes the O(1) anonymous KV-index fast-path. `/query` and `/ingest` stay static (forms, no live-data dependency).

## Test plan
- `pnpm build` — home flips from `○` to `ƒ`
- `pnpm test` — 2622 passed
- After re-ingest, the home immediately reflects content (Ask console returns, onboarding gone) with no redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)