### PR TITLE
Support long-form X Articles in on-demand ingest

### DIFF
--- a/src/lib/__tests__/x-post.test.ts
+++ b/src/lib/__tests__/x-post.test.ts
@@ -275,4 +275,52 @@ describe("fetchXPostContent — X Articles", () => {
     await fetchXPostContent("https://x.com/ada/status/123");
     expect(calls.some((u) => u.includes("api.twitter.com"))).toBe(false);
   });
+
+  it("omits the byline for an /i/web/status/ article URL (no @handle)", async () => {
+    process.env.X_BEARER_TOKEN = "test-bearer";
+    mockApi({
+      apiBody: { data: { article: { title: "Anon Essay", text: "Body." } } },
+      synBody: {},
+    });
+    const { content } = await fetchXPostContent("https://x.com/i/web/status/123");
+    expect(content).toContain("# Anon Essay");
+    expect(content).toContain("Body.");
+    expect(content).not.toContain("· X Article"); // no byline line for /i/
+  });
+
+  it("renders an article with no image line when there's no cover", async () => {
+    process.env.X_BEARER_TOKEN = "test-bearer";
+    mockApi({
+      apiBody: { data: { article: { title: "No Cover", text: "Just text." } } },
+      synBody: {}, // no article.cover_media
+    });
+    const { content } = await fetchXPostContent("https://x.com/ada/status/9");
+    expect(content).toContain("# No Cover");
+    expect(content).toContain("Just text.");
+    expect(content).not.toContain("!["); // no image markdown
+  });
+
+  it("renders a title-only article (empty body) rather than falling back", async () => {
+    process.env.X_BEARER_TOKEN = "test-bearer";
+    mockApi({
+      apiBody: { data: { article: { title: "Title Only", text: "  " } } },
+      synBody: { text: "SYNDICATION TWEET", user: { name: "Ada", screen_name: "ada" } },
+    });
+    const { title, content } = await fetchXPostContent("https://x.com/ada/status/9");
+    expect(title).toBe("Title Only");
+    expect(content).toContain("# Title Only");
+    expect(content).not.toContain("SYNDICATION TWEET"); // article path, not fallback
+  });
+
+  it("defaults the heading to 'X Article' when the article has body but no title", async () => {
+    process.env.X_BEARER_TOKEN = "test-bearer";
+    mockApi({
+      apiBody: { data: { article: { text: "Body without a title." } } },
+      synBody: {},
+    });
+    const { title, content } = await fetchXPostContent("https://x.com/ada/status/9");
+    expect(title).toBe("X Article");
+    expect(content).toContain("# X Article");
+    expect(content).toContain("Body without a title.");
+  });
 });

--- a/src/lib/__tests__/x-post.test.ts
+++ b/src/lib/__tests__/x-post.test.ts
@@ -193,3 +193,86 @@ describe("fetchXPostContent", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// fetchXPostContent — long-form X Articles (X API v2, X_BEARER_TOKEN)
+// ---------------------------------------------------------------------------
+
+describe("fetchXPostContent — X Articles", () => {
+  const originalFetch = globalThis.fetch;
+  const savedToken = process.env.X_BEARER_TOKEN;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (savedToken === undefined) delete process.env.X_BEARER_TOKEN;
+    else process.env.X_BEARER_TOKEN = savedToken;
+    vi.restoreAllMocks();
+  });
+
+  /** Route fetches: api.twitter.com → `apiBody`/`apiStatus`; syndication → `synBody`. */
+  function mockApi(opts: {
+    apiBody?: unknown;
+    apiStatus?: number;
+    synBody?: unknown;
+  }) {
+    globalThis.fetch = vi.fn(async (input: unknown) => {
+      const u = String(input);
+      if (u.includes("api.twitter.com")) {
+        const status = opts.apiStatus ?? 200;
+        return { ok: status >= 200 && status < 300, status, json: async () => opts.apiBody ?? {} };
+      }
+      return { ok: true, status: 200, json: async () => opts.synBody ?? {} };
+    }) as unknown as typeof fetch;
+  }
+
+  it("reads a long-form Article body via the X API (token set), with cover + byline", async () => {
+    process.env.X_BEARER_TOKEN = "test-bearer";
+    mockApi({
+      apiBody: { data: { article: { title: "My Long Essay", text: "## Section\n\nThe full article body." } } },
+      // syndication is hit only for the cover image here
+      synBody: { article: { cover_media: { media_info: { original_img_url: "https://pbs.twimg.com/cover.jpg" } } } },
+    });
+
+    const { title, content } = await fetchXPostContent("https://x.com/ada/status/123");
+    expect(title).toBe("My Long Essay");
+    expect(content).toContain("# My Long Essay");
+    expect(content).toContain("**@ada** · X Article");
+    expect(content).toContain("![My Long Essay](https://pbs.twimg.com/cover.jpg)");
+    expect(content).toContain("The full article body.");
+    expect(content).toContain("**Source:** [https://x.com/ada/status/123]");
+  });
+
+  it("falls back to syndication when the post is not an article", async () => {
+    process.env.X_BEARER_TOKEN = "test-bearer";
+    mockApi({
+      apiBody: { data: { text: "no article here" } }, // no `article` field
+      synBody: { text: "just a normal tweet", user: { name: "Ada", screen_name: "ada" } },
+    });
+
+    const { content } = await fetchXPostContent("https://x.com/ada/status/123");
+    expect(content).toContain("just a normal tweet");
+    expect(content).not.toContain("X Article");
+  });
+
+  it("falls back to syndication on an X API error (e.g. rate limit)", async () => {
+    process.env.X_BEARER_TOKEN = "test-bearer";
+    mockApi({
+      apiStatus: 429,
+      synBody: { text: "fallback tweet", user: { name: "Ada", screen_name: "ada" } },
+    });
+
+    const { content } = await fetchXPostContent("https://x.com/ada/status/123");
+    expect(content).toContain("fallback tweet");
+  });
+
+  it("never calls the X API when no token is configured", async () => {
+    delete process.env.X_BEARER_TOKEN;
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (input: unknown) => {
+      calls.push(String(input));
+      return { ok: true, status: 200, json: async () => ({ text: "tweet", user: { name: "Ada", screen_name: "ada" } }) };
+    }) as unknown as typeof fetch;
+
+    await fetchXPostContent("https://x.com/ada/status/123");
+    expect(calls.some((u) => u.includes("api.twitter.com"))).toBe(false);
+  });
+});

