### PR TITLE
Fix #413 stream agent-scope leak + lock in #398 commons rebuild

### DIFF
--- a/src/app/api/query/stream/route.ts
+++ b/src/app/api/query/stream/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { hasLLMKey, callLLMStream } from "@/lib/llm";
 import { QUERY_MAX_OUTPUT_TOKENS } from "@/lib/constants";
-import { listReadableWikiPages } from "@/lib/wiki";
+import { listReadableWikiPages, isAgentScopedType } from "@/lib/wiki";
 import { getPrincipal } from "@/lib/auth";
 import {
   selectPagesForQuery,
@@ -64,7 +64,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: scopeError }, { status: 400 });
     }
 
-    const entries = await listReadableWikiPages(principal);
+    let entries = await listReadableWikiPages(principal);
+
+    // Unscoped queries answer from the public commons only — exclude agent-scoped
+    // pages (identity / knowledge / social), which surface solely via an explicit
+    // `agent:` scope. Mirrors the non-streaming query() path (query.ts).
+    if (!scopeSlugs) {
+      entries = entries.filter((e) => !isAgentScopedType(e.type));
+    }
 
     // Empty wiki — nothing to query
     if (entries.length === 0) {

--- a/src/lib/__tests__/maintenance.test.ts
+++ b/src/lib/__tests__/maintenance.test.ts
@@ -10,7 +10,8 @@ import {
   type Frontmatter,
 } from "../wiki";
 import { createThread, addComment } from "../talk";
-import { scanForMaintenance } from "../maintenance";
+import { scanForMaintenance, rebuildDerivedIndexes } from "../maintenance";
+import { listCommonsPages } from "../commons";
 import { _resetStorage } from "../storage";
 
 let tmpDir: string;
@@ -335,5 +336,22 @@ describe("scanForMaintenance", () => {
       lintType: "missing-crossref",
       targetSlug: "artificial-intelligence",
     });
+  });
+});
+
+describe("rebuildDerivedIndexes — commons index (#398)", () => {
+  it("includes the commons index in the daily self-heal rebuild", async () => {
+    await seed("agentic-systems");
+
+    const results = await rebuildDerivedIndexes();
+
+    // The commons index must be one of the rebuilt indexes (it powers every
+    // unauthenticated surface; without this it never self-heals from drift).
+    expect(results).toHaveProperty("commons");
+    expect(results.commons.ok).toBe(true);
+
+    // And the rebuild actually populated it with the public page.
+    const commons = await listCommonsPages();
+    expect(commons.map((p) => p.slug)).toContain("agentic-systems");
   });
 });

