### PR TITLE
Add an admin role (ADMIN_HANDLES) with full page management

### DIFF
--- a/src/lib/__tests__/authz.test.ts
+++ b/src/lib/__tests__/authz.test.ts
@@ -157,6 +157,16 @@ describe("admin role (ADMIN_HANDLES)", () => {
     expect(isAdmin(bob)).toBe(false);
     expect(isAdmin(null)).toBe(false);
     expect(isAdmin({ handle: "" })).toBe(false);
+    process.env.ADMIN_HANDLES = "   ";
+    expect(isAdmin({ handle: "alice" })).toBe(false); // whitespace-only → no admins
+  });
+
+  it("isAdmin matches a Clerk user id exactly (spoof-proof) regardless of handle", () => {
+    process.env.ADMIN_HANDLES = "user_2abc";
+    expect(isAdmin({ id: "user_2abc", handle: "anything" })).toBe(true);
+    // A different user who set their handle to the id string is NOT admin
+    // (id is matched exactly against principal.id, not the handle).
+    expect(isAdmin({ id: "user_evil", handle: "user_2abc" })).toBe(false);
   });
 
   it("an admin reads and writes any page, including others' private pages", () => {

--- a/src/lib/__tests__/authz.test.ts
+++ b/src/lib/__tests__/authz.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
   canReadPage,
   canReadEntry,
@@ -6,6 +6,7 @@ import {
   canSetPrivate,
   canWritePage,
   canWriteFrontmatter,
+  isAdmin,
 } from "../authz";
 import { agentOwnerHandle } from "../agents";
 import type { IndexEntry } from "../types";
@@ -136,6 +137,43 @@ describe("canWritePage", () => {
 
   it("fails closed on a private page with no owner", () => {
     expect(canWritePage({ visibility: "private" }, aliceP)).toBe(false);
+  });
+});
+
+describe("admin role (ADMIN_HANDLES)", () => {
+  const saved = process.env.ADMIN_HANDLES;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.ADMIN_HANDLES;
+    else process.env.ADMIN_HANDLES = saved;
+  });
+
+  it("isAdmin matches ADMIN_HANDLES case-insensitively; unset/empty/anon → false", () => {
+    delete process.env.ADMIN_HANDLES;
+    expect(isAdmin(aliceP)).toBe(false); // no admins configured
+
+    process.env.ADMIN_HANDLES = "yuanhao, Alice";
+    expect(isAdmin({ handle: "alice" })).toBe(true); // case-insensitive
+    expect(isAdmin({ handle: "yuanhao" })).toBe(true);
+    expect(isAdmin(bob)).toBe(false);
+    expect(isAdmin(null)).toBe(false);
+    expect(isAdmin({ handle: "" })).toBe(false);
+  });
+
+  it("an admin reads and writes any page, including others' private pages", () => {
+    process.env.ADMIN_HANDLES = "alice";
+    const bobsPrivate = { owner: "bob", visibility: "private" };
+    expect(canReadPage(bobsPrivate, aliceP)).toBe(true);
+    expect(canWritePage(bobsPrivate, aliceP)).toBe(true);
+    // A non-admin, non-owner is still denied.
+    const carol = { id: "user_carol", handle: "carol" };
+    expect(canReadPage(bobsPrivate, carol)).toBe(false);
+    expect(canWritePage(bobsPrivate, carol)).toBe(false);
+  });
+
+  it("grants nothing extra when ADMIN_HANDLES is unset", () => {
+    delete process.env.ADMIN_HANDLES;
+    expect(canWritePage({ owner: "bob", visibility: "private" }, aliceP)).toBe(false);
+    expect(canReadPage({ owner: "bob", visibility: "private" }, aliceP)).toBe(false);
   });
 });
 

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -26,6 +26,25 @@ export interface PageReadMeta {
 type Reader = { handle: string } | null;
 
 /**
+ * Admins — the comma-separated handles in `ADMIN_HANDLES` (case-insensitive) —
+ * may READ, WRITE, and DELETE every page, including other users' private pages.
+ * Unset/empty → no admins; a null or handleless principal is never an admin.
+ *
+ * Set it as a Worker var: `ADMIN_HANDLES=yuanhao` (or `a,b,c`).
+ */
+export function isAdmin(principal: { handle?: string } | null | undefined): boolean {
+  const handle = principal?.handle?.trim().toLowerCase();
+  if (!handle) return false;
+  const raw = process.env.ADMIN_HANDLES;
+  if (!raw) return false;
+  return raw
+    .split(",")
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean)
+    .includes(handle);
+}
+
+/**
  * True iff `principal` may read a page with the given metadata. Fail-closed:
  * only an explicit `visibility: "private"` ever denies; anything else is public.
  */
