### PR TITLE
Drop model/infra names from the ingest synthesis checklist

### DIFF
--- a/src/components/IngestSynthesis.tsx
+++ b/src/components/IngestSynthesis.tsx
@@ -12,8 +12,8 @@ import { Icon } from "@/components/folio/icons";
  */
 const STAGES = [
   ["Fetch", "retrieving & cleaning the source"],
-  ["Synthesize", "DeepSeek-V4 drafts a cited page"],
-  ["Embed", "bge-m3 vectors · CJK-aware"],
+  ["Synthesize", "drafting a cited page"],
+  ["Embed", "indexing for semantic search"],
   ["Cross-link", "wikilinks to related pages"],
   ["Score", "confidence & review-by date"],
 ] as const;


### PR DESCRIPTION
The `/ingest` step-2 SYNTHESIS checklist showed internal implementation names to users:
- `Synthesize`: "DeepSeek-V4 drafts a cited page" → **"drafting a cited page"**
- `Embed`: "bge-m3 vectors · CJK-aware" → **"indexing for semantic search"**

The provider/embedding stack is intentionally swappable, so naming a specific model here is noise + a maintenance trap. Other stages and the "yoyo is synthesizing…" header are unchanged.

`pnpm build` clean. UI-string-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)