### PR TITLE
Ingest X posts via the syndication CDN (fix tweet-URL ingest)

### DIFF
--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -3,7 +3,7 @@ import { ingest, ingestUrl } from "@/lib/ingest";
 import type { IngestOptions } from "@/lib/ingest";
 import { isUrl } from "@/lib/fetch";
 import { getPrincipal, getServicePrincipal } from "@/lib/auth";
-import { getErrorMessage } from "@/lib/errors";
+import { ClientInputError, getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 
 export async function POST(request: NextRequest) {
@@ -113,12 +113,15 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(result);
   } catch (error) {
+    const msg = getErrorMessage(error);
+    // Bad-input failures (e.g. a deleted/private X post, an unsafe URL) are
+    // tagged ClientInputError → 400 + warn. Anything else is a real server
+    // failure → 500 + error log, so genuine bugs aren't buried as 500 noise.
+    if (error instanceof ClientInputError) {
+      logger.warn("ingest", `Ingest rejected: ${msg}`);
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
     logger.error("ingest", "Ingest error", error);
-    return NextResponse.json(
-      {
-        error: getErrorMessage(error),
-      },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: msg }, { status: 500 });
   }
 }

--- a/src/lib/__tests__/ingest-routes.test.ts
+++ b/src/lib/__tests__/ingest-routes.test.ts
@@ -39,6 +39,7 @@ import { POST } from "@/app/api/ingest/route";
 import { POST as POST_BATCH } from "@/app/api/ingest/batch/route";
 import { POST as POST_REINGEST } from "@/app/api/ingest/reingest/route";
 import type { IngestResult } from "@/lib/types";
+import { ClientInputError } from "@/lib/errors";
 
 const mockedIngest = vi.mocked(ingest);
 const mockedIngestUrl = vi.mocked(ingestUrl);
@@ -74,6 +75,30 @@ const fakeResult: IngestResult = {
   wikiPages: ["test-page"],
   indexUpdated: true,
 };
+
+// ===========================================================================
+// POST /api/ingest — error → HTTP status mapping
+// ===========================================================================
+describe("POST /api/ingest — error status mapping", () => {
+  it("maps a ClientInputError (e.g. deleted/private X post) to 400 + the message", async () => {
+    mockedIngestUrl.mockRejectedValue(
+      new ClientInputError("That X post couldn't be read — it may be deleted, private, or from a protected account."),
+    );
+    const res = await POST(
+      makeRequest("http://localhost/api/ingest", { url: "https://x.com/u/status/1" }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/deleted, private/);
+  });
+
+  it("maps an unexpected error to 500", async () => {
+    mockedIngestUrl.mockRejectedValue(new Error("boom"));
+    const res = await POST(
+      makeRequest("http://localhost/api/ingest", { url: "https://x.com/u/status/2" }),
+    );
+    expect(res.status).toBe(500);
+  });
+});
 
 // ===========================================================================
 // POST /api/ingest — tags support

--- a/src/lib/__tests__/mcp.test.ts
+++ b/src/lib/__tests__/mcp.test.ts
@@ -69,6 +69,19 @@ vi.mock("../fetch", async (importOriginal) => {
   };
 });
 
