### PR TITLE
Home Ask redirects to /query and auto-runs (signed-in)

### DIFF
--- a/src/app/query/page.tsx
+++ b/src/app/query/page.tsx
@@ -112,6 +112,7 @@ export default function QueryPage() {
     error,
     setError,
     submit,
+    runQuery,
     isProcessing,
   } = useStreamingQuery({
     onComplete: saveToHistory,
@@ -129,6 +130,26 @@ export default function QueryPage() {
       new URLSearchParams(window.location.search).get("scope") || undefined;
     if (deepLink) setScope(deepLink);
   }, [isLoaded, setScope]);
+
+  // Auto-run a `?q=` deep link once (e.g. arriving from the homepage Ask). Runs
+  // after the scope init above so any scope deep-link is applied first. Strips
+  // `?q=` from the URL afterward so a refresh doesn't silently re-run the query.
+  const didInitQuestion = useRef(false);
+  useEffect(() => {
+    if (didInitQuestion.current || !isLoaded) return;
+    didInitQuestion.current = true;
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get("q");
+    if (!q) return;
+    runQuery(q);
+    params.delete("q");
+    const rest = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname + (rest ? `?${rest}` : ""),
+    );
+  }, [isLoaded, runQuery]);
 
   // A deep-linked owner:<handle> scope renders as a dismissible chip; otherwise
   // the Public + your-vaults selector drives `scope` (undefined=Public vs

--- a/src/app/query/page.tsx
+++ b/src/app/query/page.tsx
@@ -131,9 +131,10 @@ export default function QueryPage() {
     if (deepLink) setScope(deepLink);
   }, [isLoaded, setScope]);
 
