### PR TITLE
Concept-derived slug + generic source-image salvage on ingest

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -110,7 +110,7 @@ export default async function Home() {
       ) : (
         <>
           {/* Receipts strip — proof of life, in mono */}
-          <section className="shell" style={{ marginTop: 28 }}>
+          <section className="shell" style={{ marginTop: 75 }}>
             <div
               className="row rise"
               style={{ gap: 0, flexWrap: "wrap", animationDelay: ".2s" }}

--- a/src/lib/__tests__/html-parse.test.ts
+++ b/src/lib/__tests__/html-parse.test.ts
@@ -4,6 +4,7 @@ import {
   htmlToMarkdown,
   extractTitle,
   extractWithReadability,
+  extractImageUrls,
 } from "../html-parse";
 
 // ---------------------------------------------------------------------------
@@ -215,6 +216,58 @@ describe("extractWithReadability — images", () => {
     const md = htmlToMarkdown(result!.htmlContent);
     expect(md).toContain("![");
     expect(md).toContain("https://example.com/photo.jpg");
+  });
+});
+
+describe("extractImageUrls", () => {
+  it("captures lazy-loaded (data-src), srcset, and Next-style empty-alt SVG figures", () => {
+    const html = `<html><body><article>
+      <img alt="" loading="lazy" width="2554" height="2554" src="https://cdn.example.com/diagram.svg"/>
+      <img data-src="https://cdn.example.com/lazy.png" alt="lazy"/>
+      <img srcset="https://cdn.example.com/small.png 480w, https://cdn.example.com/big.png 1080w"/>
+    </article></body></html>`;
+    const urls = extractImageUrls(html);
+    expect(urls).toContain("https://cdn.example.com/diagram.svg");
+    expect(urls).toContain("https://cdn.example.com/lazy.png");
+    // srcset → first candidate URL only
+    expect(urls).toContain("https://cdn.example.com/small.png");
+    expect(urls).not.toContain("https://cdn.example.com/big.png");
+  });
+
+  it("reads <picture>/<figure> <source srcset>", () => {
+    const html = `<figure><picture>
+      <source srcset="https://cdn.example.com/fig.avif 1x"/>
+      <img src="https://cdn.example.com/fallback.png"/>
+    </picture></figure>`;
+    const urls = extractImageUrls(html);
+    expect(urls).toContain("https://cdn.example.com/fig.avif");
+    expect(urls).toContain("https://cdn.example.com/fallback.png");
+  });
+
+  it("drops chrome, icons/logos, tiny images, data URIs, and relative URLs; dedupes", () => {
+    const html = `<html><body>
+      <header><img src="https://x.com/logo.png" width="40" height="40"/></header>
+      <nav><img src="https://x.com/nav-sprite.svg"/></nav>
+      <article>
+        <img src="https://x.com/favicon-icon.png"/>
+        <img src="https://x.com/tiny.png" width="24" height="24"/>
+        <img src="data:image/png;base64,AAAA"/>
+        <img src="/relative/path.png"/>
+        <img src="https://x.com/real-diagram.png"/>
+        <img src="https://x.com/real-diagram.png"/>
+      </article>
+      <footer><img src="https://x.com/footer.png"/></footer>
+    </body></html>`;
+    const urls = extractImageUrls(html);
+    expect(urls).toEqual(["https://x.com/real-diagram.png"]);
+  });
+
+  it("respects the max cap", () => {
+    const imgs = Array.from(
+      { length: 20 },
+      (_, i) => `<img src="https://x.com/img${i}.png"/>`,
+    ).join("");
+    expect(extractImageUrls(`<article>${imgs}</article>`, 5)).toHaveLength(5);
   });
 });
 

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -21,6 +21,7 @@ import {
   htmlToMarkdown,
   extractTitle,
   extractWithReadability,
+  extractImageUrls,
 } from "./html-parse";
 import { validateUrlSafety } from "./url-safety";
 import { getStorage } from "./storage";
