### PR TITLE
Re-ingest display: distinct source count + consistent trail titles

### DIFF
--- a/src/lib/__tests__/recent-index.test.ts
+++ b/src/lib/__tests__/recent-index.test.ts
@@ -101,6 +101,22 @@ describe("recent-index", () => {
     expect(trail.map((e) => e.slug)).toEqual(["page-c", "page-b"]);
   });
 
+  it("getTrail resolves each event to the page's CURRENT title", async () => {
+    const { updateIndex } = await import("../wiki");
+    await seedEmpty();
+    // Two ingest events for one page captured two differently-cased titles.
+    await pushRecentEvent(ev({ ts: 1000, slug: "agentic-systems", title: "Agentic systems" }));
+    await pushRecentEvent(ev({ ts: 2000, slug: "agentic-systems", title: "agentic systems" }));
+    // The page's CURRENT title (from the wiki index) is the canonical one.
+    await updateIndex([
+      { title: "Agentic Systems", slug: "agentic-systems", summary: "x" },
+    ]);
+
+    const trail = await getTrail(10, null);
+    // Both events render the same current title — not the stale snapshots.
+    expect(trail.every((e) => e.title === "Agentic Systems")).toBe(true);
+  });
+
   it("getTrail falls back to the scan when the index is unseeded", async () => {
     // No index seeded → getTrail scans; an empty wiki yields no events (and
     // crucially does not throw).

--- a/src/lib/__tests__/recent-index.test.ts
+++ b/src/lib/__tests__/recent-index.test.ts
@@ -101,20 +101,38 @@ describe("recent-index", () => {
     expect(trail.map((e) => e.slug)).toEqual(["page-c", "page-b"]);
   });
 
-  it("getTrail resolves each event to the page's CURRENT title", async () => {
+  it("getTrail resolves every event to the page's CURRENT title", async () => {
     const { updateIndex } = await import("../wiki");
     await seedEmpty();
-    // Two ingest events for one page captured two differently-cased titles.
-    await pushRecentEvent(ev({ ts: 1000, slug: "agentic-systems", title: "Agentic systems" }));
-    await pushRecentEvent(ev({ ts: 2000, slug: "agentic-systems", title: "agentic systems" }));
+    // Two ingest events for one page, > the 120s dedup window apart so BOTH
+    // survive, captured with two differently-cased snapshot titles.
+    await pushRecentEvent(
+      ev({ ts: 1000, slug: "agentic-systems", title: "Agentic systems", action: "ingested" }),
+    );
+    await pushRecentEvent(
+      ev({ ts: 500_000, slug: "agentic-systems", title: "agentic systems", action: "ingested" }),
+    );
     // The page's CURRENT title (from the wiki index) is the canonical one.
     await updateIndex([
       { title: "Agentic Systems", slug: "agentic-systems", summary: "x" },
     ]);
 
     const trail = await getTrail(10, null);
-    // Both events render the same current title — not the stale snapshots.
-    expect(trail.every((e) => e.title === "Agentic Systems")).toBe(true);
+    // Both events survive, in newest-first order, both rewritten to the current
+    // title (not the stale snapshots).
+    expect(trail.map((e) => e.ts)).toEqual([500_000, 1000]);
+    expect(trail.map((e) => e.title)).toEqual(["Agentic Systems", "Agentic Systems"]);
+  });
+
+  it("getTrail keeps the snapshot title when the slug isn't in the readable set", async () => {
+    await seedEmpty();
+    // No wiki-index entry for "ghost" → listReadableWikiPages returns [] → the
+    // event keeps its original snapshot title rather than being dropped.
+    await pushRecentEvent(ev({ ts: 1000, slug: "ghost", title: "Snapshot Name" }));
+
+    const trail = await getTrail(10, null);
+    expect(trail).toHaveLength(1);
+    expect(trail[0].title).toBe("Snapshot Name");
   });
 
   it("getTrail falls back to the scan when the index is unseeded", async () => {

--- a/src/lib/__tests__/wiki.test.ts
+++ b/src/lib/__tests__/wiki.test.ts
@@ -25,6 +25,7 @@ import {
   withPageCache,
   _getPageCacheSize,
   updateRelatedPages,
+  enrichEntry,
 } from "../wiki";
 import { _resetStorage } from "../storage";
 import type { IndexEntry } from "../types";
@@ -171,6 +172,26 @@ describe("updateIndex + listWikiPages roundtrip", () => {
     expect(gamma.tags).toBeUndefined();
     expect(gamma.updated).toBeUndefined();
     expect(gamma.sourceCount).toBeUndefined();
+  });
+
+  it("enrichEntry: sourceCount counts DISTINCT sources (by URL), not the event counter", () => {
+    const base = { slug: "x", title: "X", summary: "" };
+    // Same URL recorded twice (pdf then url) — 1 distinct source, even though
+    // source_count (the ingest-event counter) says 3.
+    const fm = {
+      source_count: "3",
+      sources: JSON.stringify([
+        { type: "pdf", url: "https://arxiv.org/p.pdf", fetched: "2026-06-07", triggered_by: "system" },
+        { type: "url", url: "https://arxiv.org/p.pdf", fetched: "2026-06-08", triggered_by: "system" },
+      ]),
+    } as unknown as import("../frontmatter").Frontmatter;
+    expect(enrichEntry(base, fm).sourceCount).toBe(1);
+  });
+
+  it("enrichEntry: falls back to source_count for legacy pages without sources[]", () => {
+    const base = { slug: "y", title: "Y", summary: "" };
+    const fm = { source_count: "3" } as unknown as import("../frontmatter").Frontmatter;
+    expect(enrichEntry(base, fm).sourceCount).toBe(3);
   });
 
   it("falls back to the plain entry when a page is missing on disk", async () => {

--- a/src/lib/__tests__/wiki.test.ts
+++ b/src/lib/__tests__/wiki.test.ts
@@ -188,6 +188,18 @@ describe("updateIndex + listWikiPages roundtrip", () => {
     expect(enrichEntry(base, fm).sourceCount).toBe(1);
   });
 
+  it("enrichEntry: counts two distinct source URLs as sourceCount 2", () => {
+    const base = { slug: "z", title: "Z", summary: "" };
+    const fm = {
+      source_count: "2",
+      sources: JSON.stringify([
+        { type: "url", url: "https://a.com", fetched: "2026-06-07", triggered_by: "system" },
+        { type: "pdf", url: "https://b.com/p.pdf", fetched: "2026-06-08", triggered_by: "system" },
+      ]),
+    } as unknown as import("../frontmatter").Frontmatter;
+    expect(enrichEntry(base, fm).sourceCount).toBe(2);
+  });
+
   it("enrichEntry: falls back to source_count for legacy pages without sources[]", () => {
     const base = { slug: "y", title: "Y", summary: "" };
     const fm = { source_count: "3" } as unknown as import("../frontmatter").Frontmatter;

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -45,9 +45,29 @@ export async function getTrail(
   if (!principal) {
     const { getRecentIndex } = await import("./recent-index");
     const idx = await getRecentIndex();
-    if (idx !== null) return idx.slice(0, limit);
+    // The index stores each event's title as a SNAPSHOT from ingest time, so a
+    // page re-ingested under a differently-cased concept ("Agentic systems" →
+    // "agentic systems") shows up twice under two names. Resolve to the page's
+    // CURRENT title so one page reads as one name. (scanTrail already uses the
+    // live page title, so it needs no fixup.)
+    if (idx !== null) return withCurrentTitles(idx.slice(0, limit), principal);
   }
   return scanTrail(limit, principal);
+}
+
+/** Overwrite each event's snapshot title with the page's current title. */
+async function withCurrentTitles(
+  events: TrailEvent[],
+  principal: Principal | null,
+): Promise<TrailEvent[]> {
+  if (events.length === 0) return events;
+  const titleBySlug = new Map(
+    (await listReadableWikiPages(principal)).map((p) => [p.slug, p.title]),
+  );
+  return events.map((e) => {
+    const current = titleBySlug.get(e.slug);
+    return current && current !== e.title ? { ...e, title: current } : e;
+  });
 }
 
 /**

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -385,13 +385,7 @@ export function enrichEntry(
   // counter (re-ingesting one URL bumps it), so it overcounts — only fall back
   // to it for legacy pages that have no structured `sources[]`.
   const distinctSources = dedupeSourcesForDisplay(
-    parseSources(
-      typeof fm.sources === "string"
-        ? fm.sources
-        : Array.isArray(fm.sources)
-          ? fm.sources
-          : undefined,
-    ),
+    parseSources(fm.sources as string | string[] | undefined),
   ).length;
   const sourceCountRaw = fm.source_count;
   const sourceCountNum =

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -12,6 +12,7 @@ import {
 } from "./config";
 import { getTenantWikiDir, getTenantRawDir } from "./paths";
 import { DEFAULT_TENANT, ownerToTenant } from "./links";
+import { parseSources, dedupeSourcesForDisplay } from "./sources";
 
 // ---------------------------------------------------------------------------
 // Configurable base directories — delegated to the config layer
@@ -379,7 +380,19 @@ export function enrichEntry(
   const updated =
     typeof fm.updated === "string" && fm.updated.length > 0 ? fm.updated : undefined;
 
-  // source_count may be a number (new behavior) or a string (legacy).
+  // Displayed source count = number of DISTINCT sources (deduped by URL), so it
+  // matches the SOURCES panel. `source_count` frontmatter is an ingest-EVENT
+  // counter (re-ingesting one URL bumps it), so it overcounts — only fall back
+  // to it for legacy pages that have no structured `sources[]`.
+  const distinctSources = dedupeSourcesForDisplay(
+    parseSources(
+      typeof fm.sources === "string"
+        ? fm.sources
+        : Array.isArray(fm.sources)
+          ? fm.sources
+          : undefined,
+    ),
+  ).length;
   const sourceCountRaw = fm.source_count;
   const sourceCountNum =
     typeof sourceCountRaw === "number"
@@ -387,8 +400,9 @@ export function enrichEntry(
       : typeof sourceCountRaw === "string" && sourceCountRaw.length > 0
         ? Number.parseInt(sourceCountRaw, 10)
         : NaN;
-  const sourceCount =
+  const legacyCount =
     Number.isFinite(sourceCountNum) && sourceCountNum >= 0 ? sourceCountNum : undefined;
+  const sourceCount = distinctSources > 0 ? distinctSources : legacyCount;
 
   const sourceUrl =
     typeof fm.source_url === "string" && fm.source_url.length > 0


### PR DESCRIPTION
## Why
Re-ingesting a page surfaced two confusing display bugs (from the trail/cards):
1. The same URL ingested twice showed **"2 sources"** on cards even though there's **1 distinct source** (the deduped SOURCES panel correctly showed 1).
2. The trail listed **one page under two names** — "Agentic systems" and "agentic systems" — because each ingest snapshots the title and the synthesis named the concept with different casing across runs.

## Fixes
1. **Distinct source count** (`enrichEntry`, `src/lib/wiki.ts`): the displayed `sourceCount` is now the number of **distinct sources** (`dedupeSourcesForDisplay(parseSources(...)).length`), matching the SOURCES panel. `source_count` (an ingest-EVENT counter) is only used as a fallback for legacy pages with no structured `sources[]`. Affects all surfaces (cards, browse, sort).
2. **Consistent trail titles** (`getTrail`, `src/lib/trail.ts`): each trail event's snapshot title is resolved to the page's **current** title at read time, so one page reads as one name. (`scanTrail` already used the live title; this fixes the precomputed `_idx:recent` path the homepage serves.)

## Tests
- `enrichEntry`: counts distinct sources by URL (same URL twice → 1, not the source_count of 3); legacy fallback to `source_count` when no `sources[]`.
- `getTrail`: two events for one page with differently-cased snapshot titles both render the page's current title.
- Full suite: **2735 passed**; `pnpm build` clean.

## Note
The current pages reflect this once their derived index refreshes (it's read at render for the trail; the card count updates on the next index read / re-ingest).

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)