-  // Auto-run a `?q=` deep link once (e.g. arriving from the homepage Ask). Runs
-  // after the scope init above so any scope deep-link is applied first. Strips
-  // `?q=` from the URL afterward so a refresh doesn't silently re-run the query.
+  // Auto-run a `?q=` deep link once (e.g. arriving from the homepage Ask). Any
+  // `?scope=` in the same URL is passed to runQuery explicitly — the scope-init
+  // effect's setScope() hasn't propagated to `scope` state yet in this commit.
+  // Strips `?q=` from the URL afterward so a refresh doesn't silently re-run.
   const didInitQuestion = useRef(false);
   useEffect(() => {
     if (didInitQuestion.current || !isLoaded) return;
@@ -141,7 +142,8 @@ export default function QueryPage() {
     const params = new URLSearchParams(window.location.search);
     const q = params.get("q");
     if (!q) return;
-    runQuery(q);
+    const scopeParam = params.get("scope") || undefined;
+    runQuery(q, scopeParam);
     params.delete("q");
     const rest = params.toString();
     window.history.replaceState(

--- a/src/app/query/page.tsx
+++ b/src/app/query/page.tsx
@@ -132,9 +132,10 @@ export default function QueryPage() {
   }, [isLoaded, setScope]);
 
   // Auto-run a `?q=` deep link once (e.g. arriving from the homepage Ask). Any
-  // `?scope=` in the same URL is passed to runQuery explicitly — the scope-init
-  // effect's setScope() hasn't propagated to `scope` state yet in this commit.
-  // Strips `?q=` from the URL afterward so a refresh doesn't silently re-run.
+  // `?scope=` is read straight from the URL and passed to runQuery, so this run
+  // uses the right scope without waiting on the scope-init effect's setScope()
+  // to land in state. Strips `?q=` from the URL afterward so a refresh doesn't
+  // silently re-run.
   const didInitQuestion = useRef(false);
   useEffect(() => {
     if (didInitQuestion.current || !isLoaded) return;

--- a/src/components/HomeAsk.tsx
+++ b/src/components/HomeAsk.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useUser, useClerk, SignInButton } from "@clerk/nextjs";
 import { useStreamingQuery } from "@/hooks/useStreamingQuery";
 import { QueryResultPanel } from "./QueryResultPanel";
@@ -18,16 +19,23 @@ const EXAMPLES = [
 const DEMO_USED_KEY = "yopedia_demo_used";
 
 /**
- * The homepage hero. Signed-in: ask the wiki live, streamed in place. Signed
- * OUT: clicking a sample question shows a cached, pre-computed answer (a "taste"
- * — no LLM cost, served from /api/query/demo) with a simulated stream; the next
- * question enforces sign-in.
+ * The homepage hero / launcher. Signed-in: submitting (or clicking a sample)
+ * navigates to /query?q=… which auto-runs the answer there. Signed-OUT: clicking
+ * a sample shows a cached, pre-computed answer (a "taste" — no LLM cost, served
+ * from /api/query/demo); the next question enforces sign-in.
  */
 export function HomeAsk() {
+  const router = useRouter();
   const { isSignedIn } = useUser();
   const { openSignIn } = useClerk();
-  const { question, setQuestion, result, streaming, error, submit, isProcessing } =
-    useStreamingQuery();
+  // Only the question input is used here; signed-in asks run on /query, not inline.
+  const { question, setQuestion } = useStreamingQuery();
+
+  /** Hand the question off to /query, which reads ?q= and auto-runs it. */
+  function goToQuery(q: string) {
+    const trimmed = q.trim();
+    if (trimmed) router.push(`/query?q=${encodeURIComponent(trimmed)}`);
+  }
 
   // Signed-out demo state.
   const [demo, setDemo] = useState<{ answer: string; sources: string[] } | null>(
@@ -98,7 +106,7 @@ export function HomeAsk() {
 
   function onChip(q: string) {
     if (isSignedIn) {
-      setQuestion(q);
+      goToQuery(q);
       return;
     }
     // Signed-out: one free demo, then enforce sign-in.
@@ -116,7 +124,10 @@ export function HomeAsk() {
       <form
         onSubmit={
           isSignedIn
-            ? submit
+            ? (e) => {
+                e.preventDefault();
+                goToQuery(question);
+              }
             : (e) => {
                 e.preventDefault();
                 openSignIn();
@@ -150,7 +161,7 @@ export function HomeAsk() {
               }}
               placeholder="Consult the commons — ask, and get an answer cited to the pages it stands on…"
               rows={2}
-              disabled={!isSignedIn || isProcessing}
+              disabled={!isSignedIn}
               style={{
                 flex: 1,
                 border: 0,
@@ -203,11 +214,10 @@ export function HomeAsk() {
             {isSignedIn ? (
               <button
                 type="submit"
-                disabled={isProcessing || !question.trim()}
+                disabled={!question.trim()}
                 className="btn primary shrink-0 disabled:opacity-50"
               >
-                {isProcessing ? "Thinking…" : "Ask"}
-                {!isProcessing && <Icon.arrow width="16" height="16" />}
+                Ask <Icon.arrow width="16" height="16" />
               </button>
             ) : (
               <SignInButton mode="modal">
@@ -232,26 +242,14 @@ export function HomeAsk() {
         </p>
       )}
 
-      {(error || demoError) && (
+      {demoError && (
         <div className="mt-4">
-          <Alert variant="error">{error ?? demoError}</Alert>
+          <Alert variant="error">{demoError}</Alert>
         </div>
       )}
 
       {!isSignedIn && demoLoading && (
         <p className="mt-4 text-sm text-muted">Thinking…</p>
-      )}
-
-      {/* Signed-in live result */}
-      {isSignedIn && result && (
-        <div className="mt-6">
-          <QueryResultPanel
-            result={result}
-            streaming={streaming}
-            question={question}
-            currentHistoryId={null}
-          />
-        </div>
       )}
 
       {/* Signed-out demo result (read-only — no save) */}

--- a/src/hooks/useStreamingQuery.ts
+++ b/src/hooks/useStreamingQuery.ts
@@ -26,8 +26,12 @@ export interface UseStreamingQueryReturn {
   error: string | null;
   setError: (e: string | null) => void;
   submit: (e: React.FormEvent) => void;
-  /** Run a query programmatically (e.g. from a `?q=` deep link). */
-  runQuery: (q: string) => void;
+  /**
+   * Run a query programmatically (e.g. from a `?q=` deep link). `scopeOverride`
+   * applies that scope to THIS run directly — pass it when the scope arrives in
+   * the same tick (deep link) and `scope` state may not have propagated yet.
+   */
+  runQuery: (q: string, scopeOverride?: string) => void;
   isProcessing: boolean;
 }
 
@@ -68,9 +72,12 @@ export function useStreamingQuery(
   // by the form (submit) and programmatically (runQuery), with no state-timing
   // race between setQuestion() and reading `question` back.
   const execute = useCallback(
-    async (rawQuestion: string) => {
+    async (rawQuestion: string, scopeOverride?: string) => {
       const trimmed = rawQuestion.trim();
       if (!trimmed) return;
+      // Use the explicit scope when given (deep-link arriving the same tick that
+      // setScope was called, before state propagates); else the current state.
+      const effectiveScope = scopeOverride ?? scope;
 
       // Abort any previous in-flight request
       abortControllerRef.current?.abort();
@@ -88,7 +95,7 @@ export function useStreamingQuery(
         const res = await fetch("/api/query/stream", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ question: trimmed, format, scope }),
+          body: JSON.stringify({ question: trimmed, format, scope: effectiveScope }),
           signal: controller.signal,
         });
 
@@ -101,7 +108,7 @@ export function useStreamingQuery(
           const fallbackRes = await fetch("/api/query", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ question: trimmed, format, scope }),
+            body: JSON.stringify({ question: trimmed, format, scope: effectiveScope }),
             signal: controller.signal,
           });
 
@@ -191,9 +198,10 @@ export function useStreamingQuery(
   // Programmatic run — submits with the given question directly (also reflects
   // it in the input via setQuestion).
   const runQuery = useCallback(
-    (q: string) => {
+    (q: string, scopeOverride?: string) => {
       setQuestion(q);
-      execute(q);
+      if (scopeOverride !== undefined) setScope(scopeOverride);
+      execute(q, scopeOverride);
     },
     [execute],
   );

--- a/src/hooks/useStreamingQuery.ts
+++ b/src/hooks/useStreamingQuery.ts
@@ -112,9 +112,9 @@ export function useStreamingQuery(
             signal: controller.signal,
           });
 
-          const fallbackData = await fallbackRes.json();
-          if (!fallbackRes.ok) {
-            setError(fallbackData.error ?? errMsg);
+          const fallbackData = await fallbackRes.json().catch(() => null);
+          if (!fallbackRes.ok || !fallbackData) {
+            setError(fallbackData?.error ?? errMsg);
             return;
           }
           setResult(fallbackData);

--- a/src/hooks/useStreamingQuery.ts
+++ b/src/hooks/useStreamingQuery.ts
@@ -26,6 +26,8 @@ export interface UseStreamingQueryReturn {
   error: string | null;
   setError: (e: string | null) => void;
   submit: (e: React.FormEvent) => void;
+  /** Run a query programmatically (e.g. from a `?q=` deep link). */
+  runQuery: (q: string) => void;
   isProcessing: boolean;
 }
 
@@ -62,10 +64,13 @@ export function useStreamingQuery(
     };
   }, []);
 
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault();
-      if (!question.trim()) return;
+  // Core query runner — takes the question explicitly so it can be driven both
+  // by the form (submit) and programmatically (runQuery), with no state-timing
+  // race between setQuestion() and reading `question` back.
+  const execute = useCallback(
+    async (rawQuestion: string) => {
+      const trimmed = rawQuestion.trim();
+      if (!trimmed) return;
 
       // Abort any previous in-flight request
       abortControllerRef.current?.abort();
@@ -77,8 +82,6 @@ export function useStreamingQuery(
       setError(null);
       setResult(null);
       onSubmitStartRef.current?.();
-
-      const trimmed = question.trim();
 
       try {
         // Try the streaming endpoint first
@@ -173,7 +176,26 @@ export function useStreamingQuery(
         setStreaming(false);
       }
     },
-    [question, format, scope],
+    [format, scope],
+  );
+
+  // Form submit — reads the current question from state.
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      execute(question);
+    },
+    [execute, question],
+  );
+
+  // Programmatic run — submits with the given question directly (also reflects
+  // it in the input via setQuestion).
+  const runQuery = useCallback(
+    (q: string) => {
+      setQuestion(q);
+      execute(q);
+    },
+    [execute],
   );
 
   const isProcessing = loading || streaming;
@@ -194,6 +216,7 @@ export function useStreamingQuery(
     error,
     setError,
     submit: handleSubmit,
+    runQuery,
     isProcessing,
   };
 }


### PR DESCRIPTION
## What
Asking on the homepage now **navigates to `/query` and answers there** instead of inline — `/query` is the full ask surface (centered console, format options, scope selector, history).

- **`useStreamingQuery`**: extracted `execute(q)` core; added **`runQuery(q)`** for programmatic runs (avoids the `setQuestion`→`submit` state race). `submit(e)` behavior unchanged.
- **`/query`**: reads `?q=` once on load → `runQuery` → strips `?q=` from the URL via `replaceState` so a refresh doesn't silently re-run. Mirrors the existing `?scope=` init.
- **`HomeAsk`**: signed-in submit/chip → `router.push('/query?q=…')`; removed the inline signed-in result panel.

## Decisions
- **Signed-in** → redirect + auto-run.
- **Signed-out** → unchanged: the cached one-shot "free taste" demo + sign-in funnel stays on the home (per request).

## Test plan
- `pnpm build` clean; `pnpm test` — 2630 passed.
- Manual (signed-in): ask on home → lands on `/query`, answer streams, `?q=` stripped from address bar, refresh doesn't re-run; chip → same.
- Manual (signed-out): home still shows the cached demo, then prompts sign-in.
- Manual: `/query?q=…` direct link auto-runs; `/query?scope=owner:<h>` still pins scope.

**Not merging — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)