@@ -35,6 +54,8 @@ export function canReadPage(meta: PageReadMeta, principal: Reader): boolean {
 
   // Private — requires an authenticated owner.
   if (!principal) return false;
+  // Admins read every page, including others' private pages.
+  if (isAdmin(principal)) return true;
   const owner = meta.owner;
   if (!owner) return false; // private but unowned — fail closed
 
@@ -121,6 +142,8 @@ export function canWritePage(
 ): boolean {
   // Deployment-trusted automated caller — writes for owners (agents, cron).
   if (principal?.id.startsWith("service:")) return true;
+  // Admins may write/delete/manage every page (incl. others' private pages).
+  if (isAdmin(principal)) return true;
   // Public / collective commons — editable by any caller the write-gate admits.
   if (meta.visibility !== "private") return true;
   // Private — exactly the owner-equivalence class that may READ it (requires an

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -22,26 +22,47 @@ export interface PageReadMeta {
   type?: string;
 }
 
-/** A reader identity (only the handle matters for authorization). */
-type Reader = { handle: string } | null;
+/** A reader identity (id is used for the spoof-proof admin match). */
+type Reader = { id?: string; handle: string } | null;
 
 /**
- * Admins — the comma-separated handles in `ADMIN_HANDLES` (case-insensitive) —
- * may READ, WRITE, and DELETE every page, including other users' private pages.
- * Unset/empty → no admins; a null or handleless principal is never an admin.
+ * Admins — listed in the comma-separated `ADMIN_HANDLES` Worker var — may READ,
+ * WRITE, and DELETE every **page**, including other users' private pages. Unset/
+ * empty → no admins; a null/handleless principal is never an admin.
  *
- * Set it as a Worker var: `ADMIN_HANDLES=yuanhao` (or `a,b,c`).
+ * Each entry matches EITHER:
+ *  - a **Clerk user id** (`user_…`), compared exactly — spoof-proof, use this if
+ *    your Clerk instance lets users edit their username; or
+ *  - a **handle** (Twitter/X username), compared case-insensitively — convenient,
+ *    but only as trustworthy as the handle: it assumes a non-admin cannot set
+ *    their Clerk username to an admin's handle (true when usernames come from
+ *    Twitter SSO and aren't user-editable).
+ *
+ * Scope is pages only — it does NOT grant managing others' agents, vaults, or
+ * discussion moderation (those keep their own owner checks).
+ *
+ * Examples: `ADMIN_HANDLES=yuanhao` or `ADMIN_HANDLES=user_2abc...,alice`.
  */
-export function isAdmin(principal: { handle?: string } | null | undefined): boolean {
-  const handle = principal?.handle?.trim().toLowerCase();
-  if (!handle) return false;
+export function isAdmin(
+  principal: { id?: string; handle?: string } | null | undefined,
+): boolean {
   const raw = process.env.ADMIN_HANDLES;
   if (!raw) return false;
-  return raw
+  const admins = raw
     .split(",")
-    .map((h) => h.trim().toLowerCase())
-    .filter(Boolean)
-    .includes(handle);
+    .map((h) => h.trim())
+    .filter(Boolean);
+  if (admins.length === 0) return false;
+
+  // `user_…` entries are Clerk ids — matched ONLY against principal.id (exact),
+  // never as a handle, so setting a handle to the id string can't grant admin.
+  const ids = admins.filter((a) => a.startsWith("user_"));
+  if (principal?.id && ids.includes(principal.id)) return true;
+
+  // Everything else is a handle — case-insensitive match.
+  const handle = principal?.handle?.trim().toLowerCase();
+  if (!handle) return false;
+  return admins.some((a) => !a.startsWith("user_") && a.toLowerCase() === handle);
 }
 
 /**


### PR DESCRIPTION
## Why
There was no way for a designated user to manage all pages (e.g. delete another user's page, or a stray page) without the service token. This adds an admin role so `yuanhao` can read/write/delete/re-ingest any page from the normal UI/API.

## What
- New `isAdmin(principal)` in `src/lib/authz.ts` — matches the comma-separated **`ADMIN_HANDLES`** env (case-insensitive). Unset/empty → no admins (no behavior change). A null/handleless principal is never an admin.
- `canReadPage` and `canWritePage` grant admins full access — including other users' **private** pages — so every read/edit/delete/re-ingest surface (which already route through `canRead*`/`canWrite*`) honors it automatically. Placed alongside the existing service-principal bypass.

## Config
Set a Worker var: `ADMIN_HANDLES=yuanhao` (or `a,b,c`). The handle is the Twitter/X handle (same value used for `owner`/attribution).

## Tests
- `isAdmin`: case-insensitive match, unset/empty/anonymous → false.
- An admin reads + writes another user's private page; a non-admin non-owner is still denied; unset `ADMIN_HANDLES` grants nothing extra.
- Full suite: **2714 passed**; `pnpm build` clean.

## Security notes
- Admin only widens access for an **authenticated** principal whose handle is in the env list — it never affects anonymous callers, and the write-gate middleware still requires a session for any mutation.
- Scope is read/write/delete. It does NOT change `canSetPrivate` (creating private pages still needs the paid plan) — out of scope; say the word if admins should bypass that too.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)