### PR TITLE
Synthesize concise distillations, not source transcripts

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -33,6 +33,10 @@ yoyo updates this document so future sessions inherit the convention. See
 - Every page starts with an H1 title (`# Title`).
 - Every page has a one-paragraph summary immediately after the H1. The index
   builder uses this paragraph as the page's catalog blurb.
+- Pages DISTILL their sources concisely — a synthesized reference, not a
+  transcript. The full raw source is preserved separately and viewable
+  ("View raw"), so a page captures the essential substance rather than
+  reproducing the source verbatim.
 - Cross-references between wiki pages use markdown links of the form
   `[Title](other-slug.md)` — relative, no leading slash, `.md` suffix
   required. The `.md` suffix is what lets the graph builder

--- a/src/components/IngestSynthesis.tsx
+++ b/src/components/IngestSynthesis.tsx
@@ -12,8 +12,8 @@ import { Icon } from "@/components/folio/icons";
  */
 const STAGES = [
   ["Fetch", "retrieving & cleaning the source"],
-  ["Synthesize", "DeepSeek-V4 drafts a cited page"],
-  ["Embed", "bge-m3 vectors · CJK-aware"],
+  ["Synthesize", "drafting a cited page"],
+  ["Embed", "indexing for semantic search"],
   ["Cross-link", "wikilinks to related pages"],
   ["Score", "confidence & review-by date"],
 ] as const;

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -655,14 +655,15 @@ Then, on the following lines, the wiki article. Include:
 - A brief summary section (## Summary)
 - Key points or takeaways (## Key Points)
 - Notable entities, concepts, or terms worth remembering (## Concepts)
-- A detailed section (## Details) that faithfully preserves the source's
-  substantive content — important explanations, definitions, examples, steps,
-  data, and notable passages — written as readable prose and lists, not just
-  one-line bullets. Aim to retain what a reader would need so the page can
-  stand in for the source. Do not pad, repeat the summary, or invent anything
-  not supported by the source.
+- A detailed section (## Details) that DISTILLS the source's essential substance
+  — the key explanations, definitions, mechanisms, steps, and notable specifics
+  a reader needs to understand the concept — as readable prose and lists. Be
+  concise: omit boilerplate, marketing, repetition, and tangents; summarize
+  rather than transcribe. The full raw source is preserved separately and one
+  click away ("View raw"), so do NOT try to reproduce it. Invent nothing not
+  supported by the source.
 
-Output the CONCEPT and ALIASES lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
+Write a focused, distilled page, not a transcript of the source. Output the CONCEPT and ALIASES lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
 
 /**
  * System prompt for continuation chunks when a long source document has been


### PR DESCRIPTION
## What
The synthesis `## Details` instruction told the model to *"faithfully preserve the source's substantive content … so the page can stand in for the source."* That made pages near-copies of the source. Now that the **raw source is kept and viewable** ("View raw"), the page should be a **distillation**.

- Reworded the `## Details` instruction in `INGEST_SYSTEM_PROMPT_BASE`: distill the essential substance concisely (key explanations / definitions / mechanisms / notable specifics), omit boilerplate / marketing / repetition / tangents, and don't reproduce the source verbatim (raw is one click away).
- Added a matching "pages distill, not transcribe" bullet to `SCHEMA.md` page conventions (loaded into the prompt at runtime).
- Kept `INGEST_MAX_OUTPUT_TOKENS = 8192` as a ceiling (prompt drives length, not the cap).

## Test plan
- `pnpm build` clean; `pnpm test` — 2634 passed.
- Ingest a long URL → focused distilled page; "View raw" still holds the full source.

Part 1 of 2 (concise synthesis + per-source raw viewer). **Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)