### PR TITLE
Fix trail source chip on fresh ingest + readable raw for PDFs

### DIFF
--- a/src/components/RawSourceBrowser.tsx
+++ b/src/components/RawSourceBrowser.tsx
@@ -61,6 +61,35 @@ function downloadHref(slug: string, item: RawItem): string {
     : `/api/raw/${slug}`;
 }
 
+/**
+ * Does the raw content carry markdown structure worth rendering (headings,
+ * images, lists, blockquotes, or paragraph breaks)? Extracted PDF / pasted text
+ * is often a structureless blob — rendering THAT through markdown collapses it
+ * into one giant paragraph, so we show it as faithful preformatted text instead.
+ */
+function looksLikeMarkdown(s: string): boolean {
+  const t = s.trimStart();
+  return (
+    /(^|\n)#{1,6}\s/.test(t) || // headings
+    /!\[[^\]]*\]\([^)]+\)/.test(t) || // images
+    /(^|\n)[-*+]\s/.test(t) || // bullet lists
+    /(^|\n)>\s/.test(t) || // blockquotes
+    /\n\n/.test(t) // paragraph breaks
+  );
+}
+
+/** Render raw content: markdown when it's structured, else faithful plaintext. */
+function RawContent({ text }: { text: string }) {
+  if (looksLikeMarkdown(text)) {
+    return <MarkdownRenderer content={text} />;
+  }
+  return (
+    <pre className="whitespace-pre-wrap break-words font-mono text-sm leading-relaxed text-foreground/80">
+      {text}
+    </pre>
+  );
+}
+
 export function RawSourceBrowser({
   slug,
   items,
@@ -219,10 +248,10 @@ export function RawSourceBrowser({
                       </a>{" "}
                       for the full content.
                     </div>
-                    <MarkdownRenderer content={content.slice(0, MAX_INLINE)} />
+                    <RawContent text={content.slice(0, MAX_INLINE)} />
                   </>
                 ) : (
-                  <MarkdownRenderer content={content} />
+                  <RawContent text={content} />
                 )}
               </div>
             </>

--- a/src/lib/__tests__/pdf-extraction.test.ts
+++ b/src/lib/__tests__/pdf-extraction.test.ts
@@ -63,6 +63,22 @@ describe("PDF extraction via fetchUrlContent", () => {
     expect(mockCleanup).toHaveBeenCalled();
   });
 
+  it("joins per-page text with blank lines (mergePages:false → string[])", async () => {
+    setupDocProxy();
+    // unpdf with mergePages:false returns text as a per-page array.
+    mockExtractText.mockResolvedValue({
+      totalPages: 2,
+      text: ["Page one body.", "Page two body."],
+    });
+    stubPdfFetch(new ArrayBuffer(300));
+
+    const result = await fetchUrlContent("https://example.com/multi.pdf");
+    expect(result.content).toContain("Page one body.");
+    expect(result.content).toContain("Page two body.");
+    // Page-level paragraph break preserved (not collapsed into one blob).
+    expect(result.content).toContain("Page one body.\n\nPage two body.");
+  });
+
   it("throws ClientInputError for empty text layer", async () => {
     setupDocProxy();
     mockExtractText.mockResolvedValue({ totalPages: 1, text: "" });

--- a/src/lib/__tests__/sources.test.ts
+++ b/src/lib/__tests__/sources.test.ts
@@ -3,8 +3,35 @@ import {
   serializeSources,
   parseSources,
   buildSourceEntry,
+  newestSourceType,
 } from "../sources";
 import type { SourceEntry } from "../types";
+
+describe("newestSourceType", () => {
+  const mk = (type: SourceEntry["type"], fetched: string): SourceEntry => ({
+    type,
+    url: "u",
+    fetched,
+    triggered_by: "system",
+  });
+
+  it("returns undefined for an empty list", () => {
+    expect(newestSourceType([])).toBeUndefined();
+  });
+
+  it("returns the only entry's type", () => {
+    expect(newestSourceType([mk("pdf", "2026-06-01")])).toBe("pdf");
+  });
+
+  it("picks the type of the newest entry by fetched date", () => {
+    const sources = [
+      mk("text", "2026-05-01"),
+      mk("pdf", "2026-06-07"),
+      mk("url", "2026-05-20"),
+    ];
+    expect(newestSourceType(sources)).toBe("pdf");
+  });
+});
 
 // ---------------------------------------------------------------------------
 // serializeSources

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -73,9 +73,12 @@ async function extractPdfText(
   const { getDocumentProxy, extractText } = await import("unpdf");
   const doc = await getDocumentProxy(new Uint8Array(buffer));
   try {
-    const { text } = await extractText(doc, { mergePages: true });
+    // Per-page joined with blank lines, so the text keeps page-level paragraph
+    // breaks instead of collapsing into one unreadable blob (synthesis + raw).
+    const { text } = await extractText(doc, { mergePages: false });
+    const joined = Array.isArray(text) ? text.join("\n\n") : text;
 
-    const trimmed = text.trim();
+    const trimmed = joined.trim();
     if (!trimmed) {
       throw new ClientInputError(
         "PDF has no extractable text layer. Scanned/image-only PDFs are not supported yet.",

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -335,8 +335,12 @@ export async function ingestPdf(
   const { getDocumentProxy, extractText } = await import("unpdf");
   const doc = await getDocumentProxy(new Uint8Array(bytes));
   try {
-    const { text } = await extractText(doc, { mergePages: true });
-    const trimmed = text.trim();
+    // Per-page (mergePages: false) joined with blank lines, so the extracted
+    // text keeps page-level paragraph breaks instead of collapsing into one
+    // unreadable blob — both for synthesis and for the stored raw snapshot.
+    const { text } = await extractText(doc, { mergePages: false });
+    const joined = Array.isArray(text) ? text.join("\n\n") : text;
+    const trimmed = joined.trim();
     if (!trimmed) {
       throw new ClientInputError(
         "PDF has no extractable text layer. Scanned/image-only PDFs are not supported yet.",

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -31,7 +31,7 @@ import { recordEditForAuthor } from "./contributor-index";
 import { pushRecentEvent, removeRecentForSlug } from "./recent-index";
 import { isAgentHandle } from "./agents";
 import { parseFrontmatter } from "./frontmatter";
-import { parseSources } from "./sources";
+import { parseSources, newestSourceType } from "./sources";
 import type { LogOperation } from "./wiki";
 import { logger } from "./logger";
 
@@ -451,14 +451,12 @@ async function runPageLifecycleOp(
         // (URL/PDF/…) immediately — the full-scan rebuild sets it too, but the
         // incremental push must match or a fresh ingest shows a chip-less row
         // until the next daily rebuild. Use the newest source entry.
-        let sourceType;
-        if (logOp === "ingest") {
-          const srcs = parseSources(fm.sources as string | string[] | undefined);
-          sourceType = srcs.reduce(
-            (newest, s) => (newest && newest.fetched >= s.fetched ? newest : s),
-            srcs[0],
-          )?.type;
-        }
+        const sourceType =
+          logOp === "ingest"
+            ? newestSourceType(
+                parseSources(fm.sources as string | string[] | undefined),
+              )
+            : undefined;
         await pushRecentEvent({
           ts: now,
           when: new Date(now).toISOString(),

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -31,6 +31,7 @@ import { recordEditForAuthor } from "./contributor-index";
 import { pushRecentEvent, removeRecentForSlug } from "./recent-index";
 import { isAgentHandle } from "./agents";
 import { parseFrontmatter } from "./frontmatter";
+import { parseSources } from "./sources";
 import type { LogOperation } from "./wiki";
 import { logger } from "./logger";
 
@@ -446,12 +447,25 @@ async function runPageLifecycleOp(
       });
       if (isCommons) {
         const now = Date.now();
+        // For ingests, carry the source type so the trail shows its chip
+        // (URL/PDF/…) immediately — the full-scan rebuild sets it too, but the
+        // incremental push must match or a fresh ingest shows a chip-less row
+        // until the next daily rebuild. Use the newest source entry.
+        let sourceType;
+        if (logOp === "ingest") {
+          const srcs = parseSources(fm.sources as string | string[] | undefined);
+          sourceType = srcs.reduce(
+            (newest, s) => (newest && newest.fetched >= s.fetched ? newest : s),
+            srcs[0],
+          )?.type;
+        }
         await pushRecentEvent({
           ts: now,
           when: new Date(now).toISOString(),
           actor: op.author,
           isAgent: isAgentHandle(op.author),
           action: logOp === "ingest" ? "ingested" : "edited",
+          ...(sourceType ? { sourceType } : {}),
           slug,
           title: op.title,
           tenant: tenantForOwner(

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -74,6 +74,20 @@ export function parseSources(raw: string | string[] | undefined): SourceEntry[] 
  * @param type       - Provenance type. Defaults to `"url"`.
  * @param triggeredBy - Who triggered the ingest. Defaults to `"system"`.
  */
+/**
+ * The `type` of the newest source entry (by `fetched` date), or `undefined` for
+ * an empty list. Used to tag a freshly-ingested page's trail event with its
+ * source chip. `fetched` is `YYYY-MM-DD`, so lexicographic compare is date order.
+ */
+export function newestSourceType(
+  sources: SourceEntry[],
+): SourceEntry["type"] | undefined {
+  return sources.reduce(
+    (newest, s) => (newest && newest.fetched >= s.fetched ? newest : s),
+    sources[0] as SourceEntry | undefined,
+  )?.type;
+}
+
 export function buildSourceEntry(
   url: string,
   type: SourceEntry["type"] = "url",


### PR DESCRIPTION
Three fixes, from debugging "re-ingested a PDF but no [PDF] chip, and its raw is unreadable".

## 1. Trail chip missing on fresh (re)ingest — the real cause
The homepage trail serves the precomputed `_idx:recent`. `rebuildRecentIndex()` (full scan) sets each event's `sourceType` from `sources[].type`, but **`pushRecentEvent` (the incremental write-path sync in `lifecycle.ts`) omitted it**. So a freshly-ingested page showed a **chip-less row** until the next daily rebuild — exactly why older "Agentic system" had `[URL]` but a just-re-ingested "SkillOpt" had none. Fix: derive `sourceType` from the page's newest source entry and include it in the pushed event.

(Confirmed SkillOpt *is* a PDF — its raw is the SkillOpt paper — so its type is `pdf`; the chip just wasn't in the incremental index.)

## 2. PDF raw was a structureless blob
`unpdf` `extractText(..., { mergePages: true })` returned the whole PDF as **one newline-less string** (verified: 92 KB, 0 newlines), so the raw view rendered it as one giant paragraph. Now extract **per-page (`mergePages: false`) joined with blank lines**, preserving page-level paragraph breaks for both synthesis and the stored raw.

## 3. Raw viewer renders faithfully
`RawSourceBrowser` now renders structureless content as **preformatted wrapped text** (faithful to "raw"), and keeps `MarkdownRenderer` for genuinely-markdown sources (headings/images/lists/paragraphs).

## To see it on the existing SkillOpt page
- **Chip:** re-running `rebuildRecentIndex` (daily cron, or `/api/tasks/scan`) after deploy re-derives the index *with* the pdf type — no re-ingest needed.
- **Readable raw:** the extraction fix only affects *future* ingests, so SkillOpt's already-stored blob stays a blob (now shown as wrapped plaintext); re-ingesting it produces page-broken raw.

## Test plan
- `pnpm build` clean; `pnpm test` — 2641 passed.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)