### PR TITLE
Article + ingest UI tweaks

### DIFF
--- a/src/components/ArticleActions.tsx
+++ b/src/components/ArticleActions.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useUser } from "@clerk/nextjs";
-import { editPath, rawPath } from "@/lib/links";
+import { rawPath } from "@/lib/links";
 import { ReingestButton } from "@/components/ReingestButton";
 import { DeletePageButton } from "@/components/DeletePageButton";
 import { SaveToVaultButton } from "@/components/SaveToVaultButton";
@@ -28,11 +28,13 @@ interface ArticleActionsProps {
  * context-free article for everyone (cacheable); this client island reads the
  * Clerk session and shows only the actions the signed-in viewer is allowed:
  *
- *   - Edit            — always (the edit route enforces auth).
- *   - View source     — when a raw source exists.
+ *   - View raw        — when a raw source exists.
  *   - Reingest        — owner/contributor, when a source URL exists.
  *   - Delete          — owner only.
  *   - Save to vault    — signed-in non-owner/contributor on a commons page.
+ *
+ * There is intentionally NO human "Edit page" button: in the commons-first
+ * model pages are maintained by agents (via API/MCP), not hand-edited here.
  *
  * These are CONVENIENCE gates only; every underlying route re-authorizes the
  * request server-side, so a stale/forged client never bypasses the real check.
@@ -71,12 +73,9 @@ export function ArticleActions({
 
   return (
     <div className="mt-12 border-t border-rule pt-6 flex flex-wrap items-center gap-3">
-      <Link href={editPath(tenant, slug)} className="btn">
-        Edit page
-      </Link>
       {hasRawSource && (
         <Link href={rawPath(tenant, slug)} className="btn">
-          View source
+          View raw
         </Link>
       )}
       {hasSourceUrl && ownsOrContributes && <ReingestButton slug={slug} />}

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -81,12 +81,14 @@ function TableOfContents({
       <h2 className="text-xs font-medium text-muted uppercase tracking-wide mb-2">
         On this page
       </h2>
-      <ul className="space-y-1.5 border-l border-border">
+      {/* No left-border track here — the marginalia rail (the aside's borderLeft)
+          is the single sidebar line; a second one alongside the TOC was redundant. */}
+      <ul className="space-y-1.5">
         {items.map((it) => (
           <li key={it.id}>
             <a
               href={`#${it.id}`}
-              className={`block border-l border-transparent -ml-px py-0.5 text-muted hover:border-accent hover:text-accent transition-colors ${
+              className={`block py-0.5 text-muted hover:text-accent transition-colors ${
                 it.level === 3 ? "pl-6" : "pl-3"
               }`}
             >

--- a/src/components/IngestReview.tsx
+++ b/src/components/IngestReview.tsx
@@ -68,7 +68,6 @@ export function IngestReview({ preview, loading, onApprove, onCancel, error }: P
   const [showDraft, setShowDraft] = useState(false);
   const meta = preview.meta;
   const title = meta?.title || preview.title || preview.slug;
-  const deduped = meta?.deduped ?? false;
 
   return (
     <div>
@@ -183,53 +182,13 @@ export function IngestReview({ preview, loading, onApprove, onCancel, error }: P
         )}
       </div>
 
-      {/* Canonical-page / merge note */}
-      <div
-        className="row"
-        style={{
-          gap: 12,
-          alignItems: "flex-start",
-          background: "var(--paper-3)",
-          borderRadius: 12,
-          padding: "14px 18px",
-          margin: "16px 0 0",
-        }}
-      >
-        <span
-          aria-hidden
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: 999,
-            border: "1.5px solid var(--muted)",
-            marginTop: 6,
-            flexShrink: 0,
-          }}
-        />
-        <p style={{ fontSize: 13.5, color: "var(--ink-2)", margin: 0, lineHeight: 1.55 }}>
-          One canonical page per source.{" "}
-          {deduped ? (
-            <>
-              This source already lives in the commons, so it will{" "}
-              <strong>merge into{meta?.existingTitle ? ` “${meta.existingTitle}”` : " the existing page"}</strong>{" "}
-              — kept live, never forked.
-            </>
-          ) : (
-            <>
-              This source is new to the commons, so a fresh page will be created.
-              You&apos;ll be added as <strong>owner</strong>.
-            </>
-          )}
-        </p>
-      </div>
-
       {/* Inspect the full draft before publishing */}
       <button
         type="button"
         onClick={() => setShowDraft((v) => !v)}
         className="receipt"
         style={{
-          marginTop: 16,
+          marginTop: 20,
           fontSize: 12.5,
           color: "var(--muted)",
           background: "transparent",


### PR DESCRIPTION
Small UI corrections from review:

1. **Ingest review** — removed the "One canonical page per source. This source is new to the commons…" note box.
2. **Article TOC** — removed the TOC `<ul>`'s own `border-l` track so there's a single sidebar line (the marginalia rail), not two parallel lines beside "On this page". Hover affordance is now a text-color change.
3. **Article actions** — removed the human **Edit page** button. In the commons-first model pages are agent-maintained; humans don't hand-edit here. The edit route remains for agent/API use.
4. **Article actions** — renamed **View source** → **View raw** (it opens the raw ingested markdown; the actual source URL is in the sidebar's Sources section).

## Test plan
- `pnpm build` clean
- `pnpm test` — 2622 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)