### PR TITLE
Per-source raw storage + multi-source raw browser

### DIFF
--- a/src/app/api/raw/[slug]/route.ts
+++ b/src/app/api/raw/[slug]/route.ts
@@ -1,20 +1,20 @@
 import { NextResponse } from "next/server";
 import { decodeSlug } from "@/lib/slugify";
-import { readRawSource } from "@/lib/wiki";
+import { readRawSource, readRawSourceById } from "@/lib/wiki";
 import { getPrincipal } from "@/lib/auth";
 import { canReadSlug } from "@/lib/authz";
 import { getErrorMessage } from "@/lib/errors";
 
 /**
- * GET /api/raw/[slug]
+ * GET /api/raw/[slug][?source=<rawId>]
  *
- * Returns a single raw source as `text/plain`, suitable for download or
- * programmatic inspection. This is a thin read-only wrapper over
- * {@link readRawSource}; the library function owns both the path-traversal
- * guard and the not-found semantics.
+ * Returns a raw source as `text/plain`, suitable for download or programmatic
+ * inspection. Without `?source`, returns the latest single blob; with a
+ * `?source=<rawId>`, returns that per-source snapshot. Thin read-only wrapper —
+ * the library functions own the path-traversal guard and not-found semantics.
  */
 export async function GET(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ slug: string }> },
 ) {
   try {
@@ -24,7 +24,10 @@ export async function GET(
     if (!(await canReadSlug(slug, await getPrincipal()))) {
       return NextResponse.json({ error: "not found" }, { status: 404 });
     }
-    const source = await readRawSource(slug);
+    const sourceId = new URL(req.url).searchParams.get("source");
+    const source = sourceId
+      ? await readRawSourceById(slug, sourceId)
+      : await readRawSource(slug);
     return new NextResponse(source.content, {
       status: 200,
       headers: {

--- a/src/app/u/[handle]/raw/[slug]/page.tsx
+++ b/src/app/u/[handle]/raw/[slug]/page.tsx
@@ -1,32 +1,25 @@
-import Link from "next/link";
 import { decodeSlug } from "@/lib/slugify";
 import { notFound, permanentRedirect } from "next/navigation";
-import { readRawSource, readWikiPageWithFrontmatter, tenantForOwner } from "@/lib/wiki";
+import {
+  readRawSource,
+  readRawSourceById,
+  readWikiPageWithFrontmatter,
+  tenantForOwner,
+} from "@/lib/wiki";
+import { parseSources } from "@/lib/sources";
 import { pagePath, rawPath } from "@/lib/links";
 import { canReadSlug } from "@/lib/authz";
 import { getPrincipal } from "@/lib/auth";
-import { MarkdownRenderer } from "@/components/MarkdownRenderer";
+import { RawSourceBrowser, type RawItem } from "@/components/RawSourceBrowser";
 
 interface RawSourcePageProps {
   params: Promise<{ handle: string; slug: string }>;
 }
 
-/** Hard ceiling on how much raw content we render inline in the browser. */
-const MAX_INLINE_BYTES = 500 * 1024; // 500 KB
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) {
-    const kb = bytes / 1024;
-    return kb >= 10 ? `${Math.round(kb)} KB` : `${kb.toFixed(1)} KB`;
-  }
-  const mb = bytes / (1024 * 1024);
-  return mb >= 10 ? `${Math.round(mb)} MB` : `${mb.toFixed(1)} MB`;
-}
-
 export default async function RawSourcePage({ params }: RawSourcePageProps) {
   const { handle: encodedHandle, slug: encodedSlug } = await params;
   const slug = decodeSlug(encodedSlug);
+
   // A private page's raw source is owner-only — 404 (same as missing) otherwise.
   if (!(await canReadSlug(slug, await getPrincipal()))) {
     notFound();
@@ -43,67 +36,70 @@ export default async function RawSourcePage({ params }: RawSourcePageProps) {
   if (decodeSlug(encodedHandle).toLowerCase() !== pageTenant) {
     permanentRedirect(rawPath(pageTenant, slug));
   }
-  let source;
-  try {
-    source = await readRawSource(slug);
-  } catch {
-    // readRawSource throws for both "not found" and "invalid slug" — in
-    // either case the right response to the user is a 404.
-    notFound();
+
+  // Build the source list from the page's provenance. Newest first.
+  const sources = parseSources(
+    ownerPage?.frontmatter.sources as string | string[] | undefined,
+  )
+    .slice()
+    .reverse();
+  const anyRaw = sources.some((s) => s.raw_id);
+
+  let items: RawItem[];
+  let initialKey: string;
+  let initialContent: string | null = null;
+
+  if (anyRaw) {
+    // Per-source pages: one entry per source. Snapshots are viewable; sources
+    // ingested before per-source raw existed are shown as "uncaptured".
+    items = sources.map((s, i) => ({
+      key: s.raw_id ?? `uncaptured-${i}`,
+      kind: s.raw_id ? "snapshot" : "uncaptured",
+      sourceId: s.raw_id ?? null,
+      type: s.type,
+      url: s.url,
+      fetched: s.fetched,
+      triggeredBy: s.triggered_by,
+    }));
+    const firstSnapshot = items.find((it) => it.kind === "snapshot")!;
+    initialKey = firstSnapshot.key;
+    try {
+      initialContent = (await readRawSourceById(slug, firstSnapshot.sourceId!))
+        .content;
+    } catch {
+      initialContent = null;
+    }
+  } else {
+    // Legacy page: a single latest blob, regardless of how many sources exist.
+    let blob;
+    try {
+      blob = await readRawSource(slug);
+    } catch {
+      notFound();
+    }
+    const latest = sources[0];
+    items = [
+      {
+        key: "__legacy__",
+        kind: "legacy",
+        sourceId: null,
+        type: latest?.type ?? "url",
+        url: latest?.url ?? "text-paste",
+        fetched: latest?.fetched ?? blob.modified.slice(0, 10),
+        triggeredBy: latest?.triggered_by ?? "system",
+      },
+    ];
+    initialKey = "__legacy__";
+    initialContent = blob.content;
   }
 
-  // Raw sources can be arbitrarily large (full HTML pages, PDFs, ...).
-  // Truncate anything above the inline budget and tell the user to use the
-  // download link for the full content, so the browser never chokes.
-  const tooLarge = source.size > MAX_INLINE_BYTES;
-  const displayedContent = tooLarge
-    ? source.content.slice(0, MAX_INLINE_BYTES)
-    : source.content;
-
   return (
-    <main className="mx-auto max-w-3xl px-6 py-12">
-      <Link
-        href={pagePath(pageTenant, slug)}
-        className="text-sm text-foreground/60 hover:text-foreground transition-colors"
-      >
-        ← Back to page
-      </Link>
-
-      <div className="mt-6">
-        <h1 className="font-mono text-2xl font-bold break-all">
-          {source.filename}
-        </h1>
-        <div className="mt-2 text-sm text-foreground/60">
-          {formatSize(source.size)} · Modified{" "}
-          {source.modified.slice(0, 10)} ·{" "}
-          <a
-            href={`/api/raw/${source.slug}`}
-            className="text-blue-600 underline hover:text-blue-500 dark:text-blue-400"
-          >
-            View raw
-          </a>
-        </div>
-      </div>
-
-      {tooLarge && (
-        <div className="mt-6 rounded-md border border-amber-300/60 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-800/60 dark:bg-amber-950/30 dark:text-amber-200">
-          File is {formatSize(source.size)} — showing the first{" "}
-          {formatSize(MAX_INLINE_BYTES)}. Use the{" "}
-          <a
-            href={`/api/raw/${source.slug}`}
-            className="underline hover:no-underline"
-          >
-            raw download
-          </a>{" "}
-          to see the full content.
-        </div>
-      )}
-
-      {/* Render the markdown so images and formatting show. The "View raw"
-          link above serves the unrendered plaintext via /api/raw. */}
-      <div className="mt-6 max-h-[70vh] overflow-auto rounded-lg border border-foreground/10 bg-foreground/[0.03] p-4">
-        <MarkdownRenderer content={displayedContent} />
-      </div>
-    </main>
+    <RawSourceBrowser
+      slug={slug}
+      items={items}
+      initialKey={initialKey}
+      initialContent={initialContent}
+      backHref={pagePath(pageTenant, slug)}
+    />
   );
 }

--- a/src/components/RawSourceBrowser.tsx
+++ b/src/components/RawSourceBrowser.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { MarkdownRenderer } from "@/components/MarkdownRenderer";
+import { SrcChip } from "@/components/folio/primitives";
+import type { SourceEntry } from "@/lib/types";
+
+/** One selectable source in the raw browser. */
+export interface RawItem {
+  /** React key + selection id. */
+  key: string;
+  /** snapshot = per-source raw; legacy = the single latest blob; uncaptured =
+   *  a source whose raw predates per-source storage (nothing to show). */
+  kind: "snapshot" | "legacy" | "uncaptured";
+  /** Per-source raw id (snapshot only); null for legacy/uncaptured. */
+  sourceId: string | null;
+  type: SourceEntry["type"];
+  url: string;
+  fetched: string;
+  triggeredBy: string;
+}
+
+interface Props {
+  slug: string;
+  items: RawItem[];
+  initialKey: string;
+  /** Pre-fetched content for the initial item (avoids a load flash). */
+  initialContent: string | null;
+  backHref: string;
+}
+
+/** Hard ceiling on how much raw content we render inline. */
+const MAX_INLINE = 500 * 1024; // 500 KB
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) {
+    const kb = bytes / 1024;
+    return kb >= 10 ? `${Math.round(kb)} KB` : `${kb.toFixed(1)} KB`;
+  }
+  const mb = bytes / (1024 * 1024);
+  return mb >= 10 ? `${Math.round(mb)} MB` : `${mb.toFixed(1)} MB`;
+}
+
+/** Human label for a source: its host, or "Pasted text" / "Uploaded file". */
+function sourceLabel(item: RawItem): string {
+  if (item.url === "text-paste") return "Pasted text";
+  if (item.url === "upload") return "Uploaded file";
+  try {
+    return new URL(item.url).hostname.replace(/^www\./, "");
+  } catch {
+    return item.url;
+  }
+}
+
+/** Download URL for an item (per-source when it's a snapshot). */
+function downloadHref(slug: string, item: RawItem): string {
+  return item.sourceId
+    ? `/api/raw/${slug}?source=${encodeURIComponent(item.sourceId)}`
+    : `/api/raw/${slug}`;
+}
+
+export function RawSourceBrowser({
+  slug,
+  items,
+  initialKey,
+  initialContent,
+  backHref,
+}: Props) {
+  const [selectedKey, setSelectedKey] = useState(initialKey);
+  // Per-item content cache: undefined = not loaded, null = errored/empty.
+  const [cache, setCache] = useState<Record<string, string | null>>(() =>
+    initialContent !== null ? { [initialKey]: initialContent } : {},
+  );
+  const [loading, setLoading] = useState(false);
+
+  const selected = items.find((i) => i.key === selectedKey) ?? items[0];
+
+  const load = useCallback(
+    async (item: RawItem) => {
+      if (item.kind === "uncaptured") return;
+      if (cache[item.key] !== undefined) return; // already loaded (or errored)
+      setLoading(true);
+      try {
+        const res = await fetch(downloadHref(slug, item));
+        const text = res.ok ? await res.text() : null;
+        setCache((c) => ({ ...c, [item.key]: text }));
+      } catch {
+        setCache((c) => ({ ...c, [item.key]: null }));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [slug, cache],
+  );
+
+  // Fetch the selected item's content on demand (skips the pre-seeded initial).
+  useEffect(() => {
+    if (selected) void load(selected);
+  }, [selected, load]);
+
+  const content = selected ? cache[selected.key] : undefined;
+
+  return (
+    <main className="mx-auto max-w-6xl px-6" style={{ paddingTop: 40, paddingBottom: 80 }}>
+      <Link
+        href={backHref}
+        className="text-sm text-foreground/60 hover:text-foreground transition-colors"
+      >
+        ← Back to page
+      </Link>
+
+      <p className="fmark" style={{ margin: "22px 0 18px" }}>
+        sources · {items.length}
+      </p>
+
+      <div className="flex flex-col lg:flex-row gap-8">
+        {/* Source rail */}
+        <aside className="lg:w-72 shrink-0">
+          {/* Mobile: a select; desktop: the list below. */}
+          <select
+            className="lg:hidden w-full rounded-lg border border-foreground/20 bg-transparent px-3 py-2 text-sm mb-4"
+            value={selectedKey}
+            onChange={(e) => setSelectedKey(e.target.value)}
+          >
+            {items.map((it) => (
+              <option key={it.key} value={it.key}>
+                {sourceLabel(it)} · {it.fetched}
+              </option>
+            ))}
+          </select>
+
+          <ul className="hidden lg:flex flex-col gap-1.5">
+            {items.map((it) => {
+              const active = it.key === selectedKey;
+              return (
+                <li key={it.key}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedKey(it.key)}
+                    className={`w-full text-left rounded-lg border px-3 py-2.5 transition-colors ${
+                      active
+                        ? "border-foreground/40 bg-foreground/5"
+                        : "border-foreground/10 hover:bg-foreground/[0.03]"
+                    }`}
+                  >
+                    <span className="flex items-center gap-2">
+                      <SrcChip type={it.type} />
+                      <span className="truncate text-sm font-medium">
+                        {sourceLabel(it)}
+                      </span>
+                    </span>
+                    <span className="mt-1 block text-xs text-foreground/50">
+                      {it.fetched} · @{it.triggeredBy}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </aside>
+
+        {/* Content pane */}
+        <section className="flex-1 min-w-0">
+          {selected && (
+            <>
+              <div className="mb-3 text-sm text-foreground/60 break-all">
+                {selected.url !== "text-paste" && selected.url !== "upload" ? (
+                  <a
+                    href={selected.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 underline hover:text-blue-500 dark:text-blue-400"
+                  >
+                    {selected.url}
+                  </a>
+                ) : (
+                  <span>{sourceLabel(selected)}</span>
+                )}
+                {selected.kind !== "uncaptured" && (
+                  <>
+                    {" · "}
+                    <a
+                      href={downloadHref(slug, selected)}
+                      className="text-blue-600 underline hover:text-blue-500 dark:text-blue-400"
+                    >
+                      Download
+                    </a>
+                  </>
+                )}
+              </div>
+
+              <div className="rounded-lg border border-foreground/10 bg-foreground/[0.03] p-4 max-h-[72vh] overflow-auto">
+                {selected.kind === "uncaptured" ? (
+                  <p className="text-sm text-foreground/50">
+                    Raw content for this source wasn&apos;t captured (it was
+                    ingested before per-source raw was stored). Only its
+                    provenance is recorded.
+                  </p>
+                ) : content === undefined ? (
+                  <p className="text-sm text-foreground/40">
+                    {loading ? "Loading…" : ""}
+                  </p>
+                ) : content === null ? (
+                  <p className="text-sm text-foreground/50">
+                    Couldn&apos;t load this source.
+                  </p>
+                ) : content.length > MAX_INLINE ? (
+                  <>
+                    <div className="mb-4 rounded-md border border-amber-300/60 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-800/60 dark:bg-amber-950/30 dark:text-amber-200">
+                      Source is {formatSize(content.length)} — showing the first{" "}
+                      {formatSize(MAX_INLINE)}. Use{" "}
+                      <a
+                        href={downloadHref(slug, selected)}
+                        className="underline hover:no-underline"
+                      >
+                        Download
+                      </a>{" "}
+                      for the full content.
+                    </div>
+                    <MarkdownRenderer content={content.slice(0, MAX_INLINE)} />
+                  </>
+                ) : (
+                  <MarkdownRenderer content={content} />
+                )}
+              </div>
+            </>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -538,6 +538,29 @@ describe("ingest — source URL tracking", () => {
     expect(second!.frontmatter.source_url).toBe("https://example.com/original");
   });
 
+  it("stores a per-source raw snapshot with a distinct raw_id per source", async () => {
+    const { readWikiPageWithFrontmatter, readRawSourceById } = await import("../wiki");
+
+    await ingest("Multi Source Page", "First source body. Some detail here.", {
+      sourceUrl: "https://a.example.com/one",
+    });
+    await ingest("Multi Source Page", "Second source body. Other detail here.", {
+      sourceUrl: "https://b.example.com/two",
+    });
+
+    const page = await readWikiPageWithFrontmatter("multi-source-page");
+    const sources = parseSources(page!.frontmatter.sources as string);
+    expect(sources).toHaveLength(2);
+    const ids = sources.map((s) => s.raw_id);
+    expect(ids.every(Boolean)).toBe(true);
+    expect(new Set(ids).size).toBe(2); // one snapshot per source
+
+    for (const s of sources) {
+      const raw = await readRawSourceById("multi-source-page", s.raw_id!);
+      expect(raw.content.length).toBeGreaterThan(0);
+    }
+  });
+
   it("overwrites source_url on re-ingest with a new URL", async () => {
     // First ingest with a URL
     await ingest("Reingest New Url", "First content. Has details.", {

--- a/src/lib/__tests__/raw.test.ts
+++ b/src/lib/__tests__/raw.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
-import { saveRawSource, listRawSources, readRawSource } from "../raw";
+import {
+  saveRawSource,
+  saveRawSourceFor,
+  listRawSources,
+  readRawSource,
+  readRawSourceById,
+} from "../raw";
 import { ensureDirectories } from "../wiki";
 
 let tmpDir: string;
@@ -216,5 +222,51 @@ describe("readRawSource", () => {
 
     const source = await readRawSource("mutable");
     expect(source.content).toBe("version 2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveRawSourceFor / readRawSourceById (per-source snapshots)
+// ---------------------------------------------------------------------------
+
+describe("per-source raw snapshots", () => {
+  it("round-trips a per-source snapshot at raw/<slug>/<rawId>.md", async () => {
+    await ensureDirectories();
+    await saveRawSourceFor("agentic-systems", "deadbeef", "raw source one");
+    const got = await readRawSourceById("agentic-systems", "deadbeef");
+    expect(got.content).toBe("raw source one");
+    expect(got.filename).toBe("deadbeef.md");
+    expect(got.slug).toBe("agentic-systems");
+  });
+
+  it("keeps multiple sources for the same slug side by side", async () => {
+    await ensureDirectories();
+    await saveRawSourceFor("p", "aaa111", "source A");
+    await saveRawSourceFor("p", "bbb222", "source B");
+    expect((await readRawSourceById("p", "aaa111")).content).toBe("source A");
+    expect((await readRawSourceById("p", "bbb222")).content).toBe("source B");
+  });
+
+  it("rejects a non-hex raw id (path-traversal guard)", async () => {
+    await ensureDirectories();
+    await expect(saveRawSourceFor("p", "../evil", "x")).rejects.toThrow();
+    await expect(readRawSourceById("p", "../../etc/passwd")).rejects.toThrow(
+      /not found/,
+    );
+  });
+
+  it("throws not-found for a missing snapshot", async () => {
+    await ensureDirectories();
+    await expect(readRawSourceById("p", "abc123")).rejects.toThrow(/not found/);
+  });
+
+  it("does not pollute the flat listRawSources() (subdirs are skipped)", async () => {
+    await ensureDirectories();
+    await saveRawSource("flat-one", "flat");
+    await saveRawSourceFor("flat-one", "cafe01", "nested snapshot");
+    const slugs = (await listRawSources()).map((s) => s.slug);
+    expect(slugs).toContain("flat-one");
+    // The per-source subdir is not surfaced as a flat raw source.
+    expect(slugs).not.toContain("cafe01");
   });
 });

--- a/src/lib/__tests__/sources.test.ts
+++ b/src/lib/__tests__/sources.test.ts
@@ -156,6 +156,16 @@ describe("buildSourceEntry", () => {
       fetched: "2026-05-02",
       triggered_by: "system",
     });
+    // No raw_id key when none is supplied (legacy-compatible shape).
+    expect("raw_id" in entry).toBe(false);
+  });
+
+  it("includes raw_id when supplied, and round-trips through serialize/parse", () => {
+    const entry = buildSourceEntry("https://example.com", "pdf", "yuanhao", "cafe1234");
+    expect(entry.raw_id).toBe("cafe1234");
+    const parsed = parseSources(serializeSources([entry]));
+    expect(parsed[0].raw_id).toBe("cafe1234");
+    expect(parsed[0].type).toBe("pdf");
   });
 
   it("builds a text-type entry", () => {

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -1,5 +1,6 @@
 import {
   saveRawSource,
+  saveRawSourceFor,
   writeWikiPageWithSideEffects,
   readWikiPageWithFrontmatter,
   serializeFrontmatter,
@@ -31,7 +32,14 @@ function mergeSourceEntry(sources: SourceEntry[], entry: SourceEntry): SourceEnt
       : sources;
   const idx = base.findIndex((s) => s.url === entry.url && s.type === entry.type);
   if (idx >= 0) {
-    base[idx] = { ...base[idx], fetched: entry.fetched, triggered_by: entry.triggered_by };
+    base[idx] = {
+      ...base[idx],
+      fetched: entry.fetched,
+      triggered_by: entry.triggered_by,
+      // Carry the new snapshot id (same URL → same id; also upgrades a legacy
+      // entry that predates per-source raw).
+      ...(entry.raw_id ? { raw_id: entry.raw_id } : {}),
+    };
   } else {
     base.push(entry);
   }
@@ -1352,11 +1360,19 @@ export async function ingest(
     frontmatter.source_url = options.sourceUrl;
   }
 
-  // Build the structured sources[] provenance entry for this ingest.
+  // Build the structured sources[] provenance entry for this ingest, and keep a
+  // per-source raw snapshot so a multi-source page can show each source's raw.
+  // The id is keyed on the source URL (so re-ingesting a URL refreshes that
+  // snapshot, matching how mergeSourceEntry dedups by url); paste/upload key on
+  // content instead, since they share the "text-paste" placeholder url.
   const sourceType = options?.sourceType
     ?? (options?.sourceUrl ? "url" : "text");
   const sourceUrl = options?.sourceUrl ?? "text-paste";
-  const sourceEntry = buildSourceEntry(sourceUrl, sourceType, options?.triggeredBy);
+  const rawId = contentHash(
+    sourceUrl !== "text-paste" && sourceUrl !== "upload" ? sourceUrl : content,
+  );
+  await saveRawSourceFor(slug, rawId, content);
+  const sourceEntry = buildSourceEntry(sourceUrl, sourceType, options?.triggeredBy, rawId);
   frontmatter.sources = serializeSources([sourceEntry]);
 
   // Apply tags from options (will be merged with existing tags below for re-ingests).

--- a/src/lib/raw.ts
+++ b/src/lib/raw.ts
@@ -16,6 +16,62 @@ export async function saveRawSource(
   return `${getRawDir()}/${id}.md`;
 }
 
+/** A per-source raw id is a hex hash — path-safe by construction. */
+const RAW_ID_RE = /^[a-f0-9]+$/;
+
+/**
+ * Save the raw snapshot of ONE source of a page at `raw/<slug>/<rawId>.md`.
+ * Unlike {@link saveRawSource} (a single latest blob per slug), this keeps every
+ * source's raw separately so a page built from multiple sources can show them
+ * all. `rawId` must be a hex hash; `slug` is validated as a path segment.
+ */
+export async function saveRawSourceFor(
+  slug: string,
+  rawId: string,
+  content: string,
+): Promise<string> {
+  validateSlug(slug);
+  if (!RAW_ID_RE.test(rawId)) {
+    throw new Error("Invalid raw id: must be a hex hash");
+  }
+  await ensureDirectories();
+  await getStorage().writeFile(rawRelPath(`${slug}/${rawId}.md`), content);
+  return `${getRawDir()}/${slug}/${rawId}.md`;
+}
+
+/**
+ * Read one per-source raw snapshot written by {@link saveRawSourceFor}.
+ * Both `slug` and `rawId` are validated before any filesystem access (the slug
+ * can't contain path separators; the id is a hex hash), so traversal is
+ * impossible. Throws "not found" when the snapshot doesn't exist.
+ */
+export async function readRawSourceById(
+  slug: string,
+  rawId: string,
+): Promise<RawSourceWithContent> {
+  validateSlug(slug);
+  if (!RAW_ID_RE.test(rawId)) {
+    throw new Error(`raw source not found: ${slug}/${rawId}`);
+  }
+  const rel = rawRelPath(`${slug}/${rawId}.md`);
+  let content: string;
+  try {
+    content = await getStorage().readFile(rel);
+  } catch {
+    throw new Error(`raw source not found: ${slug}/${rawId}`);
+  }
+  let size = content.length;
+  let modified = new Date().toISOString();
+  try {
+    const stat = await getStorage().stat(rel);
+    size = stat.size;
+    modified = stat.lastModified.toISOString();
+  } catch {
+    // stat is best-effort — content already read successfully.
+  }
+  return { slug, filename: `${rawId}.md`, size, modified, content };
+}
+
 // ---------------------------------------------------------------------------
 // Raw source browsing (read-only)
 // ---------------------------------------------------------------------------

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -78,11 +78,13 @@ export function buildSourceEntry(
   url: string,
   type: SourceEntry["type"] = "url",
   triggeredBy = "system",
+  rawId?: string,
 ): SourceEntry {
   return {
     type,
     url,
     fetched: new Date().toISOString().slice(0, 10),
     triggered_by: triggeredBy,
+    ...(rawId ? { raw_id: rawId } : {}),
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -137,6 +137,12 @@ export interface SourceEntry {
   fetched: string;
   /** Who triggered the ingest (user handle or "system"). */
   triggered_by: string;
+  /**
+   * Identifier of this source's per-source raw snapshot at
+   * `raw/<slug>/<raw_id>.md`. Absent on legacy pages ingested before per-source
+   * raw existed (those keep only the single latest `raw/<slug>.md`).
+   */
+  raw_id?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -560,7 +560,7 @@ export async function updateIndexUnsafe(entries: IndexEntry[]): Promise<void> {
 }
 
 // Re-export raw source utilities for backward compatibility
-export { saveRawSource, listRawSources, readRawSource } from "./raw";
+export { saveRawSource, saveRawSourceFor, listRawSources, readRawSource, readRawSourceById } from "./raw";
 export type { RawSource, RawSourceWithContent } from "./raw";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Part 2 of 2 (after #440 concise synthesis). Makes "View raw" show **all** of a page's sources, with UX that handles large content.

## Problem
Raw was a single `raw/<slug>.md` **overwritten on every re-ingest**, so a page accumulated from several sources kept only the *latest* source's raw. `sources[]` tracked metadata but pointed at no raw artifact.

## Changes
- **Storage** (`raw.ts`): `saveRawSourceFor(slug, rawId, content)` → `raw/<slug>/<rawId>.md`; `readRawSourceById`. Hex-id + `validateSlug` path-traversal guards. `saveRawSource`/`readRawSource` kept for the latest blob + legacy pages. Per-source subdirs don't pollute the flat `listRawSources()`.
- **Provenance** (`types.ts`, `sources.ts`): `SourceEntry.raw_id?`; `buildSourceEntry` sets it; `mergeSourceEntry` carries it (same URL → same id; upgrades a legacy entry).
- **Ingest** (`ingest.ts` commit path): `rawId = contentHash(url, or content for paste/upload)`; write the per-source snapshot + tag the source entry. Still writes the latest blob for back-compat.
- **API**: `GET /api/raw/[slug]?source=<rawId>` serves a specific snapshot (default = latest). Auth/404 unchanged.
- **Viewer** (`RawSourceBrowser` + rebuilt `raw/[slug]/page.tsx`): two-pane browser — left rail lists every source (type chip, host / "Pasted text" / "Uploaded file", date · @who); the content pane **lazy-loads** the selected source (never all at once), truncates >500 KB with a Download link, renders markdown. Mobile rail → `<select>`. **Legacy pages** show their single blob as one entry; sources ingested before per-source raw show an honest "uncaptured" note.

### Tradeoff
Only sources ingested **after** this ships get per-source raw; existing pages keep their single latest blob. No backfill.

## Test plan
- `pnpm build` clean; `pnpm test` — 2641 passed (+7).
- New: `raw.ts` round-trip / traversal-guard / flat-list-isolation; `sources.ts` `raw_id` round-trip; ingest integration (two URLs → two `sources[]` each with a distinct `raw_id` + both snapshot files readable).
- The `?source=` API path is a thin wrapper over the unit-tested `readRawSourceById` (incl. bad-id → 404), so it's covered indirectly rather than via a route-mock test.

**Feature branch — not merged, for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)