### PR TITLE
Layout-aware PDF extraction (readable raw + better synthesis)

### DIFF
--- a/src/components/RawSourceBrowser.tsx
+++ b/src/components/RawSourceBrowser.tsx
@@ -69,12 +69,18 @@ function downloadHref(slug: string, item: RawItem): string {
  */
 function looksLikeMarkdown(s: string): boolean {
   const t = s.trimStart();
+  // Require actual markdown markers — NOT bare blank lines, which extracted PDF
+  // text also has (rendering THAT through markdown would re-collapse its
+  // layout-preserved line breaks into a wall).
   return (
     /(^|\n)#{1,6}\s/.test(t) || // headings
     /!\[[^\]]*\]\([^)]+\)/.test(t) || // images
-    /(^|\n)[-*+]\s/.test(t) || // bullet lists
+    /\[[^\]]+\]\([^)\s]+\)/.test(t) || // links
+    /(^|\n)\s*[-*+]\s/.test(t) || // bullet lists
+    /(^|\n)\s*\d+\.\s/.test(t) || // numbered lists
     /(^|\n)>\s/.test(t) || // blockquotes
-    /\n\n/.test(t) // paragraph breaks
+    /(^|\n)```/.test(t) || // code fences
+    /(^|\n)\|.+\|/.test(t) // tables
   );
 }
 

--- a/src/lib/__tests__/pdf-extraction.test.ts
+++ b/src/lib/__tests__/pdf-extraction.test.ts
@@ -63,6 +63,31 @@ describe("PDF extraction via fetchUrlContent", () => {
     expect(mockCleanup).toHaveBeenCalled();
   });
 
+  it("reconstructs line breaks from pdf.js text items (hasEOL) per page", async () => {
+    // A doc with getPage/getTextContent → the structured (layout-aware) path.
+    const page = {
+      getTextContent: vi.fn().mockResolvedValue({
+        items: [
+          { str: "Title Line", hasEOL: true },
+          { str: "first wrapped ", hasEOL: false },
+          { str: "sentence.", hasEOL: true },
+        ],
+      }),
+    };
+    mockGetDocumentProxy.mockResolvedValue({
+      numPages: 1,
+      getPage: vi.fn().mockResolvedValue(page),
+      cleanup: mockCleanup,
+    });
+    stubPdfFetch(new ArrayBuffer(300));
+
+    const result = await fetchUrlContent("https://example.com/structured.pdf");
+    expect(result.title).toBe("Title Line");
+    // hasEOL split lines (not one flattened blob); the non-EOL items joined.
+    expect(result.content).toContain("Title Line\nfirst wrapped sentence.");
+    expect(mockCleanup).toHaveBeenCalled();
+  });
+
   it("joins per-page text with blank lines (mergePages:false → string[])", async () => {
     setupDocProxy();
     // unpdf with mergePages:false returns text as a per-page array.

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -62,44 +62,79 @@ const ALLOWED_CONTENT_TYPES = [
 ];
 
 /**
- * Extract text from a PDF ArrayBuffer using unpdf (serverless pdf.js).
- * Returns { title, content } or throws on empty/unreadable PDFs.
- * Uses dynamic import to avoid loading the ~1.6 MB pdf.js bundle on every request.
+ * Extract a PDF's text WITH layout structure preserved.
+ *
+ * unpdf's `extractText` flattens every text item into a single space-joined run
+ * (no line breaks), turning a long PDF into one unreadable wall — bad for the
+ * human "View raw" surface and weaker as synthesis input. Instead we read
+ * pdf.js' per-item text and use each item's `hasEOL` flag to rebuild lines, with
+ * a blank line between pages. Falls back to `extractText` when the structured
+ * API isn't available (e.g. a stubbed doc) or yields nothing. Shared by the URL
+ * and upload PDF paths. Uses a dynamic import to avoid the ~1.6 MB pdf.js bundle
+ * on every request.
  */
+export async function pdfToText(buffer: ArrayBuffer): Promise<string> {
+  const { getDocumentProxy, extractText } = await import("unpdf");
+  const doc = await getDocumentProxy(new Uint8Array(buffer));
+  try {
+    try {
+      if (typeof doc.getPage === "function" && doc.numPages > 0) {
+        const pages: string[] = [];
+        for (let p = 1; p <= doc.numPages; p++) {
+          const page = await doc.getPage(p);
+          const content = await page.getTextContent();
+          const lines: string[] = [];
+          let line = "";
+          for (const item of content.items as Array<{
+            str?: string;
+            hasEOL?: boolean;
+          }>) {
+            if (typeof item.str !== "string") continue;
+            line += item.str;
+            if (item.hasEOL) {
+              lines.push(line.trimEnd());
+              line = "";
+            }
+          }
+          if (line.trim()) lines.push(line.trimEnd());
+          pages.push(lines.join("\n"));
+        }
+        const structured = pages.join("\n\n").trim();
+        if (structured) return structured;
+      }
+    } catch {
+      // Structured extraction unavailable/failed — fall through to flat text.
+    }
+    const { text } = await extractText(doc, { mergePages: false });
+    return (Array.isArray(text) ? text.join("\n\n") : text).trim();
+  } finally {
+    await doc.cleanup();
+  }
+}
+
 async function extractPdfText(
   buffer: ArrayBuffer,
   fallbackTitle: string,
 ): Promise<{ title: string; content: string }> {
-  const { getDocumentProxy, extractText } = await import("unpdf");
-  const doc = await getDocumentProxy(new Uint8Array(buffer));
-  try {
-    // Per-page joined with blank lines, so the text keeps page-level paragraph
-    // breaks instead of collapsing into one unreadable blob (synthesis + raw).
-    const { text } = await extractText(doc, { mergePages: false });
-    const joined = Array.isArray(text) ? text.join("\n\n") : text;
-
-    const trimmed = joined.trim();
-    if (!trimmed) {
-      throw new ClientInputError(
-        "PDF has no extractable text layer. Scanned/image-only PDFs are not supported yet.",
-      );
-    }
-
-    // Try to derive title from first non-empty line (often the document title)
-    const firstLine =
-      trimmed.split("\n").find((l) => l.trim().length > 0)?.trim() ??
-      fallbackTitle;
-    const title = firstLine.length > 200 ? firstLine.slice(0, 200) : firstLine;
-
-    const content =
-      trimmed.length > MAX_CONTENT_LENGTH
-        ? trimmed.slice(0, MAX_CONTENT_LENGTH) + "\n\n[Content truncated]"
-        : trimmed;
-
-    return { title: title || fallbackTitle, content };
-  } finally {
-    await doc.cleanup();
+  const trimmed = (await pdfToText(buffer)).trim();
+  if (!trimmed) {
+    throw new ClientInputError(
+      "PDF has no extractable text layer. Scanned/image-only PDFs are not supported yet.",
+    );
   }
+
+  // Title from the first non-empty line (often the document title).
+  const firstLine =
+    trimmed.split("\n").find((l) => l.trim().length > 0)?.trim() ??
+    fallbackTitle;
+  const title = firstLine.length > 200 ? firstLine.slice(0, 200) : firstLine;
+
+  const content =
+    trimmed.length > MAX_CONTENT_LENGTH
+      ? trimmed.slice(0, MAX_CONTENT_LENGTH) + "\n\n[Content truncated]"
+      : trimmed;
+
+  return { title: title || fallbackTitle, content };
 }
 
 /**

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -9,7 +9,7 @@ import {
   type Frontmatter,
 } from "./wiki";
 import { callLLM, hasLLMKey } from "./llm";
-import { fetchUrlContent, downloadImages, fetchImageBytes, storeImageBytes } from "./fetch";
+import { fetchUrlContent, downloadImages, fetchImageBytes, storeImageBytes, pdfToText } from "./fetch";
 import { describeImage } from "./vision";
 import { isYouTubeUrl, fetchYouTubeContent } from "./youtube";
 import type { IngestResult, IngestPreviewMeta, SourceEntry } from "./types";
@@ -332,44 +332,32 @@ export async function ingestPdf(
     );
   }
 
-  const { getDocumentProxy, extractText } = await import("unpdf");
-  const doc = await getDocumentProxy(new Uint8Array(bytes));
-  try {
-    // Per-page (mergePages: false) joined with blank lines, so the extracted
-    // text keeps page-level paragraph breaks instead of collapsing into one
-    // unreadable blob — both for synthesis and for the stored raw snapshot.
-    const { text } = await extractText(doc, { mergePages: false });
-    const joined = Array.isArray(text) ? text.join("\n\n") : text;
-    const trimmed = joined.trim();
-    if (!trimmed) {
-      throw new ClientInputError(
-        "PDF has no extractable text layer. Scanned/image-only PDFs are not supported yet.",
-      );
-    }
-    const content =
-      trimmed.length > MAX_CONTENT_LENGTH
-        ? trimmed.slice(0, MAX_CONTENT_LENGTH)
-        : trimmed;
-
-    // Derive title from first line or filename
-    const firstLine =
-      trimmed.split("\n").find((l) => l.trim().length > 0)?.trim() ?? "";
-    const derivedTitle =
-      firstLine.length > 200 ? firstLine.slice(0, 200) : firstLine;
-    const title =
-      options?.title ||
-      derivedTitle ||
-      filename.replace(/\.pdf$/i, "") ||
-      "PDF Document";
-
-    const result = await ingest(title, content, {
-      ...options,
-      sourceType: "pdf",
-    });
-    return options?.preview ? { ...result, sourceContent: content } : result;
-  } finally {
-    await doc.cleanup();
+  // Layout-aware extraction (preserves line/paragraph structure) — shared with
+  // the URL PDF path so the raw stays readable and synthesis gets better input.
+  const trimmed = (await pdfToText(bytes)).trim();
+  if (!trimmed) {
+    throw new ClientInputError(
+      "PDF has no extractable text layer. Scanned/image-only PDFs are not supported yet.",
+    );
   }
+  const content =
+    trimmed.length > MAX_CONTENT_LENGTH
+      ? trimmed.slice(0, MAX_CONTENT_LENGTH)
+      : trimmed;
+
+  // Derive title from first line or filename.
+  const firstLine =
+    trimmed.split("\n").find((l) => l.trim().length > 0)?.trim() ?? "";
+  const derivedTitle =
+    firstLine.length > 200 ? firstLine.slice(0, 200) : firstLine;
+  const title =
+    options?.title || derivedTitle || filename.replace(/\.pdf$/i, "") || "PDF Document";
+
+  const result = await ingest(title, content, {
+    ...options,
+    sourceType: "pdf",
+  });
+  return options?.preview ? { ...result, sourceContent: content } : result;
 }
 
 /**


### PR DESCRIPTION
## Problem
The SkillOpt page's raw is an unreadable wall (no paragraphs/lines). Root cause: `unpdf`'s `extractText` **flattens every text item into one space-joined run** — it discards the PDF's line layout, so even per-page joining gives a blob. (Earlier `mergePages:false` only added page breaks, not line structure.)

## Fix
New shared **`pdfToText(buffer)`** reads pdf.js' per-item text via `getTextContent()` and rebuilds lines from each item's **`hasEOL`** flag, joining pages with blank lines — readable for "View raw" and better-structured input for synthesis. It falls back to the flat `extractText` when the structured API isn't available (e.g. a stubbed doc) or yields nothing. **Both** the URL (`fetchUrlContent`) and upload (`ingestPdf`) PDF paths now share it (de-duplicated).

Also: `RawSourceBrowser.looksLikeMarkdown` no longer treats bare blank lines as markdown (requires real markers), so layout-preserved extracted text renders as faithful `<pre>` instead of being re-collapsed into a wall by the markdown renderer.

## To fix the existing SkillOpt page
This only affects **future** extractions, so SkillOpt's stored blob stays a blob. **Re-ingest** `https://arxiv.org/pdf/2605.23904` and its raw will have line structure (and the synthesized page improves too).

## Test plan
- `pnpm build` clean; `pnpm test` — 2646 passed.
- New test: structured path reconstructs line breaks from `hasEOL` items (and merges non-EOL items into a line); existing flat-extraction tests still pass via the fallback.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)