--- a/src/lib/__tests__/query-stream-route.test.ts
+++ b/src/lib/__tests__/query-stream-route.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// #413: the streaming query route must apply the SAME agent-scoped filter the
+// non-streaming query() does — unscoped queries answer from the public commons
+// only, never from agent-identity/knowledge/social pages.
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getPrincipal: vi.fn(async () => ({ id: "u", handle: "u" })),
+}));
+
+vi.mock("@/lib/search", () => ({
+  // Default to UNSCOPED; individual tests override per scope.
+  resolveScopeSlugs: vi.fn(async () => ({ scopeSlugs: undefined })),
+}));
+
+vi.mock("@/lib/wiki", () => ({
+  listReadableWikiPages: vi.fn(),
+  // Real-ish predicate: agent-scoped types are the `agent-*` family.
+  isAgentScopedType: (t: unknown) =>
+    typeof t === "string" && t.startsWith("agent-"),
+}));
+
+vi.mock("@/lib/llm", () => ({
+  hasLLMKey: vi.fn(() => true),
+  // Empty stream so the route completes without a real LLM.
+  callLLMStream: vi.fn(async function* () {}),
+}));
+
+vi.mock("@/lib/query", () => ({
+  selectPagesForQuery: vi.fn(async () => ["concept-a"]),
+  buildContext: vi.fn(async () => ({ context: "ctx", slugs: ["concept-a"] })),
+  buildQuerySystemPrompt: vi.fn(() => "system"),
+}));
+
+import { listReadableWikiPages } from "@/lib/wiki";
+import { resolveScopeSlugs } from "@/lib/search";
+import { selectPagesForQuery } from "@/lib/query";
+import { POST } from "@/app/api/query/stream/route";
+
+const mockedList = vi.mocked(listReadableWikiPages);
+const mockedScope = vi.mocked(resolveScopeSlugs);
+const mockedSelect = vi.mocked(selectPagesForQuery);
+
+const ENTRIES = [
+  { slug: "concept-a", title: "A", summary: "", type: undefined },
+  { slug: "yoyo-identity", title: "Y", summary: "", type: "agent-identity" },
+  { slug: "yoyo-notes", title: "N", summary: "", type: "agent-knowledge" },
+] as unknown as Awaited<ReturnType<typeof listReadableWikiPages>>;
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/query/stream", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedList.mockResolvedValue(ENTRIES);
+  mockedScope.mockResolvedValue({ scopeSlugs: undefined });
+});
+
+describe("POST /api/query/stream — agent-scope filtering (#413)", () => {
+  it("excludes agent-scoped pages from an UNSCOPED query", async () => {
+    await POST(makeRequest({ question: "what is A?" }));
+
+    expect(mockedSelect).toHaveBeenCalledTimes(1);
+    const passedEntries = mockedSelect.mock.calls[0][1] as Array<{ type?: string }>;
+    expect(passedEntries.map((e) => e.type)).not.toContain("agent-identity");
+    expect(passedEntries.map((e) => e.type)).not.toContain("agent-knowledge");
+    expect(passedEntries.map((e) => (e as { slug: string }).slug)).toEqual([
+      "concept-a",
+    ]);
+  });
+
+  it("keeps agent-scoped pages when an agent: scope is provided", async () => {
+    mockedScope.mockResolvedValue({ scopeSlugs: ["yoyo-identity", "yoyo-notes"] });
+
+    await POST(makeRequest({ question: "what is yoyo?", scope: "agent:yoyo" }));
+
+    expect(mockedSelect).toHaveBeenCalledTimes(1);
+    const passedEntries = mockedSelect.mock.calls[0][1] as Array<{ type?: string }>;
+    // Scoped query: no agent filter — the full readable set flows through.
+    expect(passedEntries.map((e) => e.type)).toContain("agent-identity");
+    expect(passedEntries.map((e) => e.type)).toContain("agent-knowledge");
+  });
+});


### PR DESCRIPTION
Reviewed both open `agent-self` issues. Both are **correct, valid bugs that reinforce (don't conflict with) the commons-first concept** — keep, don't revert.

## #413 — streaming query leaks agent-scoped pages (p1) — FIXED
`query()` filters out agent-scoped pages for unscoped queries (`query.ts:193`); the streaming route (`stream/route.ts`) — which the chat/Ask UI uses — duplicated the pipeline inline and **omitted that filter**, so agent-identity/knowledge/social pages could surface in default answers. Added the same `!isAgentScopedType` filter when `scopeSlugs` is undefined. Aligns with the concept: agent-scoped pages are private scratchpads, excluded from the commons + default query, reachable only via `agent:` scope. (4th bug in this parity class — the streaming route keeps re-duplicating logic; longer-term it should share the query pipeline.)

## #398 — commons index excluded from daily rebuild (p2) — already fixed in #409, test added
The code fix (adding `commons` to `rebuildDerivedIndexes`) shipped in #409. This adds the test the issue asked for, asserting the commons index is rebuilt + repopulated. Valid reliability fix; no concept conflict.

## Test plan
- New: `query-stream-route.test.ts` (unscoped excludes agent pages; `agent:` scope keeps them); `maintenance.test.ts` commons-rebuild case.
- `pnpm build` clean; `pnpm test` — 2630 passed.

Closes #413. Resolves #398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)