### PR TITLE
Auto-generate vocabulary-aware tags during synthesis

### DIFF
--- a/src/hooks/useIngest.ts
+++ b/src/hooks/useIngest.ts
@@ -191,14 +191,19 @@ export function useIngest(): UseIngestReturn {
     setError(null);
 
     const generated = editedContent ?? preview.previewContent;
+    // The synthesized tags shown in the review card live only in the preview
+    // meta; forward them on commit so the published page keeps them (the
+    // commit-from-preview path skips the LLM and re-derives nothing).
+    const tags = preview.meta?.tags;
 
     try {
       const body = preview.url
-        ? { url: preview.url, generatedContent: generated }
+        ? { url: preview.url, generatedContent: generated, ...(tags?.length ? { tags } : {}) }
         : {
             title: preview.title,
             content: preview.content,
             generatedContent: generated,
+            ...(tags?.length ? { tags } : {}),
             // Preserve PDF/image provenance through the text commit path.
             ...(preview.sourceType ? { sourceType: preview.sourceType } : {}),
             ...(preview.sourceUrl ? { sourceUrl: preview.sourceUrl } : {}),

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -11,6 +11,8 @@ import {
   chunkText,
   parseConceptMarker,
   parseDisputedMarker,
+  normalizeTags,
+  collectTagVocabulary,
   tokenizeSourceImages,
   restoreImageTokens,
 } from "../ingest";
@@ -309,6 +311,63 @@ describe("ingest", () => {
 // ---------------------------------------------------------------------------
 // ingest — YAML frontmatter
 // ---------------------------------------------------------------------------
+
+describe("ingest — auto tags", () => {
+  beforeEach(() => {
+    mockedHasLLMKey.mockReturnValue(true);
+  });
+  afterEach(() => {
+    mockedHasLLMKey.mockReturnValue(false);
+  });
+
+  it("persists LLM-synthesized TAGS to the page frontmatter", async () => {
+    mockedCallLLM.mockResolvedValueOnce(
+      "CONCEPT: Vector Databases\nTAGS: Databases, vector-search, #AI\n\n# Vector Databases\n\n## Summary\n\nStores embeddings.",
+    );
+
+    const result = await ingest("Vector DBs", "A source about vector databases and ANN search.");
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect(page!.frontmatter.tags).toEqual(["databases", "vector-search", "ai"]);
+  });
+
+  it("merges synthesized tags with caller-supplied tags (deduped)", async () => {
+    mockedCallLLM.mockResolvedValueOnce(
+      "CONCEPT: Caching\nTAGS: performance, caching\n\n# Caching\n\nBody.",
+    );
+
+    const result = await ingest("Caching", "Source about caching.", {
+      tags: ["systems", "caching"],
+    });
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect((page!.frontmatter.tags as string[]).sort()).toEqual([
+      "caching",
+      "performance",
+      "systems",
+    ]);
+  });
+
+  it("collectTagVocabulary reflects tags across ingested pages, most-used first", async () => {
+    mockedCallLLM.mockResolvedValueOnce("CONCEPT: Alpha\nTAGS: ml, nlp\n\n# Alpha\n\nBody.");
+    await ingest("Alpha", "source alpha about ml and nlp");
+    mockedCallLLM.mockResolvedValueOnce("CONCEPT: Beta\nTAGS: ml\n\n# Beta\n\nBody.");
+    await ingest("Beta", "source beta about ml");
+
+    const vocab = await collectTagVocabulary();
+    expect(vocab[0]).toBe("ml"); // used by both pages → ranked first
+    expect(vocab).toContain("nlp");
+  });
+
+  it("buildIngestSystemPrompt injects the existing tag vocabulary for reuse", async () => {
+    mockedCallLLM.mockResolvedValueOnce(
+      "CONCEPT: Gamma\nTAGS: machine-learning, nlp\n\n# Gamma\n\nBody.",
+    );
+    await ingest("Gamma", "source gamma");
+
+    const prompt = await buildIngestSystemPrompt();
+    expect(prompt).toContain("Tags already used across this wiki");
+    expect(prompt).toContain("machine-learning");
+  });
+});
 
 describe("ingest — YAML frontmatter", () => {
   it("prepends a frontmatter block to new pages", async () => {
@@ -1642,6 +1701,12 @@ describe("schema-aware ingest prompt", () => {
     // substantive source content (not just a thin summary).
     expect(prompt).toContain("## Details");
   });
+
+  it("buildIngestSystemPrompt asks for a TAGS line in the output spec", async () => {
+    const prompt = await buildIngestSystemPrompt();
+    expect(prompt).toContain("TAGS:");
+    expect(prompt).toContain("lowercase, hyphenated");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1707,6 +1772,49 @@ describe("parseConceptMarker", () => {
     const { concept, body } = parseConceptMarker(raw);
     expect(concept).toBe("");
     expect(body).toBe(raw);
+  });
+
+  it("parses a TAGS line (normalized) and strips all three headers", () => {
+    const { concept, aliases, tags, body } = parseConceptMarker(
+      "CONCEPT: Transformer\nALIASES: none\nTAGS: Machine Learning, deep-learning, #NLP\n\n# Transformer\n\nBody.",
+    );
+    expect(concept).toBe("Transformer");
+    expect(aliases).toEqual([]);
+    expect(tags).toEqual(["machine-learning", "deep-learning", "nlp"]);
+    expect(body).toBe("# Transformer\n\nBody.");
+    expect(body).not.toContain("TAGS:");
+  });
+
+  it("parses TAGS even when it precedes ALIASES", () => {
+    const { aliases, tags, body } = parseConceptMarker(
+      "CONCEPT: RAG\nTAGS: retrieval, llm\nALIASES: retrieval-augmented generation\n\n# RAG\n",
+    );
+    expect(tags).toEqual(["retrieval", "llm"]);
+    expect(aliases).toEqual(["retrieval-augmented generation"]);
+    expect(body).toBe("# RAG\n");
+  });
+
+  it("returns no tags when the TAGS line is absent or 'none'", () => {
+    expect(parseConceptMarker("CONCEPT: X\n\n# X\n").tags).toEqual([]);
+    expect(parseConceptMarker("CONCEPT: X\nTAGS: none\n\n# X\n").tags).toEqual([]);
+  });
+});
+
+describe("normalizeTags", () => {
+  it("lowercases, hyphenates, strips '#', and dedupes", () => {
+    expect(normalizeTags(["Machine Learning", "#NLP", "machine  learning", "deep_learning"])).toEqual([
+      "machine-learning",
+      "nlp",
+      "deep-learning",
+    ]);
+  });
+
+  it("caps the number of tags", () => {
+    expect(normalizeTags(["a", "b", "c", "d", "e", "f", "g", "h"], 3)).toEqual(["a", "b", "c"]);
+  });
+
+  it("drops entries that normalize to empty", () => {
+    expect(normalizeTags(["###", "  ", "ok"])).toEqual(["ok"]);
   });
 });
 

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -318,6 +318,34 @@ describe("ingest — auto tags", () => {
   });
   afterEach(() => {
     mockedHasLLMKey.mockReturnValue(false);
+    mockedCallLLM.mockReset();
+  });
+
+  it("keeps caller tags on the commit-from-preview path (generatedContent skips the LLM)", async () => {
+    // The web flow: handleApprove forwards the preview's tags as options.tags
+    // and sends generatedContent, which short-circuits the LLM — so the only
+    // way tags survive is the options.tags merge (conceptTags is empty here).
+    const result = await ingest("Reviewed Page", "original source text", {
+      generatedContent: "# Reviewed Page\n\n## Summary\n\nApproved body.",
+      tags: ["ml", "nlp"],
+    });
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect((page!.frontmatter.tags as string[]).sort()).toEqual(["ml", "nlp"]);
+  });
+
+  it("merges freshly synthesized tags with an existing page's on-disk tags on re-ingest", async () => {
+    mockedCallLLM.mockResolvedValue(
+      "CONCEPT: Topic Alpha\nTAGS: keep-me\n\n# Topic Alpha\n\nFirst version.",
+    );
+    await ingest("Topic Alpha", "first source about the topic");
+
+    mockedCallLLM.mockResolvedValue(
+      "CONCEPT: Topic Alpha\nTAGS: keep-me, new-one\n\n# Topic Alpha\n\nSecond version, changed.",
+    );
+    const result = await ingest("Topic Alpha", "second source, changed content");
+
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect((page!.frontmatter.tags as string[]).sort()).toEqual(["keep-me", "new-one"]);
   });
 
   it("persists LLM-synthesized TAGS to the page frontmatter", async () => {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -39,6 +39,15 @@ export const MAX_IMAGES_PER_SOURCE = 20;
 /** Maximum number of source images tokenized for inline placement during synthesis. */
 export const MAX_APPENDED_IMAGES = 12;
 
+/** Max auto-generated tags persisted per page during synthesis. */
+export const MAX_AUTO_TAGS = 6;
+
+/**
+ * Max existing tags shown to the synthesis LLM as the reuse vocabulary. Bounds
+ * prompt size on large wikis (most-used tags first).
+ */
+export const TAG_VOCAB_LIMIT = 60;
+
 // ---- Batch ingest ---------------------------------------------------------
 
 /** Maximum number of URLs accepted in a single batch-ingest request. */

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -1418,12 +1418,9 @@ export async function ingest(
     // Synthesized tags + any existing/caller tags. The reviewer sees these in
     // the card and (via the commit-from-preview path) they're sent back as
     // options.tags on approve, so the published page keeps them.
-    const tags = Array.from(
-      new Set([
-        ...(existingEntry?.tags ?? []),
-        ...(options?.tags ?? []),
-        ...conceptTags,
-      ]),
+    const tags = normalizeTags(
+      [...(existingEntry?.tags ?? []), ...(options?.tags ?? []), ...conceptTags],
+      Infinity, // canonicalize + dedupe; the per-synthesis cap was applied above
     );
 
     const previewMeta: IngestPreviewMeta = {
@@ -1509,8 +1506,9 @@ export async function ingest(
   frontmatter.sources = serializeSources([sourceEntry]);
 
   // Tags: synthesized (conceptTags, empty on commit-from-preview/fallback) plus
-  // any caller-supplied tags. Merged with existing tags below for re-ingests.
-  const newTags = [...new Set([...(options?.tags ?? []), ...conceptTags])];
+  // any caller-supplied tags — normalized to the canonical form so caller tags
+  // dedupe against synthesized ones. Merged with existing tags below for re-ingests.
+  const newTags = normalizeTags([...(options?.tags ?? []), ...conceptTags], Infinity);
   if (newTags.length > 0) {
     frontmatter.tags = newTags;
   }
@@ -1536,7 +1534,7 @@ export async function ingest(
       const existingTags = existing.frontmatter.tags.filter(
         (t): t is string => typeof t === "string",
       );
-      const merged = [...new Set([...existingTags, ...newTags])];
+      const merged = normalizeTags([...existingTags, ...newTags], Infinity);
       frontmatter.tags = merged;
     }
     // Preserve existing source_url if the new ingest doesn't provide one.

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -52,6 +52,8 @@ import {
   MAX_APPENDED_IMAGES,
   MAX_CONTENT_LENGTH,
   MAX_PDF_SIZE,
+  MAX_AUTO_TAGS,
+  TAG_VOCAB_LIMIT,
 } from "./constants";
 import { ClientInputError } from "./errors";
 import { slugify } from "./slugify";
@@ -684,11 +686,13 @@ function splitSentences(text: string): string[] {
 // Conventions are documented in SCHEMA.md at the repo root.
 const INGEST_SYSTEM_PROMPT_BASE = `You are a wiki editor. Given a source document, generate a wiki article in markdown format.
 
-Begin your output with these two header lines in EXACTLY this form:
+Begin your output with these three header lines in EXACTLY this form:
 CONCEPT: <canonical concept name>
 ALIASES: <comma-separated alternative names / synonyms for the concept, or "none">
+TAGS: <3-6 lowercase, hyphenated topic tags, comma-separated>
 CONCEPT names the one CANONICAL CONCEPT the document is about — the established term other writers on the same topic would also use (a concept, NOT the article's headline). Pick a granularity that is one coherent topic: general enough that other articles on the same subject would share it, specific enough not to lump distinct topics together.
 ALIASES lists other names the SAME concept is known by (acronyms, expansions, common synonyms) so future sources under those names converge here — not narrower sub-topics or related concepts. Use "none" if there are no real synonyms.
+TAGS are 3-6 broad topical labels for browsing/filtering (e.g. \`machine-learning\`, \`distributed-systems\`) — lowercase, hyphenated, no \`#\`. Tags are coarser than the CONCEPT: they group MANY pages, so reuse shared themes rather than coining a unique tag per page.
 
 Then, on the following lines, the wiki article. Include:
 - A title as a level-1 heading (# Title) — use the SAME canonical concept
@@ -705,7 +709,7 @@ Then, on the following lines, the wiki article. Include:
 
 Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. KEEP the ones that are genuine content — diagrams, figures, charts, screenshots that illustrate the topic — by writing the SAME token on its own line at the most relevant point in the article (next to the text it illustrates). Omit any token whose image is clearly decorative/branding/UI. Never invent tokens or change their numbers; output each kept token verbatim.
 
-Write a focused, distilled page, not a transcript of the source. Output the CONCEPT and ALIASES lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
+Write a focused, distilled page, not a transcript of the source. Output the CONCEPT, ALIASES, and TAGS lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
 
 /**
  * System prompt for continuation chunks when a long source document has been
@@ -763,27 +767,68 @@ Output the optional DISPUTED line, then pure markdown, and nothing else. Do not 
 export function parseConceptMarker(raw: string): {
   concept: string;
   aliases: string[];
+  tags: string[];
   body: string;
 } {
   const conceptM = raw.match(/^\uFEFF?\s*CONCEPT:[ \t]*(.+?)[ \t]*(?:\r?\n|$)/i);
-  if (!conceptM) return { concept: "", aliases: [], body: raw };
+  if (!conceptM) return { concept: "", aliases: [], tags: [], body: raw };
 
   let rest = raw.slice(conceptM[0].length);
   let aliases: string[] = [];
-  const aliasM = rest.match(/^\s*ALIASES:[ \t]*(.*?)[ \t]*(?:\r?\n|$)/i);
-  if (aliasM) {
-    rest = rest.slice(aliasM[0].length);
-    aliases = aliasM[1]
+  let tags: string[] = [];
+  const splitList = (s: string) =>
+    s
       .split(/[;,]/)
-      .map((s) => s.trim())
-      .filter((s) => s !== "" && s.toLowerCase() !== "none");
+      .map((x) => x.trim())
+      .filter((x) => x !== "" && x.toLowerCase() !== "none");
+
+  // Consume the optional ALIASES / TAGS header lines in either order.
+  for (let i = 0; i < 2; i++) {
+    const aliasM = rest.match(/^\s*ALIASES:[ \t]*(.*?)[ \t]*(?:\r?\n|$)/i);
+    if (aliasM && aliases.length === 0) {
+      rest = rest.slice(aliasM[0].length);
+      aliases = splitList(aliasM[1]);
+      continue;
+    }
+    const tagM = rest.match(/^\s*TAGS:[ \t]*(.*?)[ \t]*(?:\r?\n|$)/i);
+    if (tagM && tags.length === 0) {
+      rest = rest.slice(tagM[0].length);
+      tags = normalizeTags(splitList(tagM[1]));
+      continue;
+    }
+    break;
   }
 
   return {
     concept: conceptM[1].trim(),
     aliases,
+    tags,
     body: rest.replace(/^\s+/, ""),
   };
+}
+
+/**
+ * Normalize free-text tags to the wiki's canonical form: lowercase,
+ * hyphen-separated, no leading `#`, deduped, capped at {@link MAX_AUTO_TAGS}.
+ * Keeps tags consistent regardless of how the LLM (or a caller) cased/spaced them.
+ */
+export function normalizeTags(raw: string[], max: number = MAX_AUTO_TAGS): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const t of raw) {
+    const tag = t
+      .toLowerCase()
+      .trim()
+      .replace(/^#+/, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    if (tag && !seen.has(tag)) {
+      seen.add(tag);
+      out.push(tag);
+      if (out.length >= max) break;
+    }
+  }
+  return out;
 }
 
 /** Cosine-similarity floor for treating the nearest existing page as the SAME
@@ -898,16 +943,54 @@ async function reconcilePage(
  * call (no caching) so live edits to SCHEMA.md take effect immediately —
  * the whole point is to keep prompt and schema co-evolving.
  */
+/**
+ * The wiki's existing tag vocabulary (most-used first), so the synthesis LLM can
+ * PREFER reusing established tags over coining near-duplicates ("llm" vs "llms").
+ * Capped at {@link TAG_VOCAB_LIMIT} to bound prompt size. Best-effort: returns
+ * `[]` if the index can't be read.
+ */
+export async function collectTagVocabulary(
+  limit: number = TAG_VOCAB_LIMIT,
+): Promise<string[]> {
+  try {
+    const counts = new Map<string, number>();
+    for (const entry of await listWikiPages()) {
+      for (const t of entry.tags ?? []) {
+        if (typeof t === "string" && t.trim() !== "") {
+          counts.set(t, (counts.get(t) ?? 0) + 1);
+        }
+      }
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, limit)
+      .map(([tag]) => tag);
+  } catch {
+    return [];
+  }
+}
+
 export async function buildIngestSystemPrompt(): Promise<string> {
   const conventions = await loadPageConventions();
-  if (conventions === "") return INGEST_SYSTEM_PROMPT_BASE;
-  return `${INGEST_SYSTEM_PROMPT_BASE}
+  const vocab = await collectTagVocabulary();
+
+  let prompt = INGEST_SYSTEM_PROMPT_BASE;
+  if (conventions !== "") {
+    prompt += `
 
 The wiki you are editing follows these conventions (from SCHEMA.md):
 
 ${conventions}
 
 Follow these conventions when generating the page.`;
+  }
+  if (vocab.length > 0) {
+    prompt += `
+
+Tags already used across this wiki (PREFER reusing an existing tag when it fits; only coin a new one when none apply):
+${vocab.join(", ")}`;
+  }
+  return prompt;
 }
 
 // ---------------------------------------------------------------------------
@@ -1223,6 +1306,7 @@ export async function ingest(
   const {
     concept,
     aliases: conceptSynonyms,
+    tags: conceptTags,
     body: conceptStrippedBody,
   } = parseConceptMarker(wikiContent);
   wikiContent = conceptStrippedBody;
@@ -1331,8 +1415,15 @@ export async function ingest(
       }
     }
 
+    // Synthesized tags + any existing/caller tags. The reviewer sees these in
+    // the card and (via the commit-from-preview path) they're sent back as
+    // options.tags on approve, so the published page keeps them.
     const tags = Array.from(
-      new Set([...(existingEntry?.tags ?? []), ...(options?.tags ?? [])]),
+      new Set([
+        ...(existingEntry?.tags ?? []),
+        ...(options?.tags ?? []),
+        ...conceptTags,
+      ]),
     );
 
     const previewMeta: IngestPreviewMeta = {
@@ -1417,9 +1508,11 @@ export async function ingest(
   const sourceEntry = buildSourceEntry(sourceUrl, sourceType, options?.triggeredBy, rawId);
   frontmatter.sources = serializeSources([sourceEntry]);
 
-  // Apply tags from options (will be merged with existing tags below for re-ingests).
-  if (options?.tags && options.tags.length > 0) {
-    frontmatter.tags = options.tags;
+  // Tags: synthesized (conceptTags, empty on commit-from-preview/fallback) plus
+  // any caller-supplied tags. Merged with existing tags below for re-ingests.
+  const newTags = [...new Set([...(options?.tags ?? []), ...conceptTags])];
+  if (newTags.length > 0) {
+    frontmatter.tags = newTags;
   }
 
   const existing = await readWikiPageWithFrontmatter(slug);
@@ -1443,7 +1536,6 @@ export async function ingest(
       const existingTags = existing.frontmatter.tags.filter(
         (t): t is string => typeof t === "string",
       );
-      const newTags = options?.tags ?? [];
       const merged = [...new Set([...existingTags, ...newTags])];
       frontmatter.tags = merged;
     }


### PR DESCRIPTION
## Why
Wiki pages render `#tag` chips (`ArticleView.tsx:284`) but showed none, because **nothing generated tags**. Tags were only ever set when an API/MCP caller passed a `tags` field — the web `/ingest` flow never did, and the synthesis LLM never produced any. So UI-ingested pages had `tags: []`.

## What
Synthesis now auto-generates tags, **vocabulary-aware** so they stay consistent:
- **Prompt** (`INGEST_SYSTEM_PROMPT_BASE`): adds a `TAGS:` output line (3–6 lowercase, hyphenated) next to `CONCEPT`/`ALIASES`.
- **`buildIngestSystemPrompt`**: appends the wiki's existing tag vocabulary (`collectTagVocabulary`, most-used first, capped at `TAG_VOCAB_LIMIT=60`) and tells the LLM to PREFER reusing it — avoiding `llm`/`llms`/`large-language-models` drift.
- **`parseConceptMarker`**: parses + normalizes the `TAGS` line (tolerant of either order vs `ALIASES`). `normalizeTags` lowercases, hyphenates, strips `#`, dedupes, caps at `MAX_AUTO_TAGS=6`.
- **Persistence**: merged into `frontmatter.tags` on the direct-ingest path (MCP / X-mention / agent) and, for the web preview→commit flow, carried through the preview meta → `useIngest.handleApprove` sends them as `options.tags` on approve (the commit-from-preview path skips the LLM). Merged with existing + caller-supplied tags, deduped.

The review card already renders `meta.tags`, so reviewers now see the synthesized tags before publishing.

## Tests
- `parseConceptMarker`: TAGS parsing (normalized), either-order vs ALIASES, absent/`none`.
- `normalizeTags`: casing/hyphenation/`#`/dedupe, cap, empty-drop.
- `ingest`: synthesized TAGS persisted to frontmatter; merged with caller tags (deduped).
- `collectTagVocabulary` reflects tags across ingested pages (most-used first); `buildIngestSystemPrompt` injects the vocabulary and asks for a TAGS line.
- Full suite: **2705 passed**; `pnpm build` clean.

## Rollout note
Only **new/re-ingested** pages get tags — existing pages stay untagged until re-ingested (no backfill here).

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)