### PR TITLE
Fix reingest: X routing, slug pinning, source dedup by URL

### DIFF
--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -2795,6 +2795,48 @@ describe("reingest", () => {
     }
   });
 
+  it("re-ingesting a plain URL stays on the page's slug even when the concept differs (no fork)", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    const originalFetch = global.fetch;
+    try {
+      // First ingest → concept "Original Concept" → slug "original-concept".
+      mockedCallLLM.mockResolvedValue(
+        "CONCEPT: Original Concept\n\n# Original Concept\n\n## Summary\n\nv1.",
+      );
+      const first = await ingest("Seed Title", "seed content about the topic", {
+        sourceUrl: "https://example.com/doc",
+      });
+      expect(first.primarySlug).toBe("original-concept");
+
+      // Re-fetch returns fresh content; synthesis now names a DIFFERENT concept.
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Map([["content-type", "text/html"]]) as unknown as Headers,
+        body: null,
+        text: () =>
+          Promise.resolve(
+            "<html><head><title>Doc</title></head><body><p>completely updated body here</p></body></html>",
+          ),
+      });
+      mockedCallLLM.mockResolvedValue(
+        "CONCEPT: A Completely Different Concept\n\n# Different\n\n## Summary\n\nv2.",
+      );
+
+      const result = await reingest("original-concept");
+
+      // Pinned: updated in place, no fork to the new concept slug.
+      expect(result.primarySlug).toBe("original-concept");
+      expect(
+        await readWikiPageWithFrontmatter("a-completely-different-concept"),
+      ).toBeNull();
+    } finally {
+      global.fetch = originalFetch;
+      mockedHasLLMKey.mockReturnValue(false);
+      mockedCallLLM.mockReset();
+    }
+  });
+
   it("dedups a re-ingested source by URL even when the type differs", async () => {
     // A PDF page re-fetched as a plain "url" must not create a second source
     // entry for the same URL (the bug behind the duplicated arxiv sources).

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -1966,6 +1966,22 @@ describe("ingest — concept-slug convergence", () => {
     // Plus the source title.
     expect(aliases).toContain("A Deep Dive on RAG Systems");
   });
+
+  it("pinSlug keeps the page on its slug instead of forking to the concept slug", async () => {
+    // Even though the LLM names a different concept, pinSlug (used by reingest)
+    // must update IN PLACE rather than fork to `totally-different`.
+    mockedCallLLM.mockResolvedValue(
+      "CONCEPT: Totally Different\n\n# Totally Different\n\n## Summary\n\nBody.",
+    );
+
+    const result = await ingest("Pinned Page", "some source content here", {
+      pinSlug: "pinned-page",
+    });
+
+    expect(result.primarySlug).toBe("pinned-page");
+    expect(await readWikiPageWithFrontmatter("pinned-page")).not.toBeNull();
+    expect(await readWikiPageWithFrontmatter("totally-different")).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -2777,6 +2793,25 @@ describe("reingest", () => {
     } finally {
       global.fetch = originalFetch;
     }
+  });
+
+  it("dedups a re-ingested source by URL even when the type differs", async () => {
+    // A PDF page re-fetched as a plain "url" must not create a second source
+    // entry for the same URL (the bug behind the duplicated arxiv sources).
+    await ingest("Dup Source", "First version of the content. Details.", {
+      sourceUrl: "https://example.com/paper",
+      sourceType: "pdf",
+    });
+    await ingest("Dup Source", "Second version, changed content. More.", {
+      sourceUrl: "https://example.com/paper",
+      sourceType: "url",
+    });
+
+    const page = await readWikiPageWithFrontmatter("dup-source");
+    const sources = parseSources(page!.frontmatter.sources as string);
+    expect(sources).toHaveLength(1);
+    expect(sources[0].url).toBe("https://example.com/paper");
+    expect(sources[0].type).toBe("pdf"); // original, more-specific type preserved
   });
 
   it("throws when page has no source_url", async () => {

--- a/src/lib/__tests__/mcp.test.ts
+++ b/src/lib/__tests__/mcp.test.ts
@@ -2510,6 +2510,24 @@ describe("reingest", () => {
       handleReingest({ slug: "no-source" }),
     ).rejects.toThrow("no source URL recorded");
   });
+
+  it("re-ingests an X post via the syndication path, pinned to its slug", async () => {
+    await writeTestPage(
+      "a-tweet",
+      "---\nsource_url: https://x.com/u/status/123\n---\n# A Tweet\n\nold body.",
+    );
+    await writeIndex([{ title: "A Tweet", slug: "a-tweet", summary: "a tweet" }]);
+    mockedFetchXPostContent.mockClear();
+    mockedFetchUrlContent.mockClear();
+
+    const result = await handleReingest({ slug: "a-tweet" });
+
+    // Uses the X syndication fetch, NOT the plain HTML fetch (which would
+    // re-capture the "Something went wrong" shell), and stays on the same slug.
+    expect(mockedFetchXPostContent).toHaveBeenCalledWith("https://x.com/u/status/123");
+    expect(mockedFetchUrlContent).not.toHaveBeenCalled();
+    expect(result.primarySlug).toBe("a-tweet");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -31,7 +31,15 @@ function mergeSourceEntry(sources: SourceEntry[], entry: SourceEntry): SourceEnt
     entry.url !== "text-paste"
       ? sources.filter((s) => !(s.type === entry.type && s.url === "text-paste"))
       : sources;
-  const idx = base.findIndex((s) => s.url === entry.url && s.type === entry.type);
+  // A real (non-text-paste) source is identified by its URL alone: the same URL
+  // is the same source even if a re-ingest classified its type differently
+  // (e.g. a PDF URL re-fetched as a plain "url"). Matching on URL+type here let
+  // such a re-ingest append a duplicate entry. text-paste placeholders have no
+  // real URL, so they still dedup on (url, type).
+  const idx =
+    entry.url !== "text-paste"
+      ? base.findIndex((s) => s.url === entry.url)
+      : base.findIndex((s) => s.url === entry.url && s.type === entry.type);
   if (idx >= 0) {
     base[idx] = {
       ...base[idx],
@@ -397,14 +405,34 @@ export async function reingest(
     throw new Error("Cannot re-ingest: no source URL recorded");
   }
 
+  // Re-fetch via the SAME routing as ingestUrl (YouTube transcript, X
+  // syndication, else plain fetch) — otherwise an X post re-fetches the JS
+  // shell ("Something went wrong") and a tweet page rebuilds from the error
+  // page. `pinSlug` keeps the result on this page instead of forking to a new
+  // concept-derived slug.
   if (isYouTubeUrl(sourceUrl)) {
     const { title, content } = await fetchYouTubeContent(sourceUrl);
-    return ingest(title, content, { sourceUrl, sourceType: "youtube", ...opts });
+    return ingest(title, content, {
+      sourceUrl,
+      sourceType: "youtube",
+      pinSlug: slug,
+      ...opts,
+    });
+  }
+
+  if (isXPostUrl(sourceUrl)) {
+    const { title, content } = await fetchXPostContent(sourceUrl);
+    return ingest(title, content, {
+      sourceUrl,
+      sourceType: "x-mention",
+      pinSlug: slug,
+      ...opts,
+    });
   }
 
   const { title, content: rawContent } = await fetchUrlContent(sourceUrl);
   const content = await downloadImages(rawContent, slug, getRawDir());
-  return ingest(title, content, { sourceUrl, ...opts });
+  return ingest(title, content, { sourceUrl, pinSlug: slug, ...opts });
 }
 
 /**
@@ -1053,6 +1081,13 @@ export interface IngestOptions {
    * existing page (its scope is preserved — see below).
    */
   pageType?: "agent-knowledge" | "agent-identity";
+  /**
+   * Pin the result to this exact slug, bypassing concept/alias slug derivation.
+   * Used by `reingest()` so re-synthesizing a page updates it IN PLACE rather
+   * than forking to a new concept-derived slug (e.g. `agentic-system` →
+   * `agentic-systems`). Only honored on the direct synthesis path.
+   */
+  pinSlug?: string;
 }
 
 /**
@@ -1216,7 +1251,8 @@ export async function ingest(
   // Provisional slug from the title. On the direct ingest path this is later
   // replaced by a content-derived *concept* slug (see the CONCEPT marker below),
   // so the same concept under different headlines converges onto one page.
-  let slug = resolvedSlug ?? rawSlug;
+  // `pinSlug` (re-ingest) overrides everything: stay on the known page.
+  let slug = options?.pinSlug ?? resolvedSlug ?? rawSlug;
   // The page title written to the index/log. Becomes the canonical concept name
   // when one is derived; otherwise stays the source title.
   let pageTitle = title;
@@ -1315,20 +1351,27 @@ export async function ingest(
   // re-ingests of the same concept (under any headline) land on one page. The
   // preview→commit path keeps the title-derived slug (commit carries no marker)
   // — preview/commit slug consistency is handled separately.
+  // `pinSlug` (re-ingest) keeps the page on its known slug, so skip concept-slug
+  // convergence — but still adopt the concept as the title and record aliases.
   let conceptAliases: string[] = [];
   if (!isPreview && !preGeneratedContent && concept) {
-    const conceptSlug = slugify(concept);
-    if (conceptSlug !== "") {
-      slug = await resolveConceptSlug(
-        conceptSlug,
-        concept,
-        conceptSynonyms,
-        wikiContent,
-        owner,
-        options?.pageType,
-      );
+    if (options?.pinSlug) {
       pageTitle = concept;
       conceptAliases = conceptSynonyms;
+    } else {
+      const conceptSlug = slugify(concept);
+      if (conceptSlug !== "") {
+        slug = await resolveConceptSlug(
+          conceptSlug,
+          concept,
+          conceptSynonyms,
+          wikiContent,
+          owner,
+          options?.pageType,
+        );
+        pageTitle = concept;
+        conceptAliases = conceptSynonyms;
+      }
     }
   }
 


### PR DESCRIPTION
## Why
Re-ingesting existing pages (for a tag backfill) exposed three bugs:

1. **reingest ignored the X (and type) routing.** `reingest()` only special-cased YouTube; everything else went through bare `fetchUrlContent`. So re-ingesting a tweet hit the broken plain-fetch and rebuilt the page from X's "Something went wrong" shell (producing an `x-com-privacy-extension-conflict` page). It also re-fetched a PDF URL as a plain `url`.
2. **reingest forked the page.** Synthesis derives the slug from the concept, so re-synthesizing `agentic-system` forked it to a new `agentic-systems` page instead of updating in place.
3. **Duplicate sources.** `mergeSourceEntry` keyed on `(url, type)`, so the same URL re-ingested under a different type appended a second source entry — the duplicated arxiv entries in the SOURCES panel.

## Fixes (`src/lib/ingest.ts`)
- `reingest()` now routes X URLs through `fetchXPostContent` (syndication), matching `ingestUrl`.
- New `IngestOptions.pinSlug` — `ingest()` uses it as the canonical slug and skips concept/alias slug derivation; `reingest()` passes `pinSlug = slug` so a re-synthesis updates the page in place (no fork). Still adopts the concept as the title + records aliases.
- `mergeSourceEntry` dedups a real (non-`text-paste`) source by **URL alone**, preserving the original (more-specific) type — so the same URL never duplicates.

## Tests
- `ingest`: `pinSlug` keeps the page on its slug when the LLM names a different concept (no fork); a re-ingested source dedups by URL even when the type differs (and keeps the original type).
- `mcp` reingest: an X-post page re-ingests via `fetchXPostContent` (not the HTML fetch) and stays pinned to its slug.
- Full suite: **2710 passed**; `pnpm build` clean.

## Follow-up (data cleanup, not in this PR)
The earlier backfill attempt created two stray pages on the live site (`agentic-systems` dup, `x-com-privacy-extension-conflict` error-page) — those need deleting separately. And `ai-engineering-skills` has a `source_url` pointing at an unrelated tweet, so it can't be re-ingested from its source.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)