### PR TITLE
Add the review gate to PDF and image ingest

### DIFF
--- a/src/app/api/ingest/image/route.ts
+++ b/src/app/api/ingest/image/route.ts
@@ -54,6 +54,7 @@ export async function POST(request: NextRequest) {
       if (typeof tags === "string" && tags.trim()) {
         options.tags = tags.split(",").map((t) => t.trim()).filter(Boolean);
       }
+      if (form.get("preview") === "true") options.preview = true;
       const bytes = await file.arrayBuffer();
       const result = await ingestImage(
         { bytes, filename: file.name, contentType: file.type || undefined },
@@ -62,9 +63,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(result);
     }
 
-    // JSON path: { imageUrl, title?, tags? }
+    // JSON path: { imageUrl, title?, tags?, preview? }
     const body = await request.json();
-    const { imageUrl, title, tags } = body;
+    const { imageUrl, title, tags, preview } = body;
     if (typeof imageUrl !== "string" || !isUrl(imageUrl.trim())) {
       return NextResponse.json(
         { error: "imageUrl is required and must be a valid URL." },
@@ -75,6 +76,7 @@ export async function POST(request: NextRequest) {
     if (Array.isArray(tags) && tags.every((t: unknown) => typeof t === "string")) {
       options.tags = tags;
     }
+    if (preview === true) options.preview = true;
     const result = await ingestImage({ imageUrl: imageUrl.trim() }, options);
     return NextResponse.json(result);
   } catch (error) {

--- a/src/app/api/ingest/pdf/route.ts
+++ b/src/app/api/ingest/pdf/route.ts
@@ -54,6 +54,7 @@ export async function POST(request: NextRequest) {
       if (typeof tags === "string" && tags.trim()) {
         options.tags = tags.split(",").map((t) => t.trim()).filter(Boolean);
       }
+      if (form.get("preview") === "true") options.preview = true;
       const bytes = await file.arrayBuffer();
       const result = await ingestPdf(
         { bytes, filename: file.name },
@@ -62,9 +63,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(result);
     }
 
-    // JSON path: { pdfUrl, title?, tags? }
+    // JSON path: { pdfUrl, title?, tags?, preview? }
     const body = await request.json();
-    const { pdfUrl, title, tags } = body;
+    const { pdfUrl, title, tags, preview } = body;
     if (typeof pdfUrl !== "string" || !isUrl(pdfUrl.trim())) {
       return NextResponse.json(
         { error: "pdfUrl is required and must be a valid URL." },
@@ -75,6 +76,7 @@ export async function POST(request: NextRequest) {
     if (Array.isArray(tags) && tags.every((t: unknown) => typeof t === "string")) {
       options.tags = tags;
     }
+    if (preview === true) options.preview = true;
     const result = await ingestPdf({ pdfUrl: pdfUrl.trim() }, options);
     return NextResponse.json(result);
   } catch (error) {

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -19,12 +19,22 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json();
 
-    const { url, title, content, preview, generatedContent, triggeredBy, tags, sourceUrl } = body;
+    const { url, title, content, preview, generatedContent, triggeredBy, tags, sourceUrl, sourceType } = body;
 
     // Validate triggeredBy if provided
     if (triggeredBy !== undefined && typeof triggeredBy !== "string") {
       return NextResponse.json(
         { error: "triggeredBy must be a string if provided" },
+        { status: 400 },
+      );
+    }
+
+    // Validate sourceType if provided (preserves provenance when the
+    // PDF/image review flow commits the approved body via this text path).
+    const VALID_SOURCE_TYPES = ["url", "text", "x-mention", "image", "pdf", "youtube"];
+    if (sourceType !== undefined && !VALID_SOURCE_TYPES.includes(sourceType)) {
+      return NextResponse.json(
+        { error: `sourceType must be one of: ${VALID_SOURCE_TYPES.join(", ")}` },
         { status: 400 },
       );
     }
@@ -64,6 +74,9 @@ export async function POST(request: NextRequest) {
     }
     if (typeof sourceUrl === "string" && sourceUrl.trim().length > 0) {
       options.sourceUrl = sourceUrl.trim();
+    }
+    if (typeof sourceType === "string" && sourceType.length > 0) {
+      options.sourceType = sourceType as IngestOptions["sourceType"];
     }
     // Attribution from the authenticated session (authoritative; overrides any
     // client-supplied triggeredBy to prevent spoofing).

--- a/src/components/IngestReview.tsx
+++ b/src/components/IngestReview.tsx
@@ -16,6 +16,9 @@ export interface PreviewData {
   content: string;
   /** Original URL if using URL mode. */
   url?: string;
+  /** Provenance carried through a text-path commit (PDF/image review flow). */
+  sourceType?: string;
+  sourceUrl?: string;
   /** Structured page metadata for the review card (from the preview response). */
   meta?: IngestPreviewMeta;
 }

--- a/src/hooks/useIngest.ts
+++ b/src/hooks/useIngest.ts
@@ -15,6 +15,7 @@ export interface IngestResponse {
   indexUpdated: boolean;
   previewContent?: string;
   preview?: IngestPreviewMeta;
+  sourceContent?: string;
   error?: string;
 }
 
@@ -208,8 +209,9 @@ export function useIngest(): UseIngestReturn {
     }
   }
 
-  /** Image ingest: store image, describe via vision model, write a page. Skips
-   *  the review gate (the body is just the image + description). */
+  /** Image ingest: store image + describe via vision model, then REVIEW before
+   *  publishing. The preview returns the body (image + description) as
+   *  sourceContent so approve commits via the shared text path. */
   async function handleImageIngest(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
@@ -237,6 +239,7 @@ export function useIngest(): UseIngestReturn {
         const fd = new FormData();
         fd.append("file", imageFile);
         if (title.trim()) fd.append("title", title.trim());
+        fd.append("preview", "true");
         res = await fetch("/api/ingest/image", { method: "POST", body: fd });
       } else {
         res = await fetch("/api/ingest/image", {
@@ -245,6 +248,7 @@ export function useIngest(): UseIngestReturn {
           body: JSON.stringify({
             imageUrl: imageUrl.trim(),
             title: title.trim() || undefined,
+            preview: true,
           }),
         });
       }
@@ -255,8 +259,16 @@ export function useIngest(): UseIngestReturn {
         setStage("form");
         return;
       }
-      setResult(data);
-      setStage("success");
+      setPreview({
+        slug: data.primarySlug,
+        previewContent: data.previewContent ?? "",
+        relatedPages: data.relatedUpdated ?? [],
+        title: data.preview?.title ?? title,
+        content: data.sourceContent ?? "",
+        url: undefined,
+        meta: data.preview,
+      });
+      setStage("review");
     } catch {
       setError("Network error — could not reach the server");
       setStage("form");
@@ -265,8 +277,9 @@ export function useIngest(): UseIngestReturn {
     }
   }
 
-  /** PDF ingest: extract text from a PDF, run through the ingest pipeline. Skips
-   *  the review gate (the body is the extracted text). */
+  /** PDF ingest: extract text, synthesize, then REVIEW before publishing. The
+   *  preview returns the extracted text as sourceContent so approve commits via
+   *  the shared text path (no re-fetch / re-extract). */
   async function handlePdfIngest(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
@@ -294,6 +307,7 @@ export function useIngest(): UseIngestReturn {
         const fd = new FormData();
         fd.append("file", pdfFile);
         if (title.trim()) fd.append("title", title.trim());
+        fd.append("preview", "true");
         res = await fetch("/api/ingest/pdf", { method: "POST", body: fd });
       } else {
         res = await fetch("/api/ingest/pdf", {
@@ -302,6 +316,7 @@ export function useIngest(): UseIngestReturn {
           body: JSON.stringify({
             pdfUrl: pdfUrl.trim(),
             title: title.trim() || undefined,
+            preview: true,
           }),
         });
       }
@@ -312,8 +327,16 @@ export function useIngest(): UseIngestReturn {
         setStage("form");
         return;
       }
-      setResult(data);
-      setStage("success");
+      setPreview({
+        slug: data.primarySlug,
+        previewContent: data.previewContent ?? "",
+        relatedPages: data.relatedUpdated ?? [],
+        title: data.preview?.title ?? title,
+        content: data.sourceContent ?? "",
+        url: undefined,
+        meta: data.preview,
+      });
+      setStage("review");
     } catch {
       setError("Network error — could not reach the server");
       setStage("form");

--- a/src/hooks/useIngest.ts
+++ b/src/hooks/useIngest.ts
@@ -185,6 +185,9 @@ export function useIngest(): UseIngestReturn {
             title: preview.title,
             content: preview.content,
             generatedContent: preview.previewContent,
+            // Preserve PDF/image provenance through the text commit path.
+            ...(preview.sourceType ? { sourceType: preview.sourceType } : {}),
+            ...(preview.sourceUrl ? { sourceUrl: preview.sourceUrl } : {}),
           };
 
       const res = await fetch("/api/ingest", {
@@ -266,6 +269,9 @@ export function useIngest(): UseIngestReturn {
         title: data.preview?.title ?? title,
         content: data.sourceContent ?? "",
         url: undefined,
+        sourceType: "image",
+        // Real source URL only when ingesting by URL (uploads have none).
+        sourceUrl: imageFile ? undefined : imageUrl.trim() || undefined,
         meta: data.preview,
       });
       setStage("review");
@@ -334,6 +340,9 @@ export function useIngest(): UseIngestReturn {
         title: data.preview?.title ?? title,
         content: data.sourceContent ?? "",
         url: undefined,
+        sourceType: "pdf",
+        // Real source URL only when ingesting by URL (uploads have none).
+        sourceUrl: pdfFile ? undefined : pdfUrl.trim() || undefined,
         meta: data.preview,
       });
       setStage("review");

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -267,12 +267,15 @@ export async function ingestImage(
 
   // generatedContent writes `body` as-is (skip the wiki-editor LLM) while still
   // reusing frontmatter, dedup, embedding, cross-refs, and the ledger.
-  return ingest(title, body, {
+  const result = await ingest(title, body, {
     ...options,
     generatedContent: body,
     sourceUrl: imageUrl ?? "upload",
     sourceType: "image",
   });
+  // On preview, return the body as sourceContent so the client can commit it via
+  // the text path on approve (the image asset is already stored above).
+  return options?.preview ? { ...result, sourceContent: body } : result;
 }
 
 /**
@@ -303,11 +306,14 @@ export async function ingestPdf(
     }
     // fetchUrlContent now handles application/pdf natively
     const { title, content } = await fetchUrlContent(url);
-    return ingest(options?.title ?? title, content, {
+    const result = await ingest(options?.title ?? title, content, {
       ...options,
       sourceUrl: url,
       sourceType: "pdf",
     });
+    // On preview, return the extracted text so the client can replay it to the
+    // text commit path on approve (no re-fetch / re-extract needed).
+    return options?.preview ? { ...result, sourceContent: content } : result;
   }
 
   // Upload path: extract text from bytes directly
@@ -344,10 +350,11 @@ export async function ingestPdf(
       filename.replace(/\.pdf$/i, "") ||
       "PDF Document";
 
-    return ingest(title, content, {
+    const result = await ingest(title, content, {
       ...options,
       sourceType: "pdf",
     });
+    return options?.preview ? { ...result, sourceContent: content } : result;
   } finally {
     await doc.cleanup();
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,6 +75,12 @@ export interface IngestResult {
   previewContent?: string;
   /** Structured page metadata for the review step. Present only when `preview: true`. */
   preview?: IngestPreviewMeta;
+  /**
+   * The raw source text used for synthesis. Returned on `preview: true` for the
+   * PDF/image paths (where the server extracted it) so the client can replay it
+   * to the text commit path on approve — no re-extraction / re-vision needed.
+   */
+  sourceContent?: string;
   /** The original source URL, if the ingest was URL-based. */
   sourceUrl?: string;
   /**


### PR DESCRIPTION
## What
PDF and image ingest published **directly** after synthesis, skipping the SOURCE → SYNTHESIS → **REVIEW** → publish gate that URL/text use. Now all source types share the review-before-publish flow.

## How
The pipeline already supported preview (`ingestPdf`/`ingestImage` forward `preview`/`generatedContent` to `ingest()`); only the routes + hook needed wiring.

- **Routes** (`/api/ingest/pdf`, `/api/ingest/image`): accept a `preview` flag (multipart `preview=true` / JSON `preview:true`) → `options.preview`.
- **Lib**: on preview, both return the raw source as **`sourceContent`** — extracted PDF text / the image body (`# title` + `![](asset)` + vision description).
- **Hook**: `handlePdfIngest`/`handleImageIngest` now do the preview call → set the review state → `stage = "review"`. **Approve replays via the existing text path** (`/api/ingest {title, content, generatedContent}`, since `preview.url` is undefined), so `handleApprove` is unchanged and there's **no re-extract / re-vision / re-upload** — the expensive work (PDF extraction, image vision + asset store) runs once, in preview; approve just commits the reviewed body.

Slug stays consistent (the commit's concept-slug-from-H1 derives the same slug the asset was stored under in preview).

## Test plan
- `pnpm build` clean; `pnpm test` — 2634 passed. Change is additive (non-preview still writes directly), so existing route tests hold.
- Manual: PDF (file + URL) and Image (file + URL) → SYNTHESIS → REVIEW card (title/summary/draft) → Publish writes the page; Discard returns to form.

**Feature branch — not merged, for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)