### PR TITLE
Capture proxied/relative source images (Next.js /_next/image etc.)

### DIFF
--- a/src/lib/__tests__/html-parse.test.ts
+++ b/src/lib/__tests__/html-parse.test.ts
@@ -262,12 +262,24 @@ describe("extractImageUrls", () => {
     expect(urls).toEqual(["https://x.com/real-diagram.png"]);
   });
 
+  it("unwraps Next.js image-proxy URLs and resolves relative srcs against baseUrl", () => {
+    const html = `<article>
+      <img loading="lazy" width="2401" height="1000" src="/_next/image?url=https%3A%2F%2Fcdn.example.com%2Fimages%2Fdiagram.png&w=3840&q=75"/>
+      <img src="/static/figures/chart.png" width="800" height="400"/>
+    </article>`;
+    const urls = extractImageUrls(html, "https://blog.example.com/post");
+    // proxy ?url= unwrapped to the real CDN target
+    expect(urls).toContain("https://cdn.example.com/images/diagram.png");
+    // plain relative resolved against the page URL
+    expect(urls).toContain("https://blog.example.com/static/figures/chart.png");
+  });
+
   it("respects the max cap", () => {
     const imgs = Array.from(
       { length: 20 },
       (_, i) => `<img src="https://x.com/img${i}.png"/>`,
     ).join("");
-    expect(extractImageUrls(`<article>${imgs}</article>`, 5)).toHaveLength(5);
+    expect(extractImageUrls(`<article>${imgs}</article>`, undefined, 5)).toHaveLength(5);
   });
 });
 

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -275,7 +275,9 @@ export async function fetchUrlContent(
   // missing — downloadImages() then localizes them (or keeps the URL). Appended
   // AFTER truncation so a long article never drops its figures. HTML path only.
   if (mimeType !== "text/plain" && mimeType !== "text/markdown") {
-    const salvaged = extractImageUrls(body).filter((u) => !content.includes(u));
+    const salvaged = extractImageUrls(body, url).filter(
+      (u) => !content.includes(u),
+    );
     if (salvaged.length > 0) {
       content += "\n\n" + salvaged.map((u) => `![](${u})`).join("\n\n");
     }

--- a/src/lib/html-parse.ts
+++ b/src/lib/html-parse.ts
@@ -247,12 +247,21 @@ export function extractTitle(html: string): string {
  * Salvage plausible *content* image URLs from raw HTML — a generic fallback for
  * figures Readability drops (lazy-loaded, empty-alt, `<picture>`/`<source>`, SVG
  * diagrams). Parses with linkedom (the same DOM lib Readability uses here) rather
- * than regex, so it's robust to attribute order/quoting on any site. Strips
- * chrome (nav/header/footer/script/style/aside) so we don't grab logos/sprites,
- * skips data URIs + icon/logo/avatar URLs + tiny declared sizes, and dedupes.
- * Absolute http(s) URLs only, capped at `max`.
+ * than regex, so it's robust to attribute order/quoting on any site.
+ *
+ * Each candidate is resolved against `baseUrl` (so relative `/images/x.png`
+ * become absolute) and image-proxy URLs are unwrapped to their real target —
+ * e.g. Next.js `/_next/image?url=<encoded CDN url>&w=…` → the CDN url. Many
+ * modern sites (Anthropic's blog included) serve every figure through that
+ * proxy, so without unwrapping virtually all diagrams are missed. Strips chrome
+ * (nav/header/footer/aside) so we don't grab logos/sprites, skips data URIs +
+ * icon/logo/avatar URLs + tiny declared sizes, and dedupes. Capped at `max`.
  */
-export function extractImageUrls(html: string, max = 12): string[] {
+export function extractImageUrls(
+  html: string,
+  baseUrl?: string,
+  max = 12,
+): string[] {
   let document: ReturnType<typeof parseHTML>["document"];
   try {
     document = parseHTML(html).document;
@@ -264,11 +273,26 @@ export function extractImageUrls(html: string, max = 12): string[] {
     .querySelectorAll("script,style,nav,header,footer,noscript,aside")
     .forEach((el) => el.remove());
 
+  // Resolve a raw src/srcset URL to an absolute http(s) target, unwrapping a
+  // common image-proxy `?url=<encoded absolute>` param when present.
+  const resolve = (raw?: string | null): string | null => {
+    const v = raw?.trim();
+    if (!v) return null;
+    try {
+      const abs = baseUrl ? new URL(v, baseUrl) : new URL(v);
+      const proxied = abs.searchParams.get("url");
+      if (proxied && /^https?:\/\//i.test(proxied)) return proxied;
+      return /^https?:$/i.test(abs.protocol) ? abs.href : null;
+    } catch {
+      return null;
+    }
+  };
+
   const urls: string[] = [];
   const seen = new Set<string>();
-  const push = (u?: string | null) => {
-    const url = u?.trim();
-    if (!url || !/^https?:\/\//i.test(url)) return;
+  const push = (raw?: string | null) => {
+    const url = resolve(raw);
+    if (!url) return;
     if (/(logo|sprite|icon|favicon|avatar|emoji)/i.test(url)) return;
     if (seen.has(url)) return;
     seen.add(url);


### PR DESCRIPTION
## Why the Anthropic diagrams were still missing
After the previous image-salvage PR, diagrams *still* didn't appear. Root cause: that post (like most Next.js sites) serves every figure through image optimization — `src="/_next/image?url=https%3A%2F%2Fwww-cdn.anthropic.com%2F…png&w=3840&q=75"`. That's a **relative** URL, and the salvage helper only accepted absolute `http(s)` srcs — so **8 of 9 diagrams were dropped** (only the one absolute SVG passed).

## Fix
`extractImageUrls(html, baseUrl, max)` now:
- resolves relative srcs against `baseUrl` (the page URL), and
- **unwraps image-proxy URLs** — if the resolved URL has a `?url=<encoded http(s)>` param (Next.js `/_next/image`, and the same pattern many CDNs use), it returns that decoded target.

`fetchUrlContent` passes the page URL as `baseUrl`.

### Verified against the live post
1/9 → **9/9** diagrams captured, all as direct CDN URLs (`https://www-cdn.anthropic.com/images/…`), confirmed fetchable (200, image/png) so `downloadImages` localizes them to `assets/`.

## Test plan
- New unit tests: proxy `?url=` unwrap + relative→absolute resolution against baseUrl.
- `pnpm build` clean; `pnpm test` — 2627 passed.

## To see it on an existing page
Re-ingesting the **same URL** dedupes to the existing (image-less) page and skips re-synthesis. To pick up the diagrams, ingest fresh via the UI (synthesize → publish) — with the concept-slug change it publishes to `agentic-systems` — or delete the old page first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)