### PR TITLE
Related pages section + fix stale backlink index

### DIFF
--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { slugify } from "@/lib/slugify";
 import type { Frontmatter } from "@/lib/frontmatter";
 import type { WikiPage } from "@/lib/types";
-import { findBacklinks, buildSlugTenantMap } from "@/lib/wiki";
+import { findBacklinks, findSimilarPages, buildSlugTenantMap } from "@/lib/wiki";
 import { resolveSlugPath } from "@/lib/links";
 import { getCommonsSlugSet, belongsInCommons } from "@/lib/commons";
 import type { Principal } from "@/lib/auth";
@@ -140,6 +140,12 @@ export async function ArticleView({
   const commonsSlugs = await getCommonsSlugSet();
 
   const backlinks = await findBacklinks(slug, principal);
+  // Semantic "Related pages" — exclude any page already listed under "what
+  // links here" so the two sections don't repeat the same page.
+  const backlinkSlugs = new Set(backlinks.map((b) => b.slug));
+  const related = (await findSimilarPages(slug, principal)).filter(
+    (r) => !backlinkSlugs.has(r.slug),
+  );
   const hasSourceUrl =
     typeof page.frontmatter.source_url === "string" &&
     page.frontmatter.source_url.trim().length > 0;
@@ -411,6 +417,32 @@ export async function ArticleView({
                       style={{ color: "var(--accent)" }}
                     >
                       {bl.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {related.length > 0 && (
+            <section className="mt-10 border-t border-rule pt-6">
+              <h2 className="fmark" style={{ color: "var(--faint)" }}>
+                related pages
+              </h2>
+              <ul className="mt-3 space-y-1">
+                {related.map((r) => (
+                  <li key={r.slug}>
+                    <Link
+                      href={resolveSlugPath(
+                        r.slug,
+                        slugTenants,
+                        pageTenant,
+                        commonsSlugs,
+                      )}
+                      className="text-sm"
+                      style={{ color: "var(--accent)" }}
+                    >
+                      {r.title}
                     </Link>
                   </li>
                 ))}

--- a/src/lib/__tests__/embeddings.test.ts
+++ b/src/lib/__tests__/embeddings.test.ts
@@ -50,6 +50,7 @@ import {
   upsertEmbedding,
   removeEmbedding,
   searchByVector,
+  relatedByVector,
   embedText,
   embedTexts,
   rebuildVectorStore,
@@ -423,6 +424,69 @@ describe("vector store persistence", () => {
     // No leftover .tmp file after a successful write
     const files = await fs.readdir(tmpDir);
     expect(files).not.toContain(".vectors.json.tmp");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// relatedByVector — reuses a page's stored vector (no embedding call)
+// ---------------------------------------------------------------------------
+
+describe("relatedByVector", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "embeddings-test-"));
+    process.env.WIKI_DIR = tmpDir;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  const store: VectorStore = {
+    model: "text-embedding-3-small",
+    entries: [
+      { slug: "anchor", embedding: [1, 0, 0], contentHash: "a" },
+      { slug: "near", embedding: [0.9, 0.1, 0], contentHash: "b" },
+      { slug: "mid", embedding: [0.6, 0.6, 0], contentHash: "c" },
+      { slug: "far", embedding: [0, 1, 0], contentHash: "d" },
+    ],
+  };
+
+  it("ranks other pages by similarity to the anchor and excludes the anchor itself", async () => {
+    await saveVectorStore(store);
+    process.env.EMBEDDING_MODEL = "text-embedding-3-small";
+    process.env.OPENAI_API_KEY = "sk-test";
+
+    const results = await relatedByVector("anchor", 10);
+    expect(results.map((r) => r.slug)).toEqual(["near", "mid", "far"]);
+    expect(results.some((r) => r.slug === "anchor")).toBe(false);
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+  });
+
+  it("respects topK", async () => {
+    await saveVectorStore(store);
+    process.env.EMBEDDING_MODEL = "text-embedding-3-small";
+    process.env.OPENAI_API_KEY = "sk-test";
+
+    const results = await relatedByVector("anchor", 2);
+    expect(results).toHaveLength(2);
+  });
+
+  it("returns [] when the anchor has no stored vector", async () => {
+    await saveVectorStore(store);
+    process.env.EMBEDDING_MODEL = "text-embedding-3-small";
+    process.env.OPENAI_API_KEY = "sk-test";
+
+    expect(await relatedByVector("ghost", 10)).toEqual([]);
+  });
+
+  it("returns [] when the store was built with a different model (stale)", async () => {
+    await saveVectorStore(store); // built with text-embedding-3-small
+    process.env.EMBEDDING_MODEL = "text-embedding-3-large"; // current model differs
+    process.env.OPENAI_API_KEY = "sk-test";
+
+    expect(await relatedByVector("anchor", 10)).toEqual([]);
   });
 });
 

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -10,6 +10,13 @@ vi.mock("../llm", () => ({
   callLLM: vi.fn(async () => "[]"),
 }));
 
+// Stub the vector primitive so findSimilarPages tests control the ranking
+// without a real embedding store; keep every other embeddings export real.
+vi.mock("../embeddings", async (orig) => {
+  const actual = await orig<typeof import("../embeddings")>();
+  return { ...actual, relatedByVector: vi.fn(async () => []) };
+});
+
 import {
   writeWikiPage,
   ensureDirectories,
@@ -19,6 +26,7 @@ import {
 import {
   searchWikiContent,
   findBacklinks,
+  findSimilarPages,
   updateRelatedPages,
   fuzzyMatch,
   levenshteinDistance,
@@ -35,6 +43,9 @@ import { serializeFrontmatter } from "../frontmatter";
 import { isAgentScopedType } from "../wiki";
 import type { AgentProfile } from "../types";
 import { _resetStorage } from "../storage";
+import { relatedByVector } from "../embeddings";
+
+const mockedRelatedByVector = vi.mocked(relatedByVector);
 
 let tmpDir: string;
 let originalWikiDir: string | undefined;
@@ -362,6 +373,68 @@ describe("findBacklinks", () => {
 });
 
 // ---------------------------------------------------------------------------
+// findSimilarPages — semantic "Related pages"
+// ---------------------------------------------------------------------------
+
+describe("findSimilarPages", () => {
+  async function seed(slugs: string[]) {
+    await ensureDirectories();
+    for (const s of slugs) await writeWikiPage(s, `# ${s}\n\nBody of ${s}.`);
+    await updateIndex(slugs.map((s) => ({ title: s.toUpperCase(), slug: s, summary: s })));
+  }
+
+  it("resolves titles and drops below-threshold matches", async () => {
+    await seed(["anchor", "a", "b", "c"]);
+    mockedRelatedByVector.mockResolvedValueOnce([
+      { slug: "a", score: 0.8 },
+      { slug: "b", score: 0.5 },
+      { slug: "c", score: 0.2 }, // below default 0.45 → dropped
+    ]);
+
+    const related = await findSimilarPages("anchor");
+    expect(related.map((r) => r.slug)).toEqual(["a", "b"]);
+    expect(related[0]).toMatchObject({ slug: "a", title: "A", score: 0.8 });
+  });
+
+  it("skips the page itself, index, and log", async () => {
+    await seed(["anchor", "real"]);
+    mockedRelatedByVector.mockResolvedValueOnce([
+      { slug: "anchor", score: 0.9 },
+      { slug: "index", score: 0.9 },
+      { slug: "log", score: 0.9 },
+      { slug: "real", score: 0.7 },
+    ]);
+
+    const related = await findSimilarPages("anchor");
+    expect(related.map((r) => r.slug)).toEqual(["real"]);
+  });
+
+  it("excludes pages not in the reader's readable set", async () => {
+    await seed(["anchor", "visible"]);
+    mockedRelatedByVector.mockResolvedValueOnce([
+      { slug: "ghost", score: 0.9 }, // not in the index → unreadable → excluded
+      { slug: "visible", score: 0.8 },
+    ]);
+
+    const related = await findSimilarPages("anchor");
+    expect(related.map((r) => r.slug)).toEqual(["visible"]);
+  });
+
+  it("respects the limit", async () => {
+    await seed(["anchor", "a", "b", "c", "d"]);
+    mockedRelatedByVector.mockResolvedValueOnce([
+      { slug: "a", score: 0.9 },
+      { slug: "b", score: 0.85 },
+      { slug: "c", score: 0.8 },
+      { slug: "d", score: 0.75 },
+    ]);
+
+    const related = await findSimilarPages("anchor", null, 2);
+    expect(related).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // updateRelatedPages
 // ---------------------------------------------------------------------------
 
@@ -376,6 +449,21 @@ describe("updateRelatedPages", () => {
     const page = await readWikiPage("existing");
     expect(page).not.toBeNull();
     expect(page!.content).toContain("**See also:** [New Page](new-page.md)");
+  });
+
+  it("keeps the backlink index fresh for the appended See-also link", async () => {
+    await ensureDirectories();
+    await writeWikiPage("existing", "# Existing\n\nBody.");
+    await updateIndex([{ title: "Existing", slug: "existing", summary: "x" }]);
+    const { rebuildBacklinkIndex, getBacklinkIndex } = await import("../backlink-index");
+    await rebuildBacklinkIndex(); // a present (empty) index — sync no-ops without one
+
+    await updateRelatedPages("new-page", "New Page", ["existing"]);
+
+    // The appended `[New Page](new-page.md)` in `existing` must register as a
+    // backlink so findBacklinks (which trusts the index) surfaces it.
+    const idx = await getBacklinkIndex();
+    expect(idx?.["new-page"]).toContain("existing");
   });
 
   it("skips pages that already link to the new slug", async () => {

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -420,6 +420,41 @@ describe("findSimilarPages", () => {
     expect(related.map((r) => r.slug)).toEqual(["visible"]);
   });
 
+  it("enforces visibility: a private page is hidden from non-owners, shown to its owner", async () => {
+    await ensureDirectories();
+    await writeWikiPage("anchor", "# Anchor\n\nBody.");
+    await writeWikiPage("pub", "# Pub\n\nbody");
+    await writeWikiPage(
+      "secret",
+      serializeFrontmatter({ owner: "alice", visibility: "private" }, "# Secret\n\nbody"),
+    );
+    await updateIndex([
+      { title: "Anchor", slug: "anchor", summary: "a" },
+      { title: "Pub", slug: "pub", summary: "p" },
+      { title: "Secret", slug: "secret", summary: "s", owner: "alice", visibility: "private" },
+    ]);
+    // Ranking puts the private page above the public one — only the visibility
+    // filter (not ordering) should keep it out for non-owners.
+    mockedRelatedByVector.mockResolvedValue([
+      { slug: "secret", score: 0.9 },
+      { slug: "pub", score: 0.8 },
+    ]);
+
+    // Anonymous reader and a different signed-in user: private excluded.
+    expect((await findSimilarPages("anchor", null)).map((r) => r.slug)).toEqual(["pub"]);
+    expect(
+      (await findSimilarPages("anchor", { id: "bob", handle: "bob" })).map((r) => r.slug),
+    ).toEqual(["pub"]);
+    // The owner sees their own private page.
+    expect(
+      (await findSimilarPages("anchor", { id: "alice", handle: "alice" }))
+        .map((r) => r.slug)
+        .sort(),
+    ).toEqual(["pub", "secret"]);
+
+    mockedRelatedByVector.mockResolvedValue([]); // reset default for later tests
+  });
+
   it("respects the limit", async () => {
     await seed(["anchor", "a", "b", "c", "d"]);
     mockedRelatedByVector.mockResolvedValueOnce([

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -112,6 +112,18 @@ export const INGEST_MAX_OUTPUT_TOKENS = 8192;
  */
 export const QUERY_MAX_OUTPUT_TOKENS = 8192;
 
+// ---- Related pages --------------------------------------------------------
+
+/** Max pages shown in an article's "Related pages" (semantic see-also) section. */
+export const RELATED_PAGES_LIMIT = 6;
+
+/**
+ * Minimum cosine similarity for a page to count as "related". Tuned for
+ * bge-m3: distinct-but-related pages sit well above this, while unrelated
+ * pages fall below — so weak matches don't pad the section.
+ */
+export const RELATED_MIN_SCORE = 0.45;
+
 // ---- Graph ----------------------------------------------------------------
 
 /** Default canvas height (px) for the wiki graph visualisation. */

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -526,6 +526,35 @@ export async function searchByVector(
   return scored.slice(0, topK);
 }
 
+/**
+ * Find pages most similar to an EXISTING page, reusing its already-stored
+ * vector — no embedding call, so it's cheap enough to run on every page render.
+ *
+ * Returns top-K other pages by cosine similarity (descending). Returns an empty
+ * array if there's no store, the page has no stored vector, or the store was
+ * built with a different model (stale embeddings → meaningless scores). Does NOT
+ * enforce visibility — callers must filter to readable pages.
+ */
+export async function relatedByVector(
+  slug: string,
+  topK: number = 10,
+): Promise<Array<{ slug: string; score: number }>> {
+  const store = await loadVectorStore();
+  if (!store || store.entries.length === 0) return [];
+
+  const currentModel = getEmbeddingModelName();
+  if (currentModel && store.model !== currentModel) return [];
+
+  const self = store.entries.find((e) => e.slug === slug);
+  if (!self) return [];
+
+  return store.entries
+    .filter((e) => e.slug !== slug)
+    .map((e) => ({ slug: e.slug, score: cosineSimilarity(self.embedding, e.embedding) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, topK);
+}
+
 // ---------------------------------------------------------------------------
 // Full vector store rebuild
 // ---------------------------------------------------------------------------

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -22,7 +22,9 @@ import { getAgent, resolveAgentPages } from "./agents";
 import { getVault } from "./vault";
 import { getStorage } from "./storage";
 import { getOwnerIndex } from "./owner-index";
-import { getBacklinkIndex } from "./backlink-index";
+import { getBacklinkIndex, syncBacklinksForPage } from "./backlink-index";
+import { relatedByVector } from "./embeddings";
+import { RELATED_PAGES_LIMIT, RELATED_MIN_SCORE } from "./constants";
 
 // ---------------------------------------------------------------------------
 // Cross-referencing helpers
@@ -128,6 +130,10 @@ export async function updateRelatedPages(
       }
 
       await writeWikiPage(slug, updatedContent);
+      // Keep the backlink index consistent with the new outbound "See also"
+      // link — writeWikiPage doesn't, so without this the index goes stale and
+      // findBacklinks (which trusts the index) would never surface this edge.
+      await syncBacklinksForPage(slug, updatedContent, page.content);
       updatedSlugs.push(slug);
     }
 
@@ -185,6 +191,47 @@ export async function findBacklinks(
     }
 
     return backlinks;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Related pages — semantic "see also"
+// ---------------------------------------------------------------------------
+
+/**
+ * Find pages semantically related to `slug` via vector similarity, for the
+ * "Related pages" section. Unlike backlinks (explicit links), this surfaces
+ * topically-similar pages even when nothing links to the page.
+ *
+ * Visibility is enforced on READ (a private page never leaks to a viewer who
+ * can't see it). Below-threshold matches are dropped so weakly-related pages
+ * don't appear. Returns `{ slug, title, score }`, highest score first.
+ */
+export async function findSimilarPages(
+  slug: string,
+  principal: Principal | null = null,
+  limit: number = RELATED_PAGES_LIMIT,
+  minScore: number = RELATED_MIN_SCORE,
+): Promise<Array<{ slug: string; title: string; score: number }>> {
+  return withPageCache(async () => {
+    // Over-fetch so visibility/threshold filtering still leaves up to `limit`.
+    const scored = await relatedByVector(slug, limit + 10);
+    if (scored.length === 0) return [];
+
+    const readable = new Map(
+      (await listReadableWikiPages(principal)).map((p) => [p.slug, p.title]),
+    );
+
+    const related: Array<{ slug: string; title: string; score: number }> = [];
+    for (const { slug: s, score } of scored) {
+      if (score < minScore) break; // sorted desc — nothing further qualifies
+      if (s === slug || s === "index" || s === "log") continue;
+      const title = readable.get(s);
+      if (title === undefined) continue; // not readable by this viewer
+      related.push({ slug: s, title, score });
+      if (related.length >= limit) break;
+    }
+    return related;
   });
 }
 

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -576,6 +576,7 @@ export type { LogOperation } from "./wiki-log";
 
 export {
   findRelatedPages,
+  findSimilarPages,
   updateRelatedPages,
   findBacklinks,
   searchWikiContent,


### PR DESCRIPTION
## Why
On `/wiki/ai-engineering-skills` nothing related showed — even though two pages (`skillopt`, `agentic-system`) link to it. Investigation found **two** gaps.

## 1. Stale backlink index (bug)
`updateRelatedPages` appends `**See also:** [Title](slug.md)` into related pages via raw `writeWikiPage`, which **doesn't update the backlink index**. `findBacklinks` trusts the index when present and returns empty if the target isn't in it — so "what links here" rendered nothing while the links sat in the page bodies (the graph, which live-scans, showed the edges). Now `updateRelatedPages` calls `syncBacklinksForPage` after each append to keep the index consistent.

## 2. Semantic "Related pages" (new feature)
Backlinks only cover *explicit* links and are directional. Added a **Related pages** section powered by vector similarity:
- `relatedByVector(slug, topK)` (embeddings) — reuses the page's **already-stored** embedding, so it's a pure cosine pass with **no embedding call per render**. Returns `[]` on a model mismatch (stale store) or a missing vector.
- `findSimilarPages(slug, principal, limit, minScore)` (search) — enforces **read visibility**, resolves titles, drops below-threshold matches (`RELATED_MIN_SCORE = 0.45`, bge-m3-tuned), caps at `RELATED_PAGES_LIMIT = 6`.
- `ArticleView` renders it, **deduped against "what links here"** so the two sections never repeat a page.

For the page in question this surfaces exactly `skillopt` + `agentic-system`.

## Tests
- `relatedByVector`: ranking/exclusion of self, topK, missing-vector → `[]`, model-mismatch → `[]`.
- `findSimilarPages`: title resolution + threshold cutoff, skips self/index/log, excludes unreadable pages, respects limit.
- `updateRelatedPages`: new assertion that the appended See-also link registers in the backlink index.
- Full suite: **2693 passed**; `pnpm build` clean.

## Rollout note
The staleness **fix** prevents future drift, but pages whose index entry is *already* stale (incl. `ai-engineering-skills`) need one **`/api/tasks/scan`** rebuild to repair "what links here". The **semantic** section populates immediately on deploy.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)