--- a/src/lib/x-post.ts
+++ b/src/lib/x-post.ts
@@ -252,10 +252,21 @@ async function fetchArticleViaApi(id: string, url: string): Promise<XPostContent
       { headers: { Authorization: `Bearer ${bearer}` } },
     );
     if (!res.ok) {
-      logger.warn(
-        "x-post",
-        `X API article fetch failed (HTTP ${res.status}) for ${id}; using syndication`,
-      );
+      // A 401/403 means the bearer token is bad/expired/under-privileged — a
+      // CONFIG defect that would otherwise silently degrade EVERY article to a
+      // teaser. Make it loud (error); transient 429/5xx stay a warn. Both fall
+      // back to syndication so plain-tweet ingest is never broken.
+      if (res.status === 401 || res.status === 403) {
+        logger.error(
+          "x-post",
+          `X API rejected the bearer token (HTTP ${res.status}) — X_BEARER_TOKEN is likely expired/revoked or lacks article access; article ingest is degraded to teaser-only`,
+        );
+      } else {
+        logger.warn(
+          "x-post",
+          `X API article fetch failed (HTTP ${res.status}) for ${id}; using syndication`,
+        );
+      }
       return null;
     }
     const article = ((await res.json()) as XApiTweetResponse).data?.article;
@@ -272,7 +283,8 @@ async function fetchArticleViaApi(id: string, url: string): Promise<XPostContent
     lines.push(`**Source:** [${url}](${url})`);
     return { title, content: lines.join("\n").trim() };
   } catch (err) {
-    logger.warn("x-post", `X API article fetch error for ${id}: ${String(err)}`);
+    // Pass the error object (not a string) so the stack survives in logs.
+    logger.warn("x-post", `X API article fetch error for ${id}; using syndication`, err);
     return null;
   }
 }

--- a/src/lib/x-post.ts
+++ b/src/lib/x-post.ts
@@ -7,6 +7,12 @@
  * the endpoint that powers embedded tweets), which returns the post's text,
  * author, media, and any quoted tweet as JSON — no API key required.
  *
+ * Long-form **X Articles** carry their body in the authenticated X API v2
+ * `article` field (the syndication payload only exposes the cover image), so
+ * when `X_BEARER_TOKEN` is configured we fetch the article body via the API
+ * first (matching the @yoyo mention worker) and fall back to syndication for
+ * plain tweets / no token.
+ *
  * Self-contained: URL detection, tweet-ID extraction, fetch, and markdown
  * formatting, with no dependency on the ingest pipeline (mirrors `youtube.ts`).
  */
@@ -195,6 +201,83 @@ function formatTweetAsMarkdown(tweet: SyndicationTweet, url: string): XPostConte
 }
 
 // ---------------------------------------------------------------------------
