### PR TITLE
Place source images inline + filter decorative ones

### DIFF
--- a/src/lib/__tests__/ingest-image.test.ts
+++ b/src/lib/__tests__/ingest-image.test.ts
@@ -129,10 +129,13 @@ describe("ingestImage", () => {
   });
 });
 
-describe("appendSourceImages (via ingest, LLM path)", () => {
-  it("appends a ## Images section with source images the LLM distillation dropped", async () => {
+describe("inline source images (via ingest, LLM path)", () => {
+  it("places a kept [[IMG:n]] token inline as the real image ref (no ## Images dump)", async () => {
     mockedHasLLMKey.mockReturnValue(true);
-    mockedCallLLM.mockResolvedValue("# Doc\n\n## Summary\n\nDistilled text, no images.");
+    // The LLM keeps the image by echoing its placeholder token inline.
+    mockedCallLLM.mockResolvedValue(
+      "# Doc\n\n## Summary\n\nDistilled.\n\n[[IMG:1]]\n\n## Details\n\nMore.",
+    );
 
     const result = await ingest(
       "Doc With Pics",
@@ -141,8 +144,39 @@ describe("appendSourceImages (via ingest, LLM path)", () => {
     );
 
     const page = await readWikiPageWithFrontmatter(result.primarySlug);
-    expect(page!.content).toContain("## Images");
     expect(page!.content).toContain("![a chart](assets/doc/chart.png)");
+    expect(page!.content).not.toContain("## Images");
+    expect(page!.content).not.toContain("[[IMG:"); // token substituted, none left
+  });
+
+  it("drops an image whose token the LLM omitted (relevance filtering)", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    mockedCallLLM.mockResolvedValue("# Doc\n\n## Summary\n\nDistilled, image not kept.");
+
+    const result = await ingest(
+      "Doc No Pics",
+      "Some text.\n\n![a chart](assets/doc/chart.png)\n\nmore text.",
+      { author: "alice", owner: "alice" },
+    );
+
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect(page!.content).not.toContain("chart.png");
+    expect(page!.content).not.toContain("## Images");
+  });
+
+  it("strips decorative images (logo) before the LLM sees them", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    // Even if the LLM emits IMG:1, the logo was never tokenized → nothing to restore.
+    mockedCallLLM.mockResolvedValue("# Doc\n\n## Summary\n\nText.\n\n[[IMG:1]]");
+
+    const result = await ingest(
+      "Doc Logo",
+      "Intro.\n\n![site logo](assets/doc/logo.png)\n\nbody.",
+      { author: "alice", owner: "alice" },
+    );
+
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect(page!.content).not.toContain("logo.png");
   });
 });
 

--- a/src/lib/__tests__/ingest-image.test.ts
+++ b/src/lib/__tests__/ingest-image.test.ts
@@ -17,7 +17,7 @@ import { ingest, ingestImage } from "../ingest";
 import { hasLLMKey, callLLM } from "../llm";
 import { describeImage } from "../vision";
 import { fetchImageBytes, storeImageBytes } from "../fetch";
-import { readWikiPageWithFrontmatter } from "../wiki";
+import { readWikiPageWithFrontmatter, readRawSourceById } from "../wiki";
 import { parseSources } from "../sources";
 import { resetSourceIndex } from "../source-index";
 import { resetAliasIndex } from "../alias-index";
@@ -147,6 +147,13 @@ describe("inline source images (via ingest, LLM path)", () => {
     expect(page!.content).toContain("![a chart](assets/doc/chart.png)");
     expect(page!.content).not.toContain("## Images");
     expect(page!.content).not.toContain("[[IMG:"); // token substituted, none left
+
+    // Invariant: the RAW source keeps the original refs untokenized — tokenizing
+    // only the LLM input, never `content` (which feeds saveRawSource + dedup hash).
+    const rawId = parseSources(page!.frontmatter.sources as string)[0]?.raw_id;
+    const raw = await readRawSourceById(result.primarySlug, rawId!);
+    expect(raw.content).toContain("![a chart](assets/doc/chart.png)");
+    expect(raw.content).not.toContain("[[IMG:");
   });
 
   it("drops an image whose token the LLM omitted (relevance filtering)", async () => {
@@ -177,6 +184,9 @@ describe("inline source images (via ingest, LLM path)", () => {
 
     const page = await readWikiPageWithFrontmatter(result.primarySlug);
     expect(page!.content).not.toContain("logo.png");
+    // Distinguish "logo stripped" from "feature silently no-op": the token the
+    // LLM emitted had no ref to restore, so it must be dropped, not left raw.
+    expect(page!.content).not.toContain("[[IMG:");
   });
 });
 

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -11,6 +11,8 @@ import {
   chunkText,
   parseConceptMarker,
   parseDisputedMarker,
+  tokenizeSourceImages,
+  restoreImageTokens,
 } from "../ingest";
 import { slugify } from "../slugify";
 import { loadPageConventions } from "../schema";
@@ -2987,5 +2989,44 @@ describe("ingest attribution", () => {
     const page = await readWikiPageWithFrontmatter("sys-page");
     expect(page!.frontmatter.authors).toEqual(["system"]);
     expect(page!.frontmatter.owner).toBe("system");
+  });
+});
+
+describe("tokenizeSourceImages / restoreImageTokens", () => {
+  it("round-trips content images through tokens", () => {
+    const src = "Intro.\n\n![a chart](assets/p/chart.png)\n\nbody.";
+    const { text, refs } = tokenizeSourceImages(src);
+    expect(text).toContain("[[IMG:1]]");
+    expect(text).not.toContain("chart.png");
+    expect(refs).toEqual([{ alt: "a chart", ref: "assets/p/chart.png" }]);
+    expect(restoreImageTokens(text, refs)).toContain(
+      "![a chart](assets/p/chart.png)",
+    );
+  });
+
+  it("strips decorative images (logo/icon) — never tokenized", () => {
+    const { text, refs } = tokenizeSourceImages(
+      "![site logo](assets/p/logo.png)\n\n![diagram](https://x.com/fig.png)",
+    );
+    expect(refs).toEqual([{ alt: "diagram", ref: "https://x.com/fig.png" }]);
+    expect(text).not.toContain("logo.png");
+    expect(text).toContain("[[IMG:1]]");
+  });
+
+  it("drops omitted and out-of-range tokens on restore", () => {
+    const refs = [{ alt: "a", ref: "assets/p/a.png" }];
+    // Token 1 kept inline, token 2 hallucinated → dropped; an unreferenced image filtered.
+    expect(restoreImageTokens("x [[IMG:1]] y [[IMG:2]] z", refs)).toBe(
+      "x ![a](assets/p/a.png) y  z",
+    );
+  });
+
+  it("caps the number of tokenized images", () => {
+    const imgs = Array.from(
+      { length: 20 },
+      (_, i) => `![fig${i}](assets/p/f${i}.png)`,
+    ).join("\n\n");
+    const { refs } = tokenizeSourceImages(imgs);
+    expect(refs.length).toBe(12); // MAX_APPENDED_IMAGES
   });
 });

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -3021,6 +3021,14 @@ describe("tokenizeSourceImages / restoreImageTokens", () => {
     );
   });
 
+  it("dedups a repeated ref to one entry, reusing its token", () => {
+    const { text, refs } = tokenizeSourceImages(
+      "![x](assets/p/a.png)\n\nmid\n\n![x again](assets/p/a.png)",
+    );
+    expect(refs).toEqual([{ alt: "x", ref: "assets/p/a.png" }]); // one entry
+    expect((text.match(/\[\[IMG:1\]\]/g) ?? []).length).toBe(2); // both reuse token 1
+  });
+
   it("caps the number of tokenized images", () => {
     const imgs = Array.from(
       { length: 20 },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -36,7 +36,7 @@ export const MAX_LLM_INPUT_CHARS = 12_000;
 /** Maximum number of images to download per source during ingest. */
 export const MAX_IMAGES_PER_SOURCE = 20;
 
-/** Maximum number of source images surfaced in a wiki page's `## Images` section. */
+/** Maximum number of source images tokenized for inline placement during synthesis. */
 export const MAX_APPENDED_IMAGES = 12;
 
 // ---- Batch ingest ---------------------------------------------------------

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -472,7 +472,7 @@ export function tokenizeSourceImages(content: string): {
     if (DECORATIVE_IMAGE_RE.test(ref) || DECORATIVE_IMAGE_RE.test(alt)) {
       return ""; // strip decorative images so the LLM never sees them
     }
-    if (refs.length >= MAX_APPENDED_IMAGES) return whole; // cap; leave extras as-is
+    if (refs.length >= MAX_APPENDED_IMAGES) return ""; // past the cap → drop (don't leak a raw ref)
     refs.push({ alt, ref });
     return `\n\n[[IMG:${refs.length}]]\n\n`;
   });

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -445,38 +445,50 @@ function generateFallbackPage(title: string, content: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Append the source's downloaded images to the wiki body as a trailing
- * `## Images` section. The LLM distills text and drops image refs, so this
- * deterministically re-surfaces them (no LLM cost, no hallucinated paths).
- *
- * Only locally-downloaded images (`assets/...` refs, produced by
- * {@link downloadImages}) are included — they're guaranteed servable via
- * `/api/assets`. Idempotent: if the body already has an `## Images` heading
- * (e.g. a preview→commit round-trip), it's returned unchanged.
+/** An image ref captured from the source for token-based inline placement. */
+interface SourceImageRef {
+  alt: string;
+  ref: string;
+}
+
+/** Image refs we strip outright (decorative/branding/UI — never content). */
+const DECORATIVE_IMAGE_RE = /(logo|icon|avatar|sprite|favicon|emoji|banner)/i;
+
+/**
+ * Replace the source's image refs with short `[[IMG:n]]` placeholder tokens at
+ * their original positions, so the synthesis LLM can keep the genuine ones by
+ * placing the same token inline where it now belongs (and omit the rest) — the
+ * LLM reliably preserves a tiny token but mangles long `assets/<slug>/x.png`
+ * paths. Decorative/branding images are removed outright (never tokenized).
+ * Returns the tokenized text plus the ordered ref map for {@link restoreImageTokens}.
  */
-function appendSourceImages(wikiBody: string, sourceContent: string): string {
-  if (/^##\s+Images\s*$/m.test(wikiBody)) return wikiBody;
-
-  // Surface images the LLM dropped: both localized (assets/…) and ones kept as
-  // their original http(s) URL (download skipped/failed, e.g. salvaged figures).
+export function tokenizeSourceImages(content: string): {
+  text: string;
+  refs: SourceImageRef[];
+} {
+  const refs: SourceImageRef[] = [];
   const re = /!\[([^\]]*)\]\(((?:assets\/|https?:\/\/)[^)\s]+)\)/g;
-  const seen = new Set<string>();
-  const refs: { alt: string; ref: string }[] = [];
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(sourceContent)) !== null) {
-    const ref = m[2];
-    if (seen.has(ref)) continue;
-    seen.add(ref);
-    // Don't duplicate an image the body already embeds (e.g. the image-ingest
-    // page, where the image is the page's centerpiece).
-    if (wikiBody.includes(`](${ref})`)) continue;
-    refs.push({ alt: m[1], ref });
-    if (refs.length >= MAX_APPENDED_IMAGES) break;
-  }
-  if (refs.length === 0) return wikiBody;
+  const text = content.replace(re, (whole, alt: string, ref: string) => {
+    if (DECORATIVE_IMAGE_RE.test(ref) || DECORATIVE_IMAGE_RE.test(alt)) {
+      return ""; // strip decorative images so the LLM never sees them
+    }
+    if (refs.length >= MAX_APPENDED_IMAGES) return whole; // cap; leave extras as-is
+    refs.push({ alt, ref });
+    return `\n\n[[IMG:${refs.length}]]\n\n`;
+  });
+  return { text, refs };
+}
 
-  const section = refs.map(({ alt, ref }) => `![${alt}](${ref})`).join("\n\n");
-  return `${wikiBody}\n\n## Images\n\n${section}`;
+/**
+ * Substitute the real image refs back for the `[[IMG:n]]` tokens the LLM kept.
+ * Tokens the LLM omitted are absent (those images are filtered out); tokens with
+ * an out-of-range/invalid `n` (hallucinated) are dropped.
+ */
+export function restoreImageTokens(body: string, refs: SourceImageRef[]): string {
+  return body.replace(/\[\[IMG:(\d+)\]\]/g, (_whole, n: string) => {
+    const img = refs[Number(n) - 1];
+    return img ? `![${img.alt}](${img.ref})` : "";
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -663,6 +675,8 @@ Then, on the following lines, the wiki article. Include:
   click away ("View raw"), so do NOT try to reproduce it. Invent nothing not
   supported by the source.
 
+Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. KEEP the ones that are genuine content — diagrams, figures, charts, screenshots that illustrate the topic — by writing the SAME token on its own line at the most relevant point in the article (next to the text it illustrates). OMIT tokens for decorative/branding/UI images. Never invent tokens or change their numbers; output each kept token verbatim.
+
 Write a focused, distilled page, not a transcript of the source. Output the CONCEPT and ALIASES lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
 
 /**
@@ -674,6 +688,8 @@ Write a focused, distilled page, not a transcript of the source. Output the CONC
 const CONTINUATION_SYSTEM_PROMPT = `You are a wiki editor. You have already started a wiki article from earlier parts of a long source document. You are now given additional source material.
 
 Add new key points, concepts, and details from the additional source material. Do NOT repeat the title, summary, or any content already in the article. Only output the new sections or bullet points to append.
+
+Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. Keep genuine content images (diagrams, figures, charts, screenshots) by writing the SAME token on its own line where relevant; omit decorative/branding/UI images. Never invent tokens or change their numbers.
 
 Output pure markdown and nothing else. Do not wrap in code fences.`;
 
@@ -1138,7 +1154,10 @@ export async function ingest(
     wikiContent = preGeneratedContent;
   } else if (hasLLMKey()) {
     const systemPrompt = await buildIngestSystemPrompt();
-    const chunks = chunkText(content, MAX_LLM_INPUT_CHARS);
+    // Swap source images for [[IMG:n]] tokens so the LLM can place the relevant
+    // ones inline (and omit decorative ones); refs are restored after synthesis.
+    const { text: llmInput, refs: imageRefs } = tokenizeSourceImages(content);
+    const chunks = chunkText(llmInput, MAX_LLM_INPUT_CHARS);
 
     // Larger output budget so the ## Details section can preserve substantive
     // source content instead of being truncated.
@@ -1162,6 +1181,9 @@ export async function ingest(
         wikiContent += "\n\n" + continuation;
       }
     }
+
+    // Restore the kept [[IMG:n]] tokens to real refs (omitted ones are dropped).
+    wikiContent = restoreImageTokens(wikiContent, imageRefs);
   } else {
     wikiContent = generateFallbackPage(title, content);
   }
@@ -1198,9 +1220,8 @@ export async function ingest(
     }
   }
 
-  // The LLM distills text and drops image refs, so deterministically append the
-  // source's downloaded images as a trailing section — reliable, no LLM cost.
-  wikiContent = appendSourceImages(wikiContent, content);
+  // Images are placed inline during synthesis via [[IMG:n]] tokens (see
+  // tokenizeSourceImages / restoreImageTokens) — no trailing dump.
 
   // Commit-from-preview carries no CONCEPT marker (preview stripped it), so the
   // canonical slug would otherwise stay the source-TITLE slug even though the

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -467,13 +467,17 @@ export function tokenizeSourceImages(content: string): {
   refs: SourceImageRef[];
 } {
   const refs: SourceImageRef[] = [];
+  const tokenByRef = new Map<string, number>(); // dedup: same ref → same token
   const re = /!\[([^\]]*)\]\(((?:assets\/|https?:\/\/)[^)\s]+)\)/g;
-  const text = content.replace(re, (whole, alt: string, ref: string) => {
+  const text = content.replace(re, (_whole, alt: string, ref: string) => {
     if (DECORATIVE_IMAGE_RE.test(ref) || DECORATIVE_IMAGE_RE.test(alt)) {
       return ""; // strip decorative images so the LLM never sees them
     }
+    const existing = tokenByRef.get(ref);
+    if (existing) return `\n\n[[IMG:${existing}]]\n\n`; // reuse — don't spend a cap slot
     if (refs.length >= MAX_APPENDED_IMAGES) return ""; // past the cap → drop (don't leak a raw ref)
     refs.push({ alt, ref });
+    tokenByRef.set(ref, refs.length);
     return `\n\n[[IMG:${refs.length}]]\n\n`;
   });
   return { text, refs };
@@ -485,10 +489,20 @@ export function tokenizeSourceImages(content: string): {
  * an out-of-range/invalid `n` (hallucinated) are dropped.
  */
 export function restoreImageTokens(body: string, refs: SourceImageRef[]): string {
-  return body.replace(/\[\[IMG:(\d+)\]\]/g, (_whole, n: string) => {
-    const img = refs[Number(n) - 1];
-    return img ? `![${img.alt}](${img.ref})` : "";
+  const kept = new Set<number>();
+  const out = body.replace(/\[\[IMG:(\d+)\]\]/g, (_whole, n: string) => {
+    const idx = Number(n) - 1;
+    const img = refs[idx];
+    if (!img) return "";
+    kept.add(idx);
+    return `![${img.alt}](${img.ref})`;
   });
+  // Observability: a sudden "kept 0/N" signals a prompt/truncation regression
+  // silently dropping real figures (which otherwise leaves no trace).
+  if (refs.length > 0) {
+    logger.debug("ingest", `inline images: kept ${kept.size}/${refs.length}`);
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -675,7 +689,7 @@ Then, on the following lines, the wiki article. Include:
   click away ("View raw"), so do NOT try to reproduce it. Invent nothing not
   supported by the source.
 
-Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. KEEP the ones that are genuine content — diagrams, figures, charts, screenshots that illustrate the topic — by writing the SAME token on its own line at the most relevant point in the article (next to the text it illustrates). OMIT tokens for decorative/branding/UI images. Never invent tokens or change their numbers; output each kept token verbatim.
+Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. KEEP the ones that are genuine content — diagrams, figures, charts, screenshots that illustrate the topic — by writing the SAME token on its own line at the most relevant point in the article (next to the text it illustrates). Omit any token whose image is clearly decorative/branding/UI. Never invent tokens or change their numbers; output each kept token verbatim.
 
 Write a focused, distilled page, not a transcript of the source. Output the CONCEPT and ALIASES lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
 
@@ -689,7 +703,7 @@ const CONTINUATION_SYSTEM_PROMPT = `You are a wiki editor. You have already star
 
 Add new key points, concepts, and details from the additional source material. Do NOT repeat the title, summary, or any content already in the article. Only output the new sections or bullet points to append.
 
-Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. Keep genuine content images (diagrams, figures, charts, screenshots) by writing the SAME token on its own line where relevant; omit decorative/branding/UI images. Never invent tokens or change their numbers.
+Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. Keep genuine content images (diagrams, figures, charts, screenshots) by writing the SAME token on its own line where relevant; omit any whose image is clearly decorative/branding/UI. Never invent tokens or change their numbers.
 
 Output pure markdown and nothing else. Do not wrap in code fences.`;
 


### PR DESCRIPTION
## Problem
Source images were appended in a trailing **`## Images`** dump — divorced from the text they illustrate, and including decorative junk (logos/icons). The ask: place each relevant image **inline at the right point** (anchored on its original position) and **filter out non-relevant ones**.

The challenge: the LLM rewrites the prose, so a source position doesn't map to the synthesized page.

## Approach — placeholder tokens
1. Before synthesis, `tokenizeSourceImages` replaces each source image with a short **`[[IMG:n]]`** token *at its original position* in the LLM input. Decorative refs (`logo|icon|avatar|sprite|favicon|emoji|banner`) are **stripped outright** (never tokenized).
2. The prompt tells the model to **keep genuine figures** by writing the same token inline where it now belongs, and **omit** decorative/UI ones.
3. After synthesis, `restoreImageTokens` substitutes the kept tokens back to the real `![alt](assets/…)` refs; omitted/hallucinated tokens are dropped → those images are filtered out.

Tokens survive rewriting (the LLM mangles a long `assets/<slug>/x.png` path but reliably preserves `[[IMG:3]]`), so this gives **contextual placement + relevance filtering** in one pass, anchored on the original position. Removed `appendSourceImages` (the bottom dump).

Applies to URL/text/PDF synthesis; image-ingest (centerpiece) is unaffected. **Only new ingests** benefit — existing pages keep their `## Images` until re-ingested.

## Test plan
- `pnpm build` clean; `pnpm test` — 2652 passed.
- New unit tests: tokenize/restore round-trip, decorative stripping, omitted/out-of-range token drop, cap.
- New integration tests (mock LLM): kept token → image inline (no `## Images`); omitted token → image dropped; logo → stripped before the LLM.

## To migrate an existing page
Re-ingest it (e.g. the Anthropic agents post) → diagrams appear inline near the relevant text; logos/nav icons gone.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)