+// Mock the X-post syndication fetch (X URLs route through ../x-post, not
+// ../fetch) so no real HTTP calls hit the syndication CDN. isXPostUrl is kept.
+vi.mock("../x-post", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../x-post")>();
+  return {
+    ...actual,
+    fetchXPostContent: vi.fn(async (url: string) => ({
+      title: `Mocked X post for ${url}`,
+      content: `Mocked tweet text fetched from ${url}`,
+    })),
+  };
+});
+
 // Mock the vision module so no real vision model calls are made.
 vi.mock("../vision", () => ({
   describeImage: vi.fn(async () => ({
@@ -77,7 +90,9 @@ vi.mock("../vision", () => ({
 }));
 
 import { fetchUrlContent, downloadImages } from "../fetch";
+import { fetchXPostContent } from "../x-post";
 const mockedFetchUrlContent = vi.mocked(fetchUrlContent);
+const mockedFetchXPostContent = vi.mocked(fetchXPostContent);
 const mockedDownloadImages = vi.mocked(downloadImages);
 
 let tmpDir: string;
@@ -1573,7 +1588,7 @@ describe("ingest_x_mention", () => {
       expect(result.title).toBeTruthy();
       expect(typeof result.summary).toBe("string");
       expect(result.sourceUrl).toBe("https://x.com/user/status/123");
-      expect(mockedFetchUrlContent).toHaveBeenCalledWith("https://x.com/user/status/123");
+      expect(mockedFetchXPostContent).toHaveBeenCalledWith("https://x.com/user/status/123");
     } finally {
       if (savedKey !== undefined) {
         process.env.ANTHROPIC_API_KEY = savedKey;
@@ -1596,7 +1611,7 @@ describe("ingest_x_mention", () => {
       expect(result.title).toBeTruthy();
       expect(typeof result.summary).toBe("string");
       expect(result.sourceUrl).toBe("https://twitter.com/user/status/456");
-      expect(mockedFetchUrlContent).toHaveBeenCalledWith("https://twitter.com/user/status/456");
+      expect(mockedFetchXPostContent).toHaveBeenCalledWith("https://twitter.com/user/status/456");
     } finally {
       if (savedKey !== undefined) {
         process.env.ANTHROPIC_API_KEY = savedKey;
@@ -1619,7 +1634,7 @@ describe("ingest_x_mention", () => {
       expect(result.title).toBeTruthy();
       expect(typeof result.summary).toBe("string");
       expect(result.sourceUrl).toBe("https://www.x.com/user/status/789");
-      expect(mockedFetchUrlContent).toHaveBeenCalledWith("https://www.x.com/user/status/789");
+      expect(mockedFetchXPostContent).toHaveBeenCalledWith("https://www.x.com/user/status/789");
     } finally {
       if (savedKey !== undefined) {
         process.env.ANTHROPIC_API_KEY = savedKey;

--- a/src/lib/__tests__/x-mention-integration.test.ts
+++ b/src/lib/__tests__/x-mention-integration.test.ts
@@ -67,34 +67,20 @@ afterEach(async () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Create a mock fetch that returns an HTML page with given title and body. */
+/**
+ * Mock fetch for the syndication CDN — an X post URL is now read via
+ * `cdn.syndication.twimg.com` (X serves a JS shell to plain HTML fetches), so
+ * the integration ingests the tweet text returned here. `title` becomes the
+ * author name (byline); the page title/slug come from the mocked LLM's H1.
+ */
 function mockFetchSuccess(title: string, body: string) {
   global.fetch = vi.fn().mockResolvedValue({
     ok: true,
     status: 200,
-    headers: new Map([
-      ["content-type", "text/html"],
-    ]) as unknown as Headers,
-    body: {
-      getReader: () => {
-        let called = false;
-        return {
-          read: () => {
-            if (!called) {
-              called = true;
-              return Promise.resolve({
-                done: false,
-                value: new TextEncoder().encode(
-                  `<html><head><title>${title}</title></head><body><p>${body}</p></body></html>`,
-                ),
-              });
-            }
-            return Promise.resolve({ done: true, value: undefined });
-          },
-          cancel: vi.fn(),
-        };
-      },
-    },
+    json: async () => ({
+      text: body,
+      user: { name: title, screen_name: "someuser" },
+    }),
   });
 }
 
@@ -104,9 +90,7 @@ function mockFetchFailure(status: number, statusText: string) {
     ok: false,
     status,
     statusText,
-    headers: new Map([
-      ["content-type", "text/html"],
-    ]) as unknown as Headers,
+    json: async () => ({}),
   });
 }
 
@@ -127,9 +111,10 @@ describe("X-mention integration", () => {
       "Large language models are transforming how we build software. They enable natural language interfaces for complex tasks.",
     );
 
-    // Mock LLM to return wiki content for the ingest
+    // Mock LLM to return wiki content for the ingest. The CONCEPT marker drives
+    // the canonical slug/title (as the real synthesis prompt instructs).
     mockedCallLLM.mockResolvedValueOnce(
-      "# Interesting AI Thread\n\n## Summary\n\nLLMs are transforming software development.\n\n## Key Points\n\n- Natural language interfaces\n- Complex task automation",
+      "CONCEPT: Interesting AI Thread\n\n# Interesting AI Thread\n\n## Summary\n\nLLMs are transforming software development.\n\n## Key Points\n\n- Natural language interfaces\n- Complex task automation",
     );
 
     const result = await ingestXMention(
@@ -174,7 +159,7 @@ describe("X-mention integration", () => {
     );
 
     mockedCallLLM.mockResolvedValueOnce(
-      "# Agent Memory Systems\n\n## Summary\n\nAgents need persistent memory.\n\n## Key Points\n\n- Context across sessions",
+      "CONCEPT: Agent Memory Systems\n\n# Agent Memory Systems\n\n## Summary\n\nAgents need persistent memory.\n\n## Key Points\n\n- Context across sessions",
     );
 
     await ingestXMention(
@@ -194,9 +179,11 @@ describe("X-mention integration", () => {
   it("handles fetch failure (404) gracefully", async () => {
     mockFetchFailure(404, "Not Found");
 
+    // The syndication CDN 404s deleted/private posts — surfaced as a friendly
+    // ClientInputError rather than a raw HTTP code.
     await expect(
       ingestXMention("https://x.com/user/status/999", "@someone"),
-    ).rejects.toThrow(/404/);
+    ).rejects.toThrow(/deleted, private/);
   });
 
   it("handles network error gracefully", async () => {
@@ -214,7 +201,7 @@ describe("X-mention integration", () => {
     );
 
     mockedCallLLM.mockResolvedValueOnce(
-      "# Legacy Twitter Post\n\n## Summary\n\nA post from the twitter.com era.\n\n## Key Points\n\n- Historical reference",
+      "CONCEPT: Legacy Twitter Post\n\n# Legacy Twitter Post\n\n## Summary\n\nA post from the twitter.com era.\n\n## Key Points\n\n- Historical reference",
     );
 
     const result = await ingestXMention(

--- a/src/lib/__tests__/x-post.test.ts
+++ b/src/lib/__tests__/x-post.test.ts
@@ -121,6 +121,44 @@ describe("fetchXPostContent", () => {
     expect(content).toContain("![a photo](https://pbs.twimg.com/media/p.jpg)");
   });
 
+  it("prefers mediaDetails over photos when both are present (no duplicates)", async () => {
+    mockSyndication({
+      text: "both shapes",
+      user: { name: "B", screen_name: "b" },
+      mediaDetails: [{ type: "photo", media_url_https: "https://pbs.twimg.com/media/detail.jpg" }],
+      photos: [{ type: "photo", media_url_https: "https://pbs.twimg.com/media/photo.jpg" }],
+    });
+    const { content } = await fetchXPostContent("https://x.com/b/status/5");
+    expect(content).toContain("detail.jpg");
+    expect(content).not.toContain("photo.jpg");
+  });
+
+  it("keeps a quote-only tweet (empty top-level text/media, non-empty quoted)", async () => {
+    mockSyndication({
+      text: "",
+      user: { name: "Q", screen_name: "q" },
+      quoted_tweet: { text: "the quoted substance", user: { screen_name: "orig" } },
+    });
+    const { content } = await fetchXPostContent("https://x.com/q/status/6");
+    expect(content).toContain("> the quoted substance");
+  });
+
+  it("truncates a long first line and falls back to author when text is empty", async () => {
+    const long = "x".repeat(120);
+    mockSyndication({ text: long, user: { name: "Ada", screen_name: "ada" } });
+    const a = await fetchXPostContent("https://x.com/ada/status/10");
+    expect(a.title.length).toBeLessThan(90);
+    expect(a.title.endsWith("…")).toBe(true);
+
+    mockSyndication({
+      text: "",
+      user: { name: "Ada", screen_name: "ada" },
+      mediaDetails: [{ type: "photo", media_url_https: "https://pbs.twimg.com/media/x.jpg" }],
+    });
+    const b = await fetchXPostContent("https://x.com/ada/status/11");
+    expect(b.title).toBe("Ada on X");
+  });
+
   it("throws ClientInputError when media entries carry no URL (content-free stub)", async () => {
     mockSyndication({
       text: "",

--- a/src/lib/__tests__/x-post.test.ts
+++ b/src/lib/__tests__/x-post.test.ts
@@ -110,6 +110,28 @@ describe("fetchXPostContent", () => {
     expect(content).toContain("> original insight");
   });
 
+  it("accepts a media-only tweet delivered under `photos` (no text, no mediaDetails)", async () => {
+    mockSyndication({
+      text: "",
+      user: { name: "Pic", screen_name: "pic" },
+      photos: [{ type: "photo", media_url_https: "https://pbs.twimg.com/media/p.jpg", ext_alt_text: "a photo" }],
+    });
+
+    const { content } = await fetchXPostContent("https://x.com/pic/status/7");
+    expect(content).toContain("![a photo](https://pbs.twimg.com/media/p.jpg)");
+  });
+
+  it("throws ClientInputError when media entries carry no URL (content-free stub)", async () => {
+    mockSyndication({
+      text: "",
+      user: { name: "X", screen_name: "x" },
+      mediaDetails: [{ type: "photo" }], // present but no media_url_https
+    });
+    await expect(fetchXPostContent("https://x.com/x/status/8")).rejects.toBeInstanceOf(
+      ClientInputError,
+    );
+  });
+
   it("throws ClientInputError on a 404 (deleted/private)", async () => {
     mockSyndication({}, 404);
     await expect(fetchXPostContent("https://x.com/a/status/1")).rejects.toBeInstanceOf(

--- a/src/lib/__tests__/x-post.test.ts
+++ b/src/lib/__tests__/x-post.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  isXPostUrl,
+  extractTweetId,
+  syndicationToken,
+  fetchXPostContent,
+} from "../x-post";
+import { ClientInputError } from "../errors";
+
+// ---------------------------------------------------------------------------
+// isXPostUrl
+// ---------------------------------------------------------------------------
+
+describe("isXPostUrl", () => {
+  it("matches x.com / twitter.com status URLs (incl. www, mobile)", () => {
+    expect(isXPostUrl("https://x.com/jack/status/20")).toBe(true);
+    expect(isXPostUrl("https://twitter.com/jack/status/20")).toBe(true);
+    expect(isXPostUrl("https://www.x.com/a/status/123?s=46")).toBe(true);
+    expect(isXPostUrl("https://mobile.twitter.com/a/status/123")).toBe(true);
+    expect(isXPostUrl("https://x.com/i/web/status/456")).toBe(true);
+  });
+
+  it("rejects non-status X URLs and other hosts", () => {
+    expect(isXPostUrl("https://x.com/jack")).toBe(false); // profile, no status
+    expect(isXPostUrl("https://x.com/home")).toBe(false);
+    expect(isXPostUrl("https://example.com/jack/status/20")).toBe(false);
+    expect(isXPostUrl("not a url")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractTweetId
+// ---------------------------------------------------------------------------
+
+describe("extractTweetId", () => {
+  it("pulls the numeric id from a status path", () => {
+    expect(extractTweetId("https://x.com/jack/status/20")).toBe("20");
+    expect(extractTweetId("https://x.com/i/web/status/1789?s=1")).toBe("1789");
+  });
+
+  it("returns null for non-status / non-X URLs", () => {
+    expect(extractTweetId("https://x.com/jack")).toBeNull();
+    expect(extractTweetId("https://example.com/a/status/9")).toBeNull();
+    expect(extractTweetId("garbage")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syndicationToken
+// ---------------------------------------------------------------------------
+
+describe("syndicationToken", () => {
+  it("is deterministic, non-empty, and contains no '0' or '.'", () => {
+    const t = syndicationToken("1788000000000000000");
+    expect(t.length).toBeGreaterThan(0);
+    expect(t).not.toMatch(/[0.]/);
+    expect(syndicationToken("1788000000000000000")).toBe(t); // stable
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchXPostContent
+// ---------------------------------------------------------------------------
+
+describe("fetchXPostContent", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function mockSyndication(body: unknown, status = 200) {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    }) as unknown as typeof fetch;
+  }
+
+  it("formats text, byline, expanded links, media, and source", async () => {
+    mockSyndication({
+      text: "Shipping this today https://t.co/abc",
+      user: { name: "Ada Lovelace", screen_name: "ada" },
+      entities: { urls: [{ url: "https://t.co/abc", expanded_url: "https://example.com/post" }] },
+      mediaDetails: [{ type: "photo", media_url_https: "https://pbs.twimg.com/media/x.jpg", ext_alt_text: "a chart" }],
+    });
+
+    const { title, content } = await fetchXPostContent("https://x.com/ada/status/99");
+
+    expect(title).toContain("Ada Lovelace");
+    expect(content).toContain("**Ada Lovelace @ada** · X post");
+    // t.co link is expanded to its destination.
+    expect(content).toContain("https://example.com/post");
+    expect(content).not.toContain("https://t.co/abc");
+    // Media is an inline image ref with alt text.
+    expect(content).toContain("![a chart](https://pbs.twimg.com/media/x.jpg)");
+    // Provenance link back to the original post.
+    expect(content).toContain("**Source:** [https://x.com/ada/status/99]");
+  });
+
+  it("includes a quoted tweet as a blockquote", async () => {
+    mockSyndication({
+      text: "look at this",
+      user: { name: "A", screen_name: "a" },
+      quoted_tweet: { text: "original insight", user: { screen_name: "b" } },
+    });
+
+    const { content } = await fetchXPostContent("https://x.com/a/status/1");
+    expect(content).toContain("**Quoting @b:**");
+    expect(content).toContain("> original insight");
+  });
+
+  it("throws ClientInputError on a 404 (deleted/private)", async () => {
+    mockSyndication({}, 404);
+    await expect(fetchXPostContent("https://x.com/a/status/1")).rejects.toBeInstanceOf(
+      ClientInputError,
+    );
+  });
+
+  it("throws ClientInputError on an error/tombstone payload", async () => {
+    mockSyndication({ tombstone: { text: "This Post was deleted" } });
+    await expect(fetchXPostContent("https://x.com/a/status/1")).rejects.toBeInstanceOf(
+      ClientInputError,
+    );
+  });
+
+  it("throws ClientInputError for an unrecognizable URL (no fetch)", async () => {
+    const spy = vi.fn();
+    globalThis.fetch = spy as unknown as typeof fetch;
+    await expect(fetchXPostContent("https://x.com/jack")).rejects.toBeInstanceOf(
+      ClientInputError,
+    );
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -12,6 +12,7 @@ import { callLLM, hasLLMKey } from "./llm";
 import { fetchUrlContent, downloadImages, fetchImageBytes, storeImageBytes, pdfToText } from "./fetch";
 import { describeImage } from "./vision";
 import { isYouTubeUrl, fetchYouTubeContent } from "./youtube";
+import { isXPostUrl, fetchXPostContent } from "./x-post";
 import type { IngestResult, IngestPreviewMeta, SourceEntry } from "./types";
 import {
   serializeSources,
@@ -173,6 +174,18 @@ export async function ingestUrl(
 
   if (isYouTubeUrl(url)) {
     return ingestYouTube(url, options);
+  }
+
+  // X.com serves a JS shell to plain fetches (the "Something went wrong" page),
+  // so read the post via the syndication CDN instead. Default the provenance to
+  // x-mention when the caller didn't already set one (e.g. a manual UI ingest).
+  if (isXPostUrl(url)) {
+    const { title, content } = await fetchXPostContent(url);
+    return ingest(title, content, {
+      ...options,
+      sourceUrl: url,
+      sourceType: options?.sourceType ?? "x-mention",
+    });
   }
 
   const { title, content } = await fetchUrlContent(url);
@@ -395,8 +408,9 @@ export async function reingest(
 /**
  * Ingest an X (Twitter) post into the wiki.
  *
- * Fetches the post content via URL, then delegates to the standard ingest
- * pipeline with `x-mention` provenance so the source is correctly attributed.
+ * Delegates to {@link ingestUrl}, which reads the post via the syndication CDN
+ * (X serves a JS shell to plain fetches), tagged with `x-mention` provenance so
+ * the source is correctly attributed.
  *
  * @param url         - Full URL to the X/Twitter post.
  * @param triggeredBy - Handle of the user or agent that triggered the ingest.

--- a/src/lib/x-post.ts
+++ b/src/lib/x-post.ts
@@ -138,9 +138,14 @@ function expandLinks(text: string, urls?: SyndicationUrlEntity[]): string {
   return out;
 }
 
-/** Photo refs as markdown image lines (videos/gifs contribute their poster). */
+/**
+ * Photo refs as markdown image lines (videos/gifs contribute their poster).
+ *
+ * The CDN may carry media under `mediaDetails` OR `photos` — prefer whichever
+ * is non-empty (not just non-null), and keep only entries with a real URL.
+ */
 function mediaImageRefs(tweet: SyndicationTweet): string[] {
-  const media = tweet.mediaDetails ?? tweet.photos ?? [];
+  const media = tweet.mediaDetails?.length ? tweet.mediaDetails : tweet.photos ?? [];
   return media
     .filter((m) => m.media_url_https)
     .map((m) => `![${(m.ext_alt_text || "image").replace(/\s+/g, " ").trim()}](${m.media_url_https})`);
@@ -201,7 +206,11 @@ export async function fetchXPostContent(url: string): Promise<XPostContent> {
   if (!id) throw new ClientInputError(`Not a recognizable X post URL: "${url}"`);
 
   const tweet = await fetchSyndication(id);
-  if (tweet.error || tweet.tombstone || (!tweet.text && !tweet.mediaDetails?.length)) {
+  // Guard on exactly what the formatter would render — trimmed text and the
+  // same media set (covering both the `photos` shape and URL-less entries) — so
+  // a benign-but-empty payload errors instead of producing a content-free stub.
+  const hasText = (tweet.text ?? "").trim().length > 0;
+  if (tweet.error || tweet.tombstone || (!hasText && mediaImageRefs(tweet).length === 0)) {
     logger.warn("x-post", `No usable content for tweet ${id} (error/tombstone/empty)`);
     throw new ClientInputError(
       "That X post couldn't be read — it may be deleted, private, or from a protected account.",

--- a/src/lib/x-post.ts
+++ b/src/lib/x-post.ts
@@ -151,6 +151,13 @@ function mediaImageRefs(tweet: SyndicationTweet): string[] {
     .map((m) => `![${(m.ext_alt_text || "image").replace(/\s+/g, " ").trim()}](${m.media_url_https})`);
 }
 
+/** True if the tweet (or the tweet it quotes) has any text or media to render. */
+function hasRenderableContent(tweet: SyndicationTweet): boolean {
+  const hasOwn = (t: SyndicationTweet) =>
+    (t.text ?? "").trim().length > 0 || mediaImageRefs(t).length > 0;
+  return hasOwn(tweet) || (tweet.quoted_tweet ? hasOwn(tweet.quoted_tweet) : false);
+}
+
 /** Build a concise wiki-ingestion title from the author + text opening. */
 function deriveTitle(tweet: SyndicationTweet, text: string): string {
   const author = tweet.user?.name || tweet.user?.screen_name || "X post";
@@ -206,11 +213,11 @@ export async function fetchXPostContent(url: string): Promise<XPostContent> {
   if (!id) throw new ClientInputError(`Not a recognizable X post URL: "${url}"`);
 
   const tweet = await fetchSyndication(id);
-  // Guard on exactly what the formatter would render — trimmed text and the
-  // same media set (covering both the `photos` shape and URL-less entries) — so
-  // a benign-but-empty payload errors instead of producing a content-free stub.
-  const hasText = (tweet.text ?? "").trim().length > 0;
-  if (tweet.error || tweet.tombstone || (!hasText && mediaImageRefs(tweet).length === 0)) {
+  // Reject only a genuinely empty payload — no renderable text/media on the
+  // tweet itself OR the tweet it quotes (mirrors the media set the formatter
+  // actually emits, covering the `photos` shape and URL-less entries) — so a
+  // benign-but-empty response errors instead of producing a content-free stub.
+  if (tweet.error || tweet.tombstone || !hasRenderableContent(tweet)) {
     logger.warn("x-post", `No usable content for tweet ${id} (error/tombstone/empty)`);
     throw new ClientInputError(
       "That X post couldn't be read — it may be deleted, private, or from a protected account.",

--- a/src/lib/x-post.ts
+++ b/src/lib/x-post.ts
@@ -1,0 +1,212 @@
+/**
+ * X (Twitter) post fetching module.
+ *
+ * X.com serves a JavaScript shell to plain HTTP fetches — readers get a
+ * "Something went wrong" error page, never the tweet. This module instead reads
+ * a single post via the public **syndication CDN** (`cdn.syndication.twimg.com`,
+ * the endpoint that powers embedded tweets), which returns the post's text,
+ * author, media, and any quoted tweet as JSON — no API key required.
+ *
+ * Self-contained: URL detection, tweet-ID extraction, fetch, and markdown
+ * formatting, with no dependency on the ingest pipeline (mirrors `youtube.ts`).
+ */
+
+import { logger } from "./logger";
+import { ClientInputError } from "./errors";
+
+// ---------------------------------------------------------------------------
+// Types (subset of the syndication `tweet-result` response we consume)
+// ---------------------------------------------------------------------------
+
+interface SyndicationMedia {
+  type?: string; // "photo" | "video" | "animated_gif"
+  media_url_https?: string;
+  ext_alt_text?: string;
+}
+
+interface SyndicationUrlEntity {
+  url?: string; // the t.co short link as it appears in `text`
+  expanded_url?: string;
+  display_url?: string;
+}
+
+interface SyndicationTweet {
+  text?: string;
+  created_at?: string;
+  user?: { name?: string; screen_name?: string };
+  entities?: { urls?: SyndicationUrlEntity[] };
+  mediaDetails?: SyndicationMedia[];
+  photos?: SyndicationMedia[];
+  quoted_tweet?: SyndicationTweet;
+  // Error shapes the endpoint may return instead of a tweet.
+  error?: string;
+  tombstone?: unknown;
+  __typename?: string;
+}
+
+export interface XPostContent {
+  title: string;
+  content: string;
+}
+
+// ---------------------------------------------------------------------------
+// URL detection
+// ---------------------------------------------------------------------------
+
+/** Hostnames that serve X/Twitter posts (case-insensitive). */
+const X_HOSTS = new Set([
+  "x.com",
+  "www.x.com",
+  "mobile.x.com",
+  "twitter.com",
+  "www.twitter.com",
+  "mobile.twitter.com",
+]);
+
+/** A status URL path: `/<handle>/status/<id>` or `/i/web/status/<id>`. */
+const STATUS_PATH_RE = /\/status(?:es)?\/(\d+)/;
+
+/** Returns `true` for an X/Twitter URL pointing at a specific post. */
+export function isXPostUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (!X_HOSTS.has(parsed.hostname.toLowerCase())) return false;
+    return STATUS_PATH_RE.test(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
+/** Extracts the numeric tweet ID from an X/Twitter status URL, or `null`. */
+export function extractTweetId(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (!X_HOSTS.has(parsed.hostname.toLowerCase())) return null;
+    return parsed.pathname.match(STATUS_PATH_RE)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Syndication fetch
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the syndication request token from the tweet ID — the same scheme the
+ * official tweet-embed widget (react-tweet) uses. The endpoint rejects requests
+ * without a plausible token, so this is required, not cosmetic.
+ */
+export function syndicationToken(id: string): string {
+  return ((Number(id) / 1e15) * Math.PI)
+    .toString(36) // 6 ** 2
+    .replace(/(0+|\.)/g, "");
+}
+
+/** Fetch the raw syndication payload for a tweet ID (throws on HTTP failure). */
+async function fetchSyndication(id: string): Promise<SyndicationTweet> {
+  const endpoint =
+    `https://cdn.syndication.twimg.com/tweet-result?id=${id}` +
+    `&lang=en&token=${syndicationToken(id)}`;
+
+  const res = await fetch(endpoint, {
+    // The CDN serves the JSON only to browser-like clients.
+    headers: { "User-Agent": "Mozilla/5.0", Accept: "application/json" },
+  });
+
+  if (res.status === 404) {
+    throw new ClientInputError(
+      "That X post couldn't be found — it may be deleted, private, or from a protected account.",
+    );
+  }
+  if (!res.ok) {
+    throw new Error(`X syndication request failed (HTTP ${res.status})`);
+  }
+  return (await res.json()) as SyndicationTweet;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown formatting
+// ---------------------------------------------------------------------------
+
+/** Replace t.co short links in the text with their expanded URLs. */
+function expandLinks(text: string, urls?: SyndicationUrlEntity[]): string {
+  let out = text;
+  for (const u of urls ?? []) {
+    if (u.url && u.expanded_url) out = out.split(u.url).join(u.expanded_url);
+  }
+  return out;
+}
+
+/** Photo refs as markdown image lines (videos/gifs contribute their poster). */
+function mediaImageRefs(tweet: SyndicationTweet): string[] {
+  const media = tweet.mediaDetails ?? tweet.photos ?? [];
+  return media
+    .filter((m) => m.media_url_https)
+    .map((m) => `![${(m.ext_alt_text || "image").replace(/\s+/g, " ").trim()}](${m.media_url_https})`);
+}
+
+/** Build a concise wiki-ingestion title from the author + text opening. */
+function deriveTitle(tweet: SyndicationTweet, text: string): string {
+  const author = tweet.user?.name || tweet.user?.screen_name || "X post";
+  const firstLine = text.split("\n").map((l) => l.trim()).find(Boolean) ?? "";
+  const snippet = firstLine.length > 70 ? firstLine.slice(0, 70).trim() + "…" : firstLine;
+  return snippet ? `${author}: ${snippet}` : `${author} on X`;
+}
+
+/** Format a fetched tweet as the markdown the ingest pipeline distills. */
+function formatTweetAsMarkdown(tweet: SyndicationTweet, url: string): XPostContent {
+  const text = expandLinks(tweet.text ?? "", tweet.entities?.urls);
+  const handle = tweet.user?.screen_name ? `@${tweet.user.screen_name}` : "";
+  const name = tweet.user?.name ?? "";
+  const byline = [name, handle].filter(Boolean).join(" ");
+  const title = deriveTitle(tweet, text);
+
+  const lines: string[] = [`# ${title}`, ""];
+  if (byline) lines.push(`**${byline}** · X post`, "");
+  if (text) lines.push(text, "");
+  for (const ref of mediaImageRefs(tweet)) lines.push(ref, "");
+
+  const quoted = tweet.quoted_tweet;
+  if (quoted?.text) {
+    const qBy = quoted.user?.screen_name ? `@${quoted.user.screen_name}` : "quoted";
+    const qText = expandLinks(quoted.text, quoted.entities?.urls)
+      .split("\n")
+      .map((l) => `> ${l}`)
+      .join("\n");
+    lines.push(`**Quoting ${qBy}:**`, "", qText, "");
+    for (const ref of mediaImageRefs(quoted)) lines.push(ref, "");
+  }
+
+  lines.push(`**Source:** [${url}](${url})`);
+  return { title, content: lines.join("\n").trim() };
+}
+
+// ---------------------------------------------------------------------------
+// High-level entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch an X/Twitter post ready for ingestion.
+ *
+ * 1. Extract the tweet ID (throws on an unrecognized URL).
+ * 2. Read the post via the syndication CDN (no API key).
+ * 3. Return the post text + media + quoted tweet as markdown.
+ *
+ * Throws a {@link ClientInputError} for a missing/private/deleted post so the
+ * caller surfaces a useful message rather than ingesting an error page.
+ */
+export async function fetchXPostContent(url: string): Promise<XPostContent> {
+  const id = extractTweetId(url);
+  if (!id) throw new ClientInputError(`Not a recognizable X post URL: "${url}"`);
+
+  const tweet = await fetchSyndication(id);
+  if (tweet.error || tweet.tombstone || (!tweet.text && !tweet.mediaDetails?.length)) {
+    logger.warn("x-post", `No usable content for tweet ${id} (error/tombstone/empty)`);
+    throw new ClientInputError(
+      "That X post couldn't be read — it may be deleted, private, or from a protected account.",
+    );
+  }
+
+  return formatTweetAsMarkdown(tweet, url);
+}


### PR DESCRIPTION
## Problem
Ingesting an X/Twitter post by URL distilled X.com's **"Something went wrong"** error page (see the report below) — because X serves a JavaScript shell to plain HTTP fetches, so `fetchUrlContent` never gets the tweet.

## Fix
New self-contained **`src/lib/x-post.ts`** (mirrors `youtube.ts`):
- `isXPostUrl(url)` / `extractTweetId(url)` — detect `x.com` / `twitter.com` (+ `www`/`mobile`) `/status/<id>` URLs.
- `fetchXPostContent(url)` — reads the post via the **public syndication CDN** `cdn.syndication.twimg.com/tweet-result` (the endpoint that powers embedded tweets / react-tweet) — **no API key**. Returns the tweet text (with t.co links expanded), media as inline image refs, and any quoted tweet, as markdown.
- `syndicationToken(id)` — the embed widget's token scheme (the endpoint rejects requests without it). Verified live: returns HTTP 200 + real text/author/media.

Wired into `ingestUrl` alongside the YouTube branch, defaulting provenance to the existing `x-mention` source type. This also **fixes the `@yoyoevolve` mention loop**, which ingested tweet URLs through the same broken plain-fetch path.

### Why the syndication CDN over the X API bearer token
The cron mention-scanner (`workers/x-ingest`) uses the X API v2 with `X_BEARER_TOKEN`, but the **main Worker has no such secret**, and the bearer API has strict rate limits aimed at the scheduled scan. The syndication CDN needs no credential, works on-demand for a single URL, and is already used in-repo (the worker uses it for cover images).

### Error handling
A missing / private / deleted post (404 or tombstone/empty payload) throws a `ClientInputError` with a friendly message, instead of silently ingesting an error page.

## Tests
- New `src/lib/__tests__/x-post.test.ts` (10 tests): URL detection, ID extraction, token shape, markdown formatting (byline, link expansion, media alt text, quoted tweet, source link), and the 404 / tombstone / bad-URL error paths.
- Updated `x-mention-integration.test.ts` and `mcp.test.ts` to the new syndication path (mock the syndication JSON / `fetchXPostContent` rather than the old HTML fetch; assert the friendly error on 404).
- Full suite: **2677 passed**; `pnpm build` clean.

## Note
Only **new** ingests benefit — the existing "Something Went Wrong" page needs a re-ingest to fix.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)