### PR TITLE
Let reviewers edit the draft before publishing

### DIFF
--- a/src/components/IngestReview.tsx
+++ b/src/components/IngestReview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { Alert } from "@/components/Alert";
 import { Icon } from "@/components/folio/icons";
@@ -26,7 +26,8 @@ export interface PreviewData {
 interface Props {
   preview: PreviewData;
   loading: boolean;
-  onApprove: () => void;
+  /** Publish; receives the edited draft when the reviewer changed it. */
+  onApprove: (editedContent?: string) => void;
   onCancel: () => void;
   error: string | null;
 }
@@ -69,6 +70,14 @@ function MetaCell({ label, children }: { label: string; children: React.ReactNod
 
 export function IngestReview({ preview, loading, onApprove, onCancel, error }: Props) {
   const [showDraft, setShowDraft] = useState(false);
+  const [editing, setEditing] = useState(false);
+  // Editable copy of the synthesized markdown; published as-is on approve.
+  const [draft, setDraft] = useState(preview.previewContent);
+  // Resync if a new draft arrives (e.g. re-synthesis) and nothing's been edited.
+  useEffect(() => {
+    setDraft(preview.previewContent);
+  }, [preview.previewContent]);
+  const edited = draft !== preview.previewContent;
   const meta = preview.meta;
   const title = meta?.title || preview.title || preview.slug;
 
@@ -185,34 +194,79 @@ export function IngestReview({ preview, loading, onApprove, onCancel, error }: P
         )}
       </div>
 
-      {/* Inspect the full draft before publishing */}
-      <button
-        type="button"
-        onClick={() => setShowDraft((v) => !v)}
-        className="receipt"
-        style={{
-          marginTop: 20,
-          fontSize: 12.5,
-          color: "var(--muted)",
-          background: "transparent",
-          border: 0,
-          cursor: "pointer",
-          padding: 0,
-        }}
+      {/* Inspect / edit the full draft before publishing */}
+      <div
+        className="spread"
+        style={{ marginTop: 20, gap: 12, alignItems: "center" }}
       >
-        {showDraft ? "▾ Hide full draft" : "▸ View full draft"}
-      </button>
+        <button
+          type="button"
+          onClick={() => setShowDraft((v) => !v)}
+          className="receipt"
+          style={{
+            fontSize: 12.5,
+            color: "var(--muted)",
+            background: "transparent",
+            border: 0,
+            cursor: "pointer",
+            padding: 0,
+          }}
+        >
+          {showDraft ? "▾ Hide full draft" : "▸ View full draft"}
+          {edited ? " · edited" : ""}
+        </button>
+        {showDraft && (
+          <button
+            type="button"
+            onClick={() => setEditing((v) => !v)}
+            className="receipt"
+            style={{
+              fontSize: 12.5,
+              color: "var(--accent)",
+              background: "transparent",
+              border: 0,
+              cursor: "pointer",
+              padding: 0,
+            }}
+          >
+            {editing ? "Preview" : "Edit"}
+          </button>
+        )}
+      </div>
       {showDraft && (
         <div
           style={{
             marginTop: 14,
             border: "1px solid var(--rule)",
             borderRadius: 12,
-            padding: "20px 24px",
+            padding: editing ? 0 : "20px 24px",
             background: "var(--paper)",
+            overflow: "hidden",
           }}
         >
-          <MarkdownRenderer content={preview.previewContent} />
+          {editing ? (
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              spellCheck={false}
+              aria-label="Edit the draft markdown"
+              style={{
+                width: "100%",
+                minHeight: 360,
+                border: 0,
+                outline: 0,
+                resize: "vertical",
+                background: "transparent",
+                fontFamily: "var(--font-mono)",
+                fontSize: 13,
+                lineHeight: 1.6,
+                color: "var(--ink)",
+                padding: "20px 24px",
+              }}
+            />
+          ) : (
+            <MarkdownRenderer content={draft} />
+          )}
         </div>
       )}
 
@@ -226,8 +280,8 @@ export function IngestReview({ preview, loading, onApprove, onCancel, error }: P
       <div className="row" style={{ gap: 20, alignItems: "center", marginTop: 28 }}>
         <button
           type="button"
-          onClick={onApprove}
-          disabled={loading}
+          onClick={() => onApprove(edited ? draft : undefined)}
+          disabled={loading || !draft.trim()}
           className="btn primary disabled:opacity-50"
         >
           {loading ? "Publishing…" : "Publish to the commons"}

--- a/src/components/IngestReview.tsx
+++ b/src/components/IngestReview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { Alert } from "@/components/Alert";
 import { Icon } from "@/components/folio/icons";
@@ -71,11 +71,16 @@ function MetaCell({ label, children }: { label: string; children: React.ReactNod
 export function IngestReview({ preview, loading, onApprove, onCancel, error }: Props) {
   const [showDraft, setShowDraft] = useState(false);
   const [editing, setEditing] = useState(false);
-  // Editable copy of the synthesized markdown; published as-is on approve.
+  // Editable copy of the synthesized markdown; the edited text is what gets
+  // published on approve (when it differs from the original).
   const [draft, setDraft] = useState(preview.previewContent);
-  // Resync if a new draft arrives (e.g. re-synthesis) and nothing's been edited.
+  // Adopt a freshly synthesized draft if one arrives, but never clobber the
+  // reviewer's unsaved edits: only resync when the buffer still matches the
+  // last value we synced from (i.e. it hasn't been hand-edited).
+  const lastSynced = useRef(preview.previewContent);
   useEffect(() => {
-    setDraft(preview.previewContent);
+    setDraft((cur) => (cur === lastSynced.current ? preview.previewContent : cur));
+    lastSynced.current = preview.previewContent;
   }, [preview.previewContent]);
   const edited = draft !== preview.previewContent;
   const meta = preview.meta;

--- a/src/hooks/useIngest.ts
+++ b/src/hooks/useIngest.ts
@@ -44,7 +44,7 @@ export interface UseIngestReturn {
   setPdfUrl: (v: string) => void;
   setPdfFile: (f: File | null) => void;
   handleSourceSubmit: (e: React.FormEvent) => void;
-  handleApprove: () => void;
+  handleApprove: (editedContent?: string) => void;
   handleImageIngest: (e: React.FormEvent) => void;
   handlePdfIngest: (e: React.FormEvent) => void;
   reset: () => void;
@@ -172,19 +172,28 @@ export function useIngest(): UseIngestReturn {
     }
   }
 
-  /** Step 3: publish — commit with the pre-generated content the user reviewed. */
-  async function handleApprove() {
+  /**
+   * Step 3: publish — commit the reviewed draft. `editedContent` (when the user
+   * edited the draft in the review step) is published instead of the original
+   * synthesized body.
+   */
+  async function handleApprove(editedContent?: string) {
     if (!preview) return;
     setLoading(true);
     setError(null);
 
+    const generated =
+      editedContent && editedContent.trim()
+        ? editedContent
+        : preview.previewContent;
+
     try {
       const body = preview.url
-        ? { url: preview.url, generatedContent: preview.previewContent }
+        ? { url: preview.url, generatedContent: generated }
         : {
             title: preview.title,
             content: preview.content,
-            generatedContent: preview.previewContent,
+            generatedContent: generated,
             // Preserve PDF/image provenance through the text commit path.
             ...(preview.sourceType ? { sourceType: preview.sourceType } : {}),
             ...(preview.sourceUrl ? { sourceUrl: preview.sourceUrl } : {}),

--- a/src/hooks/useIngest.ts
+++ b/src/hooks/useIngest.ts
@@ -179,13 +179,18 @@ export function useIngest(): UseIngestReturn {
    */
   async function handleApprove(editedContent?: string) {
     if (!preview) return;
+
+    // An edit was passed but it's blank — surface it instead of silently
+    // publishing the original AI draft (the opposite of the user's intent).
+    if (editedContent !== undefined && !editedContent.trim()) {
+      setError("The draft is empty — add content or discard to cancel.");
+      return;
+    }
+
     setLoading(true);
     setError(null);
 
-    const generated =
-      editedContent && editedContent.trim()
-        ? editedContent
-        : preview.previewContent;
+    const generated = editedContent ?? preview.previewContent;
 
     try {
       const body = preview.url


### PR DESCRIPTION
## What
The ingest **review** step (step 3) was preview-only — publish or discard. Now you can edit the synthesized draft before publishing.

- **"View full draft"** gains an **Edit / Preview** toggle: *Edit* shows the synthesized markdown in a textarea; *Preview* re-renders the edited draft via `MarkdownRenderer`.
- **Publish** sends the edited content: `handleApprove` gained an optional `editedContent` → used as `generatedContent` (falls back to the original when unchanged). The commit path's H1-derived slug/title follow any edits.
- A **"· edited"** hint appears once the draft is changed; Publish is disabled on an empty draft.

Works for all review-gated paths (URL / text / PDF / image) since they all flow through `IngestReview` → `handleApprove`.

## Test plan
- `pnpm build` clean; `pnpm test` — 2667 passed.
- Manual: ingest → review → Edit, change the body/H1 → Preview reflects it → Publish writes the edited content (slug/title follow the edited H1); Discard still works; unchanged draft publishes the original.

Note: no component test was added (the repo has no React component-test harness); the `handleApprove(editedContent)` path is a thin pass-through over the already-tested commit route.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)