+// Long-form X Articles — via the authenticated X API v2
+// ---------------------------------------------------------------------------
+
+/** Subset of the X API v2 `GET /2/tweets/:id` response we read. */
+interface XApiTweetResponse {
+  data?: { id?: string; text?: string; article?: { title?: string; text?: string } };
+}
+
+/** The `@handle` from an X status URL (`/i/...` has none) — for the byline. */
+function handleFromUrl(url: string): string | null {
+  try {
+    const seg = new URL(url).pathname.split("/").filter(Boolean)[0];
+    return seg && seg.toLowerCase() !== "i" ? seg : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The Article's cover/hero image via the syndication CDN (the API exposes
+ *  none). Best-effort: any error / shape change → null. */
+async function fetchArticleCover(id: string): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `https://cdn.syndication.twimg.com/tweet-result?id=${id}&lang=en&token=${syndicationToken(id)}`,
+      { headers: { "User-Agent": "Mozilla/5.0", Accept: "application/json" } },
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      article?: { cover_media?: { media_info?: { original_img_url?: string } } };
+    };
+    return data.article?.cover_media?.media_info?.original_img_url ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch a long-form X Article's full body via the authenticated X API v2.
+ * Returns `null` (so the caller falls back to syndication) when there's no
+ * `X_BEARER_TOKEN`, the post isn't an article, or the API call fails — a
+ * token/rate-limit hiccup must never break plain-tweet ingest.
+ */
+async function fetchArticleViaApi(id: string, url: string): Promise<XPostContent | null> {
+  const bearer = process.env.X_BEARER_TOKEN;
+  if (!bearer) return null;
+  try {
+    const res = await fetch(
+      `https://api.twitter.com/2/tweets/${id}?tweet.fields=article`,
+      { headers: { Authorization: `Bearer ${bearer}` } },
+    );
+    if (!res.ok) {
+      logger.warn(
+        "x-post",
+        `X API article fetch failed (HTTP ${res.status}) for ${id}; using syndication`,
+      );
+      return null;
+    }
+    const article = ((await res.json()) as XApiTweetResponse).data?.article;
+    if (!article || (!article.text?.trim() && !article.title?.trim())) return null;
+
+    const title = article.title?.trim() || "X Article";
+    const handle = handleFromUrl(url);
+    const cover = await fetchArticleCover(id);
+    const lines: string[] = [`# ${title}`, ""];
+    if (handle) lines.push(`**@${handle}** · X Article`, "");
+    if (cover) lines.push(`![${title}](${cover})`, "");
+    const body = article.text?.trim();
+    if (body) lines.push(body, "");
+    lines.push(`**Source:** [${url}](${url})`);
+    return { title, content: lines.join("\n").trim() };
+  } catch (err) {
+    logger.warn("x-post", `X API article fetch error for ${id}: ${String(err)}`);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // High-level entry point
 // ---------------------------------------------------------------------------
 
@@ -202,8 +285,10 @@ function formatTweetAsMarkdown(tweet: SyndicationTweet, url: string): XPostConte
  * Fetch an X/Twitter post ready for ingestion.
  *
  * 1. Extract the tweet ID (throws on an unrecognized URL).
- * 2. Read the post via the syndication CDN (no API key).
- * 3. Return the post text + media + quoted tweet as markdown.
+ * 2. If it's a long-form Article and `X_BEARER_TOKEN` is set, read the full
+ *    body via the X API v2; otherwise read the post via the syndication CDN.
+ * 3. Return the content (article body, or tweet text + media + quoted tweet)
+ *    as markdown.
  *
  * Throws a {@link ClientInputError} for a missing/private/deleted post so the
  * caller surfaces a useful message rather than ingesting an error page.
@@ -211,6 +296,10 @@ function formatTweetAsMarkdown(tweet: SyndicationTweet, url: string): XPostConte
 export async function fetchXPostContent(url: string): Promise<XPostContent> {
   const id = extractTweetId(url);
   if (!id) throw new ClientInputError(`Not a recognizable X post URL: "${url}"`);
+
+  // Long-form Article body (authenticated) when available — else plain tweet.
+  const article = await fetchArticleViaApi(id, url);
+  if (article) return article;
 
   const tweet = await fetchSyndication(id);
   // Reject only a genuinely empty payload — no renderable text/media on the


### PR DESCRIPTION
## Why
On-demand `/ingest` of an X Article only captured the tweet's teaser text — the long-form body lives in X's authenticated **API v2 `article` field** (syndication exposes only the cover image). The @yoyo mention worker already reads it that way (`workers/x-ingest/index.ts:388`); this brings the same to the on-demand path.

## What (`src/lib/x-post.ts`)
- `fetchXPostContent` now tries the **X API v2** first (`GET /2/tweets/:id?tweet.fields=article`) when **`X_BEARER_TOKEN`** is set. If the post is an Article, it renders the title + full `article.text` + a byline + the cover image (pulled from syndication) + source link.
- **Falls back to syndication** (the existing tweet path) for plain tweets, when there's no token, or on any API error — fail-soft, so a token/rate-limit hiccup never breaks plain-tweet ingest.

## Config
Set the Worker secret `X_BEARER_TOKEN` (the same token the cron `x-ingest` worker uses). Without it, behavior is unchanged (syndication only).

## Tests
- Article via API (token set): asserts the article title, full body, cover image, byline, and source.
- Falls back to syndication when the post isn't an article, on an API error (429), and when no token is set (asserts the X API is never called).
- Full suite: **2723 passed**; `pnpm build` clean.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)