@@ -266,6 +267,18 @@ export async function fetchUrlContent(
   // Truncate very long extracted text to a reasonable size for LLM processing
   if (content.length > MAX_CONTENT_LENGTH) {
     content = content.slice(0, MAX_CONTENT_LENGTH) + "\n\n[Content truncated]";
+  }
+
+  // Readability prunes figures that look decorative (lazy-loaded, empty alt, SVG
+  // diagrams), so technical posts often lose their diagrams. Salvage image URLs
+  // straight from the source DOM and reference any the extracted content is
+  // missing — downloadImages() then localizes them (or keeps the URL). Appended
+  // AFTER truncation so a long article never drops its figures. HTML path only.
+  if (mimeType !== "text/plain" && mimeType !== "text/markdown") {
+    const salvaged = extractImageUrls(body).filter((u) => !content.includes(u));
+    if (salvaged.length > 0) {
+      content += "\n\n" + salvaged.map((u) => `![](${u})`).join("\n\n");
+    }
   }
 
   return { title, content };

--- a/src/lib/html-parse.ts
+++ b/src/lib/html-parse.ts
@@ -243,6 +243,57 @@ export function extractTitle(html: string): string {
  * `htmlContent` (sanitised HTML that Readability produces, which preserves
  * images, links, and formatting).
  */
+/**
+ * Salvage plausible *content* image URLs from raw HTML — a generic fallback for
+ * figures Readability drops (lazy-loaded, empty-alt, `<picture>`/`<source>`, SVG
+ * diagrams). Parses with linkedom (the same DOM lib Readability uses here) rather
+ * than regex, so it's robust to attribute order/quoting on any site. Strips
+ * chrome (nav/header/footer/script/style/aside) so we don't grab logos/sprites,
+ * skips data URIs + icon/logo/avatar URLs + tiny declared sizes, and dedupes.
+ * Absolute http(s) URLs only, capped at `max`.
+ */
+export function extractImageUrls(html: string, max = 12): string[] {
+  let document: ReturnType<typeof parseHTML>["document"];
+  try {
+    document = parseHTML(html).document;
+  } catch (err) {
+    logger.warn("ingest", "extractImageUrls parse failed:", err);
+    return [];
+  }
+  document
+    .querySelectorAll("script,style,nav,header,footer,noscript,aside")
+    .forEach((el) => el.remove());
+
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  const push = (u?: string | null) => {
+    const url = u?.trim();
+    if (!url || !/^https?:\/\//i.test(url)) return;
+    if (/(logo|sprite|icon|favicon|avatar|emoji)/i.test(url)) return;
+    if (seen.has(url)) return;
+    seen.add(url);
+    urls.push(url);
+  };
+  const firstSrcset = (s: string | null) =>
+    s?.split(",")[0]?.trim().split(/\s+/)[0] ?? null;
+
+  for (const img of Array.from(document.querySelectorAll("img"))) {
+    if (urls.length >= max) break;
+    const w = Number(img.getAttribute("width"));
+    const h = Number(img.getAttribute("height"));
+    if ((w && w < 80) || (h && h < 80)) continue; // icon-sized
+    push(img.getAttribute("src") || img.getAttribute("data-src"));
+    push(firstSrcset(img.getAttribute("srcset")));
+  }
+  for (const source of Array.from(
+    document.querySelectorAll("picture source, figure source"),
+  )) {
+    if (urls.length >= max) break;
+    push(firstSrcset(source.getAttribute("srcset")));
+  }
+  return urls.slice(0, max);
+}
+
 export function extractWithReadability(
   html: string,
 ): { title: string; textContent: string; htmlContent: string } | null {

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -450,7 +450,9 @@ function generateFallbackPage(title: string, content: string): string {
 function appendSourceImages(wikiBody: string, sourceContent: string): string {
   if (/^##\s+Images\s*$/m.test(wikiBody)) return wikiBody;
 
-  const re = /!\[([^\]]*)\]\((assets\/[^)\s]+)\)/g;
+  // Surface images the LLM dropped: both localized (assets/…) and ones kept as
+  // their original http(s) URL (download skipped/failed, e.g. salvaged figures).
+  const re = /!\[([^\]]*)\]\(((?:assets\/|https?:\/\/)[^)\s]+)\)/g;
   const seen = new Set<string>();
   const refs: { alt: string; ref: string }[] = [];
   let m: RegExpExecArray | null;
@@ -1191,6 +1193,25 @@ export async function ingest(
   // The LLM distills text and drops image refs, so deterministically append the
   // source's downloaded images as a trailing section — reliable, no LLM cost.
   wikiContent = appendSourceImages(wikiContent, content);
+
+  // Commit-from-preview carries no CONCEPT marker (preview stripped it), so the
+  // canonical slug would otherwise stay the source-TITLE slug even though the
+  // page H1 shows the synthesized concept — e.g. "Agentic systems" published at
+  // /wiki/building-effective-ai-agents. Re-derive slug + title from the body's
+  // first H1 so they match what the reader sees. Only when the concept slug is
+  // FREE — never clobber a different existing page (same-URL re-ingest already
+  // deduped before synthesis).
+  if (!isPreview && preGeneratedContent) {
+    const h1 = wikiContent.match(/^#\s+(.+?)\s*$/m)?.[1]?.trim();
+    const conceptSlug = h1 ? slugify(h1) : "";
+    if (h1 && conceptSlug && conceptSlug !== slug) {
+      const taken = await readWikiPageWithFrontmatter(conceptSlug);
+      if (!taken) {
+        slug = conceptSlug;
+        pageTitle = h1;
+      }
+    }
+  }
 
   // 2. Compute the index summary from the *raw* source so the index reflects
   // the original document, not the LLM's reformatting.


### PR DESCRIPTION
Addresses two issues from reviewing a published page ("Agentic systems" at `/wiki/building-effective-ai-agents`, no diagrams).

## 1. Slug now matches the concept
Commit-from-preview never re-derived the slug — the CONCEPT marker is stripped during preview, so the publish kept the **source title's** slug while the page H1 showed the synthesized concept. Now the commit re-derives slug + title from the body's first H1 **when that concept slug is free** (never clobbers a different existing page; same-URL re-ingest still dedupes before synthesis). New ingests via the UI get concept slugs (e.g. `agentic-systems`). Existing pages keep their slug until re-ingested.

## 2. Source diagrams are captured (generic, any site)
Readability prunes decorative-looking figures (lazy-loaded, empty-alt, `<picture>/<source>`, SVG diagrams) — that's why the Anthropic post's diagrams were lost. Fix is **generic**, not blog-specific, and uses the DOM library already in the repo (**linkedom**), not regex:
- `extractImageUrls(html)` parses the source DOM, collects content image URLs (`src` / `data-src` / `srcset` / `<source>`), strips chrome (nav/header/footer/aside), drops icon/logo/avatar URLs + tiny declared sizes + data URIs + relative URLs, dedupes, caps at 12.
- `fetchUrlContent` references any image the extracted content missed → `downloadImages` localizes them to `assets/` (or keeps the original URL on failure).
- `appendSourceImages` now surfaces original-URL images too, not just localized `assets/` ones — so a diagram referenced by URL still shows in the page's Images section.

## 3. Home stats strip top margin → 75px

## Test plan
- `pnpm build` clean; `pnpm test` — 2626 passed
- New `extractImageUrls` unit tests: lazy/`data-src`, `srcset` (first candidate), `<picture>/<source>`, chrome/icon/tiny/data-URI filtering, dedup, max cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)