### PR TITLE
Link article tag chips to a tag-filtered browse

### DIFF
--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -12,7 +12,7 @@ export default async function WikiIndex({
 }: {
   searchParams: Promise<{ scope?: string; tag?: string }>;
 }) {
-  const { scope: scopeParam } = await searchParams;
+  const { scope: scopeParam, tag: tagParam } = await searchParams;
   const principal = await getPrincipal();
   const myHandle = principal?.handle ?? null;
 
@@ -62,6 +62,7 @@ export default async function WikiIndex({
         visibility: v.visibility,
       }))}
       discussionStats={discussionStats}
+      initialTag={tagParam ?? null}
     />
   );
 }

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -10,9 +10,12 @@ import { BrowseClient } from "@/components/BrowseClient";
 export default async function WikiIndex({
   searchParams,
 }: {
-  searchParams: Promise<{ scope?: string; tag?: string }>;
+  searchParams: Promise<{ scope?: string; tag?: string | string[] }>;
 }) {
-  const { scope: scopeParam, tag: tagParam } = await searchParams;
+  const { scope: scopeParam, tag: tagRaw } = await searchParams;
+  // A repeated `?tag=a&tag=b` arrives as string[] at runtime despite the type —
+  // take the first so the filter never compares against an array.
+  const tagParam = Array.isArray(tagRaw) ? tagRaw[0] : tagRaw;
   const principal = await getPrincipal();
   const myHandle = principal?.handle ?? null;
 

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -287,13 +287,15 @@ export async function ArticleView({
             style={{ gap: 10, marginBottom: 18, flexWrap: "wrap" }}
           >
             {tags.map((t) => (
-              <span
+              <Link
                 key={t}
+                href={`/wiki?tag=${encodeURIComponent(t)}`}
                 className="receipt"
-                style={{ fontSize: 11.5, color: "var(--accent)" }}
+                style={{ fontSize: 11.5, color: "var(--accent)", textDecoration: "none" }}
+                title={`Browse all pages tagged #${t}`}
               >
                 #{t}
-              </span>
+              </Link>
             ))}
           </div>
         )}

--- a/src/components/BrowseClient.tsx
+++ b/src/components/BrowseClient.tsx
@@ -25,6 +25,8 @@ interface BrowseClientProps {
   /** The signed-in user's own vaults — one lens pill each. */
   myVaults: VaultLite[];
   discussionStats?: Record<string, { total: number; open: number }>;
+  /** Initial tag filter (from `?tag=` — e.g. a tag chip on an article). */
+  initialTag?: string | null;
 }
 
 /** A single editorial result row (Folio `PageRow`). */
@@ -192,6 +194,7 @@ export function BrowseClient({
   activeScope,
   myVaults,
   discussionStats,
+  initialTag,
 }: BrowseClientProps) {
   // The active vault id (if the lens is a vault scope) and whether it's one of
   // the viewer's OWN vaults — only then do rows get a per-row Remove control.
@@ -205,7 +208,7 @@ export function BrowseClient({
 
   const [q, setQ] = useState("");
   const [sort, setSort] = useState<Sort>("recent");
-  const [tag, setTag] = useState<string | null>(null);
+  const [tag, setTag] = useState<string | null>(initialTag ?? null);
 
   const allTags = useMemo(() => {
     const f = new Map<string, number>();
@@ -418,6 +421,37 @@ export function BrowseClient({
 
         {/* Results */}
         <div>
+          {tag && (
+            <div
+              className="row"
+              style={{ gap: 8, alignItems: "center", marginBottom: 14 }}
+            >
+              <span style={{ fontSize: 13, color: "var(--muted)" }}>
+                Filtered by
+              </span>
+              <span
+                className="receipt"
+                style={{ fontSize: 12.5, color: "var(--accent)" }}
+              >
+                #{tag}
+              </span>
+              <button
+                type="button"
+                onClick={() => setTag(null)}
+                className="receipt"
+                style={{
+                  fontSize: 12,
+                  color: "var(--muted)",
+                  background: "transparent",
+                  border: 0,
+                  cursor: "pointer",
+                  padding: 0,
+                }}
+              >
+                · clear ✕
+              </button>
+            </div>
+          )}
           {filtered.length === 0 ? (
             <div style={{ padding: "60px 0", textAlign: "center" }}>
               <p style={{ fontSize: 22, color: "var(--ink-2)" }}>


### PR DESCRIPTION
## Why
Tags on a wiki page rendered as plain `<span>#tag</span>` — not clickable. There was no way to browse all pages under a tag, even though `BrowseClient` already filters by tag (in local state) and `/wiki` already parsed a `?tag=` param (but ignored it).

## What
- **`ArticleView`**: each `#tag` is now a `Link` to `/wiki?tag=<tag>`.
- **`/wiki/page.tsx`**: extracts the `tag` searchParam and passes it as `initialTag` to `BrowseClient`.
- **`BrowseClient`**: new `initialTag` prop seeds the existing tag-filter state, plus a small **"Filtered by #tag · clear ✕"** banner above the results so a deep-linked filter is visible and clearable even when that tag has no sidebar pill.

Clicking a tag on an article now lands on the commons browse filtered to that tag; the existing topic pills + clear control continue to work.

## Test plan
- `pnpm build` clean; `pnpm test` — 2711 passed (no behavior in the tested layers changed).
- Manual: open a tagged page → click a `#tag` → `/wiki?tag=…` shows only pages with that tag, with the clear banner; clearing restores the full list; the sidebar topic pill for that tag shows active.

Note: no component test added — the repo has no React component-test harness (same as prior UI PRs this session). The wiring is a prop pass-through + a `Link` href.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)