### PR TITLE
Fix near-invisible fenced code-block text in article body

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -478,6 +478,11 @@ body {
   --tw-prose-headings: var(--ink);
   --tw-prose-bold: var(--ink);
   --tw-prose-code: var(--ink);
+  /* Fenced code blocks use a light (paper-2) background — the default
+     pre-code color is a light gray meant for a dark block, which renders
+     near-invisible here. Pin it (and the bg var) to readable tokens. */
+  --tw-prose-pre-code: var(--ink);
+  --tw-prose-pre-bg: var(--paper-2);
   --tw-prose-links: var(--accent);
   --tw-prose-quotes: var(--muted);
   --tw-prose-quote-borders: var(--rule);


### PR DESCRIPTION
## Problem
On wiki article pages, fenced ```` ``` ```` code blocks rendered as near-invisible light-gray text on the light paper background.

## Cause
`.prose-article pre` sets a light background (`--paper-2`), but the block never set `--tw-prose-pre-code`. Tailwind Typography defaults that to a light gray (it assumes a *dark* code-block background), so the text was light-on-light. Inline code was fine because `--tw-prose-code` was already pinned to `--ink`.

## Fix
Add to the `.prose-article` var block:
- `--tw-prose-pre-code: var(--ink)` — readable code text
- `--tw-prose-pre-bg: var(--paper-2)` — keep the bg var consistent with the explicit `pre` rule

Both tokens invert in dark mode, so it's correct in both themes. CSS-only; `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)