### PR TITLE
Real confidence heuristic + fix date-only 'updated' + clearer freshness

### DIFF
--- a/src/components/folio/primitives.tsx
+++ b/src/components/folio/primitives.tsx
@@ -59,7 +59,11 @@ export function Freshness({ expiry }: { expiry: string }) {
   const days = Math.round((new Date(expiry).getTime() - Date.now()) / 864e5);
   const cls = days < 0 ? "cold" : days < 30 ? "warn" : "ok";
   const txt =
-    days < 0 ? "expired" : days < 30 ? `review in ${days}d` : `fresh · ${expiry}`;
+    days < 0
+      ? "expired"
+      : days < 30
+        ? `review in ${days}d`
+        : `fresh · review by ${expiry}`;
   return (
     <span
       className="row receipt"

--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -54,6 +54,15 @@ describe("formatRelativeTime", () => {
     expect(formatRelativeTime(iso)).toBe("1y ago");
   });
 
+  it("renders a date-only (YYYY-MM-DD) value at day granularity, not bogus hours", () => {
+    // 09:00 UTC on 2026-06-08 — a same-day date must read "today", never "9h ago".
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-06-08T09:00:00Z"));
+    expect(formatRelativeTime("2026-06-08")).toBe("today");
+    expect(formatRelativeTime("2026-06-07")).toBe("yesterday");
+    expect(formatRelativeTime("2026-06-05")).toBe("3d ago");
+    expect(formatRelativeTime("2026-05-25")).toBe("2w ago");
+  });
+
   it("returns YYYY-MM-DD slice for unparseable input", () => {
     expect(formatRelativeTime("not-a-date")).toBe("not-a-date");
   });

--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -61,6 +61,8 @@ describe("formatRelativeTime", () => {
     expect(formatRelativeTime("2026-06-07")).toBe("yesterday");
     expect(formatRelativeTime("2026-06-05")).toBe("3d ago");
     expect(formatRelativeTime("2026-05-25")).toBe("2w ago");
+    expect(formatRelativeTime("2026-03-01")).toBe("3mo ago"); // 99 days
+    expect(formatRelativeTime("2025-01-01")).toBe("1y ago"); // 523 days
   });
 
   it("returns YYYY-MM-DD slice for unparseable input", () => {

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -771,6 +771,28 @@ describe("ingest — structured sources[] provenance", () => {
     expect(sources).toHaveLength(2);
     expect(sources[0].url).toBe("https://example.com/a");
     expect(sources[1].url).toBe("https://example.com/b");
+    // Corroboration: a 2nd distinct source URL raises confidence (0.7 → 0.75).
+    expect(page!.frontmatter.confidence).toBe(0.75);
+  });
+
+  it("preview confidence matches what the commit writes (corroborating re-ingest)", async () => {
+    // Existing page with one URL source.
+    await ingest("Preview Conf", "First content. Details.", {
+      sourceUrl: "https://example.com/a",
+    });
+
+    // Preview a re-ingest that adds a 2nd distinct URL.
+    const preview = await ingest("Preview Conf", "Second content. More.", {
+      sourceUrl: "https://example.com/b",
+      preview: true,
+    });
+    // Commit the same re-ingest (no preview) and assert the page matches the card.
+    await ingest("Preview Conf", "Second content. More.", {
+      sourceUrl: "https://example.com/b",
+    });
+    const page = await readWikiPageWithFrontmatter("preview-conf");
+    expect(preview.preview!.confidence).toBe(0.75);
+    expect(page!.frontmatter.confidence).toBe(preview.preview!.confidence);
   });
 
   it("re-ingest with same URL updates fetched date instead of duplicating", async () => {
@@ -2201,6 +2223,9 @@ describe("ingest — reconcile on merge", () => {
 
     const page = await readWikiPageWithFrontmatter("topic");
     expect(page!.frontmatter.disputed).toBe(true);
+    // A reconcile-escalated dispute caps confidence at 0.5 (computed after the
+    // reconcile sets the flag).
+    expect(page!.frontmatter.confidence).toBe(0.5);
     expect(page!.content).toContain("Existing says X; the new source says Y.");
     // The DISPUTED marker is stripped from the stored body.
     expect(page!.content).not.toContain("DISPUTED:");

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -13,6 +13,7 @@ import {
   parseDisputedMarker,
   normalizeTags,
   collectTagVocabulary,
+  computeConfidence,
   tokenizeSourceImages,
   restoreImageTokens,
 } from "../ingest";
@@ -40,7 +41,7 @@ import {
 import { resetSourceIndex } from "../source-index";
 import { resetAliasIndex } from "../alias-index";
 import { hasEmbeddingSupport, searchByVector, contentHash } from "../embeddings";
-import type { IndexEntry } from "../types";
+import type { IndexEntry, SourceEntry } from "../types";
 
 const mockedHasEmbeddingSupport = vi.mocked(hasEmbeddingSupport);
 const mockedSearchByVector = vi.mocked(searchByVector);
@@ -469,7 +470,8 @@ describe("ingest — Phase 1 frontmatter fields", () => {
     const page = await readWikiPageWithFrontmatter("phase1-new");
     expect(page).not.toBeNull();
 
-    expect(page!.frontmatter.confidence).toBe(0.7);
+    // Heuristic: a single text source → 0.55 (no longer a constant 0.7).
+    expect(page!.frontmatter.confidence).toBe(0.55);
     expect(page!.frontmatter.disputed).toBe(false);
     expect(page!.frontmatter.authors).toEqual(["system"]);
     expect(page!.frontmatter.contributors).toEqual([]);
@@ -521,8 +523,10 @@ describe("ingest — Phase 1 frontmatter fields", () => {
     expect(page!.frontmatter.supersedes).toBe("old-page");
     // aliases preserved
     expect(page!.frontmatter.aliases).toEqual(["p1r", "phase-one"]);
-    // confidence preserved because existing (0.9) > 0.7
-    expect(page!.frontmatter.confidence).toBe(0.9);
+    // confidence is recomputed from signals (not preserved). The manually
+    // written page had no sources[], so the re-ingest's single text source +
+    // the preserved disputed=true flag caps it at 0.5.
+    expect(page!.frontmatter.confidence).toBe(0.5);
 
     // expiry reset to ~90 days from now (not the old 2024-09-01)
     const expiry = page!.frontmatter.expiry as string;
@@ -559,10 +563,10 @@ describe("ingest — Phase 1 frontmatter fields", () => {
     expect(page!.frontmatter.contributors).toEqual(["system", "editor"]);
   });
 
-  it("re-ingest keeps lower confidence at 0.7 when existing is lower", async () => {
+  it("re-ingest recomputes confidence from signals (ignores a manually-set value)", async () => {
     await ingest("Phase1 LowConf", "Content for confidence test. Details here.");
 
-    // Manually set confidence to 0.5 (below default)
+    // Manually set confidence to 0.5; the re-ingest should recompute, not keep it.
     await writeWikiPage(
       "phase1-lowconf",
       `---\ncreated: 2024-06-01\nupdated: 2024-06-01\nsource_count: 1\ntags: []\nconfidence: 0.5\nexpiry: 2024-09-01\nauthors: [system]\ncontributors: []\ndisputed: false\nsupersedes:\naliases: []\n---\n\n# Phase1 LowConf\n\nBody.\n`,
@@ -574,8 +578,8 @@ describe("ingest — Phase 1 frontmatter fields", () => {
     const page = await readWikiPageWithFrontmatter("phase1-lowconf");
     expect(page).not.toBeNull();
 
-    // confidence stays at 0.7 (default) since existing 0.5 is not higher
-    expect(page!.frontmatter.confidence).toBe(0.7);
+    // Recomputed from the single text source (0.55) — not the manual 0.5.
+    expect(page!.frontmatter.confidence).toBe(0.55);
   });
 });
 
@@ -1825,6 +1829,48 @@ describe("parseConceptMarker", () => {
   it("returns no tags when the TAGS line is absent or 'none'", () => {
     expect(parseConceptMarker("CONCEPT: X\n\n# X\n").tags).toEqual([]);
     expect(parseConceptMarker("CONCEPT: X\nTAGS: none\n\n# X\n").tags).toEqual([]);
+  });
+});
+
+describe("computeConfidence", () => {
+  const src = (type: SourceEntry["type"], url: string): SourceEntry => ({
+    type,
+    url,
+    fetched: "2026-01-01",
+    triggered_by: "system",
+  });
+
+  it("scores by the strongest source type present", () => {
+    expect(computeConfidence([src("text", "text-paste")], false)).toBe(0.55);
+    expect(computeConfidence([src("url", "https://a.com")], false)).toBe(0.7);
+    expect(computeConfidence([src("pdf", "https://a.com/p.pdf")], false)).toBe(0.75);
+    // strongest type wins (same URL → no corroboration bonus)
+    expect(
+      computeConfidence([src("text", "https://a.com"), src("pdf", "https://a.com")], false),
+    ).toBe(0.75);
+  });
+
+  it("adds corroboration for additional distinct source URLs (capped)", () => {
+    expect(
+      computeConfidence([src("url", "https://a.com"), src("url", "https://b.com")], false),
+    ).toBe(0.75); // 0.7 + 0.05
+    expect(
+      computeConfidence(
+        [
+          src("url", "https://a.com"),
+          src("url", "https://b.com"),
+          src("url", "https://c.com"),
+          src("url", "https://d.com"),
+          src("url", "https://e.com"),
+        ],
+        false,
+      ),
+    ).toBe(0.85); // 0.7 + capped 0.15
+  });
+
+  it("caps a disputed page at 0.5 and falls back to 0.6 for no sources", () => {
+    expect(computeConfidence([src("pdf", "https://a.com/p.pdf")], true)).toBe(0.5);
+    expect(computeConfidence([], false)).toBe(0.6);
   });
 });
 

--- a/src/lib/__tests__/x-mention-integration.test.ts
+++ b/src/lib/__tests__/x-mention-integration.test.ts
@@ -172,8 +172,8 @@ describe("X-mention integration", () => {
 
     // Authors defaults to ["system"] on new pages
     expect(page!.frontmatter.authors).toEqual(["system"]);
-    // Confidence defaults to 0.7
-    expect(page!.frontmatter.confidence).toBe(0.7);
+    // Heuristic confidence for a single x-mention source → 0.55
+    expect(page!.frontmatter.confidence).toBe(0.55);
   });
 
   it("handles fetch failure (404) gracefully", async () => {

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -32,6 +32,26 @@ export function formatRelativeTime(iso: string): string {
   const then = Date.parse(iso);
   if (!Number.isFinite(then)) return iso.slice(0, 10);
 
+  // A date-only value (`YYYY-MM-DD`) has no time component — it parses to UTC
+  // midnight, so an hour/minute relative time would be a bogus artifact of the
+  // date boundary (e.g. "9h ago" for a page ingested today). Render at DAY
+  // granularity instead, by calendar day in UTC.
+  if (/^\d{4}-\d{2}-\d{2}$/.test(iso.trim())) {
+    const startOfDay = (ms: number) => {
+      const d = new Date(ms);
+      return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+    };
+    const days = Math.floor((startOfDay(Date.now()) - startOfDay(then)) / 864e5);
+    if (days <= 0) return "today";
+    if (days === 1) return "yesterday";
+    if (days < 7) return `${days}d ago`;
+    const weeks = Math.floor(days / 7);
+    if (weeks < 5) return `${weeks}w ago`;
+    const months = Math.floor(days / 30);
+    if (months < 12) return `${months}mo ago`;
+    return `${Math.floor(days / 365)}y ago`;
+  }
+
   const diffMs = Date.now() - then;
   if (diffMs < 0) return "just now";
 

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -54,6 +54,43 @@ function mergeSourceEntry(sources: SourceEntry[], entry: SourceEntry): SourceEnt
   }
   return base;
 }
+
+/**
+ * Authority baseline per source type for the confidence heuristic — higher for
+ * documents/articles, lower for social/unverified provenance.
+ */
+const SOURCE_TYPE_WEIGHT: Record<SourceEntry["type"], number> = {
+  pdf: 0.75,
+  "wiki-ref": 0.72,
+  url: 0.7,
+  youtube: 0.62,
+  image: 0.55,
+  text: 0.55,
+  "x-mention": 0.55,
+};
+
+/**
+ * Heuristic page confidence from real provenance signals — replaces the old
+ * constant 0.7:
+ *  - authority of the STRONGEST source type present,
+ *  - corroboration: +0.05 per additional DISTINCT source URL (cap +0.15),
+ *  - a `disputed` page is capped at 0.5.
+ * Clamped to [0.3, 0.95], rounded to 2 decimals. An empty source set → 0.6.
+ */
+export function computeConfidence(
+  sources: SourceEntry[],
+  disputed: boolean,
+): number {
+  if (sources.length === 0) return 0.6;
+  const base = Math.max(
+    ...sources.map((s) => SOURCE_TYPE_WEIGHT[s.type] ?? 0.6),
+  );
+  const distinctUrls = new Set(sources.map((s) => s.url)).size;
+  const corroboration = Math.min(0.15, Math.max(0, distinctUrls - 1) * 0.05);
+  let score = base + corroboration;
+  if (disputed) score = Math.min(score, 0.5);
+  return Math.round(Math.min(0.95, Math.max(0.3, score)) * 100) / 100;
+}
 import {
   MAX_LLM_INPUT_CHARS,
   INGEST_MAX_OUTPUT_TOKENS,
@@ -1441,22 +1478,38 @@ export async function ingest(
 
     // Mirror exactly what the commit path below would write so the review card
     // never promises a value publish won't honor. Review-by always resets to
-    // now + 90 days (a re-ingest refreshes the page). Confidence defaults to 0.7
-    // and is only preserved on a merge when the existing page was set HIGHER
-    // (the > 0.7 rule at the re-ingest frontmatter merge below).
+    // now + 90 days (a re-ingest refreshes the page). Confidence is computed
+    // from the prospective source set with the same heuristic as the commit.
     const reviewExpiry = new Date();
     reviewExpiry.setDate(reviewExpiry.getDate() + 90);
     const reviewBy = reviewExpiry.toISOString().slice(0, 10);
-    let confidence = 0.7;
+    const previewSourceType =
+      options?.sourceType ?? (options?.sourceUrl ? "url" : "text");
+    const previewEntry = buildSourceEntry(
+      options?.sourceUrl ?? "text-paste",
+      previewSourceType,
+      options?.triggeredBy,
+    );
+    let previewSources: SourceEntry[] = [previewEntry];
+    let previewDisputed = false;
     if (existingEntry) {
       const ex = await readWikiPageWithFrontmatter(existingEntry.slug);
-      if (
-        typeof ex?.frontmatter.confidence === "number" &&
-        ex.frontmatter.confidence > 0.7
-      ) {
-        confidence = ex.frontmatter.confidence;
+      if (ex) {
+        const exSources = ex.frontmatter.sources;
+        previewSources = mergeSourceEntry(
+          parseSources(
+            typeof exSources === "string"
+              ? exSources
+              : Array.isArray(exSources)
+                ? exSources
+                : undefined,
+          ),
+          previewEntry,
+        );
+        previewDisputed = ex.frontmatter.disputed === true;
       }
     }
+    const confidence = computeConfidence(previewSources, previewDisputed);
 
     // Synthesized tags + any existing/caller tags. The reviewer sees these in
     // the card and (via the commit-from-preview path) they're sent back as
@@ -1647,11 +1700,8 @@ export async function ingest(
     // Expiry resets to 90 days from now (re-ingest refreshes the page).
     // valid_from also resets to now (the page's information is re-verified).
     // (both already set above — no need to change)
-    // Preserve confidence if existing was higher (manually set).
-    const existingConf = existing.frontmatter.confidence;
-    if (typeof existingConf === "number" && existingConf > 0.7) {
-      frontmatter.confidence = existingConf;
-    }
+    // Confidence is recomputed from signals below (not preserved), so adding a
+    // corroborating source raises it on re-ingest.
   }
 
   // Re-synthesize on merge (accumulate-and-reconcile): when this ingest lands on
@@ -1701,6 +1751,15 @@ export async function ingest(
     }
     frontmatter.aliases = aliasList;
   }
+
+  // Confidence from provenance signals — computed last, when sources[] and the
+  // disputed flag are final (after the re-ingest merge and reconcile).
+  frontmatter.confidence = computeConfidence(
+    parseSources(
+      typeof frontmatter.sources === "string" ? frontmatter.sources : undefined,
+    ),
+    frontmatter.disputed === true,
+  );
 
   const contentWithFm = serializeFrontmatter(frontmatter, wikiContent);
 

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -1476,10 +1476,13 @@ export async function ingest(
       ? existingEntries.find((e) => e.slug === dupSlug)
       : undefined;
 
-    // Mirror exactly what the commit path below would write so the review card
-    // never promises a value publish won't honor. Review-by always resets to
-    // now + 90 days (a re-ingest refreshes the page). Confidence is computed
-    // from the prospective source set with the same heuristic as the commit.
+    // Mirror the commit path's metadata as far as is knowable pre-synthesis, so
+    // the review card matches publish for the common case. Review-by always
+    // resets to now + 90 days. Confidence uses the SAME heuristic over the
+    // prospective source set and the EXISTING disputed flag — it can still
+    // diverge only if the reconcile step newly escalates the page to `disputed`
+    // (which caps the committed value at 0.5); the preview can't anticipate that
+    // LLM outcome.
     const reviewExpiry = new Date();
     reviewExpiry.setDate(reviewExpiry.getDate() + 90);
     const reviewBy = reviewExpiry.toISOString().slice(0, 10);
@@ -1492,22 +1495,24 @@ export async function ingest(
     );
     let previewSources: SourceEntry[] = [previewEntry];
     let previewDisputed = false;
-    if (existingEntry) {
-      const ex = await readWikiPageWithFrontmatter(existingEntry.slug);
-      if (ex) {
-        const exSources = ex.frontmatter.sources;
-        previewSources = mergeSourceEntry(
-          parseSources(
-            typeof exSources === "string"
+    // Read the existing page by the RESOLVED slug — the same way the commit path
+    // finds what it merges into. (The dedup `existingEntry` only resolves on a
+    // URL/content/concept hit, so a same-slug re-ingest with a new URL would
+    // otherwise miss the existing sources and under-report confidence.)
+    const ex = await readWikiPageWithFrontmatter(slug);
+    if (ex) {
+      const exSources = ex.frontmatter.sources;
+      previewSources = mergeSourceEntry(
+        parseSources(
+          typeof exSources === "string"
+            ? exSources
+            : Array.isArray(exSources)
               ? exSources
-              : Array.isArray(exSources)
-                ? exSources
-                : undefined,
-          ),
-          previewEntry,
-        );
-        previewDisputed = ex.frontmatter.disputed === true;
-      }
+              : undefined,
+        ),
+        previewEntry,
+      );
+      previewDisputed = ex.frontmatter.disputed === true;
     }
     const confidence = computeConfidence(previewSources, previewDisputed);
 
@@ -1754,12 +1759,23 @@ export async function ingest(
 
   // Confidence from provenance signals — computed last, when sources[] and the
   // disputed flag are final (after the re-ingest merge and reconcile).
-  frontmatter.confidence = computeConfidence(
-    parseSources(
-      typeof frontmatter.sources === "string" ? frontmatter.sources : undefined,
-    ),
-    frontmatter.disputed === true,
+  const finalSources = parseSources(
+    typeof frontmatter.sources === "string" ? frontmatter.sources : undefined,
   );
+  // Defensive: sources[] was just serialized from ≥1 entry, so an empty parse
+  // means a serialize/parse round-trip lost it — confidence would silently fall
+  // to the 0.6 default. Surface it rather than flatlining invisibly.
+  if (
+    finalSources.length === 0 &&
+    typeof frontmatter.sources === "string" &&
+    frontmatter.sources !== "[]"
+  ) {
+    logger.warn(
+      "ingest",
+      `sources[] failed to round-trip for "${slug}"; confidence falls back to the default`,
+    );
+  }
+  frontmatter.confidence = computeConfidence(finalSources, frontmatter.disputed === true);
 
   const contentWithFm = serializeFrontmatter(frontmatter, wikiContent);
 


### PR DESCRIPTION
## Why
The page header's CONFIDENCE / FRESHNESS / UPDATED all looked off:
- **Confidence was always 0.70** — a hardcoded constant; the synthesis never assessed it.
- **"Updated 9h ago"** appeared on a page ingested *just now* — `updated` is a date (`YYYY-MM-DD`), and `formatRelativeTime` anchored it to UTC midnight, inventing an hour count.
- **"fresh · 2026-09-06"** showed a bare future date (the +90-day review-by), easily mistaken for the page's date.

## Fixes
1. **Confidence heuristic** (`computeConfidence`, `ingest.ts`): derived from real signals — authority of the strongest source type (`pdf`/`url`/`wiki-ref` > `youtube` > `image`/`text`/`x-mention`), **+0.05 per additional distinct source URL** (cap +0.15), **disputed → capped at 0.5**; clamped to `[0.3, 0.95]`. Used identically on the **preview card** and **commit**, and **recomputed on re-ingest** so adding a corroborating source raises it. Removed the old "preserve if > 0.7" manual-override path.
2. **Date-only relative time** (`format.ts`): a `YYYY-MM-DD` value now renders at **day granularity** ("today" / "yesterday" / "Nd ago" / "Nw ago" …) instead of a bogus hour count. Full ISO timestamps (e.g. discussion threads) keep precise "Nm/Nh ago".
3. **Freshness label** (`primitives.tsx`): `fresh · review by <date>` instead of `fresh · <date>`.

## Tests
- `computeConfidence`: strongest-type scoring, distinct-URL corroboration (capped), disputed cap, empty-source fallback.
- `formatRelativeTime`: a date-only value reads "today"/"yesterday"/"Nd ago" (no fake hours); timestamps unchanged.
- Updated the Phase-1 / x-mention frontmatter tests to the heuristic values; repurposed the obsolete "preserve lower confidence" test to assert recompute.
- Full suite: **2723 passed**; `pnpm build` clean.

## Note
Existing pages keep their stored 0.70 until re-ingested (the heuristic runs at ingest time). Re-ingesting recomputes it.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)