### PR TITLE
Dedup wiki page sources by URL at display time

### DIFF
--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -7,7 +7,7 @@ import { findBacklinks, findSimilarPages, buildSlugTenantMap } from "@/lib/wiki"
 import { resolveSlugPath } from "@/lib/links";
 import { getCommonsSlugSet, belongsInCommons } from "@/lib/commons";
 import type { Principal } from "@/lib/auth";
-import { parseSources } from "@/lib/sources";
+import { parseSources, dedupeSourcesForDisplay } from "@/lib/sources";
 import type { SourceEntry } from "@/lib/types";
 import { formatRelativeTime } from "@/lib/format";
 import { Icon } from "@/components/folio/icons";
@@ -173,8 +173,10 @@ export async function ArticleView({
         : undefined,
   });
 
-  const lineageSources = parseSources(
-    page.frontmatter.sources as string | string[] | undefined,
+  // Dedup by URL for display so a page whose sources predate the write-time
+  // URL dedup (or were recorded under two types) never shows the same link twice.
+  const lineageSources = dedupeSourcesForDisplay(
+    parseSources(page.frontmatter.sources as string | string[] | undefined),
   );
 
   const toc = buildToc(page.body);

--- a/src/lib/__tests__/sources.test.ts
+++ b/src/lib/__tests__/sources.test.ts
@@ -4,8 +4,44 @@ import {
   parseSources,
   buildSourceEntry,
   newestSourceType,
+  dedupeSourcesForDisplay,
 } from "../sources";
 import type { SourceEntry } from "../types";
+
+describe("dedupeSourcesForDisplay", () => {
+  const mk = (
+    url: string,
+    type: SourceEntry["type"],
+    fetched = "2026-01-01",
+  ): SourceEntry => ({ type, url, fetched, triggered_by: "system" });
+
+  it("collapses the same URL even when the type differs, keeping the first", () => {
+    const out = dedupeSourcesForDisplay([
+      mk("https://arxiv.org/pdf/1.pdf", "pdf", "2026-06-07"),
+      mk("https://arxiv.org/pdf/1.pdf", "url", "2026-06-08"),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ url: "https://arxiv.org/pdf/1.pdf", type: "pdf" });
+  });
+
+  it("keeps distinct URLs", () => {
+    const out = dedupeSourcesForDisplay([
+      mk("https://a.com", "url"),
+      mk("https://b.com", "url"),
+    ]);
+    expect(out.map((s) => s.url)).toEqual(["https://a.com", "https://b.com"]);
+  });
+
+  it("keeps text-paste placeholders distinct per type", () => {
+    const out = dedupeSourcesForDisplay([
+      mk("text-paste", "text"),
+      mk("text-paste", "x-mention"),
+      mk("text-paste", "text"), // dup of the first → dropped
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out.map((s) => s.type)).toEqual(["text", "x-mention"]);
+  });
+});
 
 describe("newestSourceType", () => {
   const mk = (type: SourceEntry["type"], fetched: string): SourceEntry => ({

--- a/src/lib/__tests__/sources.test.ts
+++ b/src/lib/__tests__/sources.test.ts
@@ -41,6 +41,23 @@ describe("dedupeSourcesForDisplay", () => {
     expect(out).toHaveLength(2);
     expect(out.map((s) => s.type)).toEqual(["text", "x-mention"]);
   });
+
+  it("keeps distinct uploads separate by snapshot id (same 'upload' sentinel URL)", () => {
+    const withRaw = (rawId: string): SourceEntry => ({
+      type: "image",
+      url: "upload",
+      fetched: "2026-01-01",
+      triggered_by: "system",
+      raw_id: rawId,
+    });
+    const out = dedupeSourcesForDisplay([
+      withRaw("hashA"),
+      withRaw("hashB"),
+      withRaw("hashA"), // dup → dropped
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out.map((s) => s.raw_id)).toEqual(["hashA", "hashB"]);
+  });
 });
 
 describe("newestSourceType", () => {

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -68,6 +68,25 @@ export function parseSources(raw: string | string[] | undefined): SourceEntry[] 
 }
 
 /**
+ * Collapse duplicate sources for DISPLAY — a real source is the same source if
+ * it shares a URL (even if a past ingest recorded it under a different type),
+ * keeping the first occurrence. `text-paste` placeholders carry no real URL, so
+ * they stay distinct per type. Display-only: never use this where the full
+ * `sources[]` is needed (the ingest merge dedups at write time on its own).
+ */
+export function dedupeSourcesForDisplay(sources: SourceEntry[]): SourceEntry[] {
+  const seen = new Set<string>();
+  const out: SourceEntry[] = [];
+  for (const s of sources) {
+    const key = s.url === "text-paste" ? `text-paste:${s.type}` : s.url;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(s);
+  }
+  return out;
+}
+
+/**
  * Build a fresh {@link SourceEntry} with sensible defaults.
  *
  * @param url        - Source URL or `"text-paste"` for pasted content.

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -68,17 +68,21 @@ export function parseSources(raw: string | string[] | undefined): SourceEntry[] 
 }
 
 /**
- * Collapse duplicate sources for DISPLAY — a real source is the same source if
- * it shares a URL (even if a past ingest recorded it under a different type),
- * keeping the first occurrence. `text-paste` placeholders carry no real URL, so
- * they stay distinct per type. Display-only: never use this where the full
- * `sources[]` is needed (the ingest merge dedups at write time on its own).
+ * Collapse duplicate sources for DISPLAY — a real (http/https) source is the
+ * same source if it shares a URL, even if a past ingest recorded it under a
+ * different type; the first occurrence wins. Sentinel "URLs" (`text-paste`,
+ * `upload`) carry no real address, so they're distinguished by their snapshot
+ * id (falling back to type) — distinct pastes/uploads stay separate.
+ *
+ * Display-only: never use this where the full `sources[]` is needed (the ingest
+ * merge dedups at write time on its own).
  */
 export function dedupeSourcesForDisplay(sources: SourceEntry[]): SourceEntry[] {
   const seen = new Set<string>();
   const out: SourceEntry[] = [];
   for (const s of sources) {
-    const key = s.url === "text-paste" ? `text-paste:${s.type}` : s.url;
+    const isHttp = /^https?:\/\//i.test(s.url);
+    const key = isHttp ? s.url : `${s.url}:${s.raw_id ?? s.type}`;
     if (seen.has(key)) continue;
     seen.add(key);
     out.push(s);


### PR DESCRIPTION
## Why
The SOURCES panel on a wiki page could list the same URL twice — e.g. `skillopt` showed the same arXiv link as two entries (`pdf` fetched 06-07, `url` fetched 06-08). PR #455 fixed the write-time dedup (`mergeSourceEntry` by URL), but pages ingested **before** that fix still carry duplicate entries in frontmatter.

## What
`dedupeSourcesForDisplay(sources)` (new, in `src/lib/sources.ts`) collapses entries that share a URL — keeping the first — and `ArticleView` runs the parsed sources through it before rendering. So no page ever shows a duplicate source link, regardless of what's stored. `text-paste` placeholders (no real URL) stay distinct per type.

This is **display-only**: `parseSources` is unchanged, so the ingest merge still operates on the full `sources[]`.

## Tests
- `dedupeSourcesForDisplay`: collapses same-URL-different-type (keeps first/more-specific), keeps distinct URLs, keeps text-paste distinct per type.
- Full suite: **2714 passed**; `pnpm build` clean.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)