### PR TITLE
Add a review/draft step to the Re-ingest action

### DIFF
--- a/src/app/api/ingest/reingest/route.ts
+++ b/src/app/api/ingest/reingest/route.ts
@@ -13,11 +13,23 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Sign in required." }, { status: 401 });
     }
     const body = await request.json();
-    const { slug } = body;
+    const { slug, preview, generatedContent } = body;
 
     if (!slug || typeof slug !== "string" || slug.trim().length === 0) {
       return NextResponse.json(
         { error: "slug is required and must be a non-empty string" },
+        { status: 400 },
+      );
+    }
+    if (preview !== undefined && typeof preview !== "boolean") {
+      return NextResponse.json(
+        { error: "preview must be a boolean if provided" },
+        { status: 400 },
+      );
+    }
+    if (generatedContent !== undefined && typeof generatedContent !== "string") {
+      return NextResponse.json(
+        { error: "generatedContent must be a string if provided" },
         { status: 400 },
       );
     }
@@ -60,6 +72,10 @@ export async function POST(request: NextRequest) {
     const result = await reingest(trimmedSlug, {
       author: principal.handle,
       triggeredBy: principal.handle,
+      // `preview: true` synthesizes the draft without writing (review step);
+      // `generatedContent` commits the reviewed draft.
+      ...(preview === true ? { preview: true } : {}),
+      ...(typeof generatedContent === "string" ? { generatedContent } : {}),
     });
     return NextResponse.json(result);
   } catch (error) {

--- a/src/components/ReingestButton.tsx
+++ b/src/components/ReingestButton.tsx
@@ -1,56 +1,152 @@
 "use client";
 
 import { useState } from "react";
+import { IngestReview, type PreviewData } from "@/components/IngestReview";
 
 interface ReingestButtonProps {
   slug: string;
 }
 
+/**
+ * Re-ingest a page with a REVIEW step: re-fetch + synthesize a draft (no write),
+ * show it in {@link IngestReview} for editing, then publish on approve. Mirrors
+ * the /ingest UI's preview → review → publish, over `/api/ingest/reingest`.
+ */
 export function ReingestButton({ slug }: ReingestButtonProps) {
-  const [state, setState] = useState<"idle" | "loading" | "success" | "error">("idle");
-  const [message, setMessage] = useState("");
+  const [stage, setStage] = useState<"idle" | "loading" | "review">("idle");
+  const [preview, setPreview] = useState<PreviewData | null>(null);
+  const [publishing, setPublishing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  async function handleReingest() {
-    setState("loading");
-    setMessage("");
+  async function loadPreview() {
+    setStage("loading");
+    setError(null);
     try {
       const res = await fetch("/api/ingest/reingest", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ slug }),
+        body: JSON.stringify({ slug, preview: true }),
       });
       const data = await res.json();
       if (!res.ok) {
-        setState("error");
-        setMessage(data.error ?? "Re-ingest failed");
+        setError(data.error ?? "Re-ingest preview failed");
+        setStage("idle");
         return;
       }
-      setState("success");
-      setMessage(`Re-ingested successfully — updated ${data.wikiPages?.length ?? 0} page(s)`);
-      // Reload after a short delay so the user sees the success message
-      setTimeout(() => window.location.reload(), 1500);
-    } catch (err) {
-      setState("error");
-      setMessage(err instanceof Error ? err.message : "Re-ingest failed");
+      setPreview({
+        slug: data.primarySlug ?? slug,
+        previewContent: data.previewContent ?? "",
+        relatedPages: data.relatedUpdated ?? [],
+        title: data.preview?.title ?? slug,
+        content: "",
+        ...(data.sourceUrl ? { sourceUrl: data.sourceUrl } : {}),
+        meta: data.preview,
+      });
+      setStage("review");
+    } catch {
+      setError("Network error — could not reach the server");
+      setStage("idle");
     }
   }
 
+  async function publish(editedContent?: string) {
+    if (!preview) return;
+    setPublishing(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/ingest/reingest", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          slug,
+          generatedContent: editedContent ?? preview.previewContent,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "Publish failed");
+        setPublishing(false);
+        return;
+      }
+      // Reload so the reader sees the updated page.
+      window.location.reload();
+    } catch {
+      setError("Network error — could not reach the server");
+      setPublishing(false);
+    }
+  }
+
+  function cancel() {
+    setStage("idle");
+    setPreview(null);
+    setError(null);
+    setPublishing(false);
+  }
+
   return (
-    <div className="inline-flex flex-col items-start gap-1">
-      <button
-        onClick={handleReingest}
-        disabled={state === "loading"}
-        aria-label="Re-ingest source content"
-        className="rounded-md border border-foreground/20 px-4 py-2 text-sm font-medium text-foreground hover:bg-foreground/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        {state === "loading" ? "Re-ingesting…" : "Re-ingest"}
-      </button>
-      {state === "success" && (
-        <span className="text-xs text-green-600 dark:text-green-400">{message}</span>
+    <>
+      <div className="inline-flex flex-col items-start gap-1">
+        <button
+          onClick={loadPreview}
+          disabled={stage === "loading"}
+          aria-label="Re-ingest source content"
+          className="rounded-md border border-foreground/20 px-4 py-2 text-sm font-medium text-foreground hover:bg-foreground/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {stage === "loading" ? "Preparing draft…" : "Re-ingest"}
+        </button>
+        {stage === "idle" && error && (
+          <span className="text-xs text-red-600 dark:text-red-400">{error}</span>
+        )}
+      </div>
+
+      {stage === "review" && preview && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          onClick={(e) => {
+            if (e.target === e.currentTarget && !publishing) cancel();
+          }}
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 50,
+            background: "rgba(0,0,0,0.45)",
+            display: "flex",
+            alignItems: "flex-start",
+            justifyContent: "center",
+            padding: "5vh 16px",
+            overflowY: "auto",
+          }}
+        >
+          <div
+            style={{
+              background: "var(--paper)",
+              borderRadius: 16,
+              maxWidth: 880,
+              width: "100%",
+              padding: 28,
+              boxShadow: "var(--shadow)",
+            }}
+          >
+            <h2 className="display" style={{ fontSize: 22, margin: "0 0 6px" }}>
+              Re-ingest — review the new draft
+            </h2>
+            <p
+              className="receipt"
+              style={{ fontSize: 12.5, color: "var(--muted)", margin: "0 0 18px" }}
+            >
+              Re-fetched from the source. Review and edit before it replaces the page.
+            </p>
+            <IngestReview
+              preview={preview}
+              loading={publishing}
+              onApprove={publish}
+              onCancel={cancel}
+              error={error}
+            />
+          </div>
+        </div>
       )}
-      {state === "error" && (
-        <span className="text-xs text-red-600 dark:text-red-400">{message}</span>
-      )}
-    </div>
+    </>
   );
 }

--- a/src/lib/__tests__/ingest-routes.test.ts
+++ b/src/lib/__tests__/ingest-routes.test.ts
@@ -568,6 +568,67 @@ describe("POST /api/ingest/batch — service token auth", () => {
 });
 
 // ===========================================================================
+// POST /api/ingest/reingest — preview / commit passthrough
+// ===========================================================================
+describe("POST /api/ingest/reingest — preview/commit", () => {
+  const fakeResult: IngestResult = {
+    rawPath: "",
+    primarySlug: "p",
+    relatedUpdated: [],
+    wikiPages: ["p"],
+    indexUpdated: true,
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const publicPage: any = {
+    content: "# P",
+    frontmatter: { title: "P", source_url: "https://example.com/s" },
+  };
+
+  beforeEach(() => {
+    mockedGetPrincipal.mockResolvedValue({ id: "u", handle: "yuanhao" });
+    mockedReadWikiPage.mockResolvedValue(publicPage);
+    mockedReingest.mockResolvedValue(fakeResult);
+  });
+
+  it("forwards preview:true to reingest (review step, no write)", async () => {
+    const res = await POST_REINGEST(
+      makeRequest("http://localhost/api/ingest/reingest", { slug: "p", preview: true }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedReingest).toHaveBeenCalledWith(
+      "p",
+      expect.objectContaining({ preview: true }),
+    );
+  });
+
+  it("forwards generatedContent to reingest (commit the reviewed draft)", async () => {
+    const res = await POST_REINGEST(
+      makeRequest("http://localhost/api/ingest/reingest", {
+        slug: "p",
+        generatedContent: "# Edited\n\nApproved body.",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedReingest).toHaveBeenCalledWith(
+      "p",
+      expect.objectContaining({ generatedContent: "# Edited\n\nApproved body." }),
+    );
+  });
+
+  it("rejects a non-boolean preview and a non-string generatedContent", async () => {
+    const r1 = await POST_REINGEST(
+      makeRequest("http://localhost/api/ingest/reingest", { slug: "p", preview: "yes" }),
+    );
+    expect(r1.status).toBe(400);
+    const r2 = await POST_REINGEST(
+      makeRequest("http://localhost/api/ingest/reingest", { slug: "p", generatedContent: 5 }),
+    );
+    expect(r2.status).toBe(400);
+    expect(mockedReingest).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
 // POST /api/ingest/reingest — service token auth
 // ===========================================================================
 describe("POST /api/ingest/reingest — service token auth", () => {

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -2908,6 +2908,72 @@ describe("reingest", () => {
     }
   });
 
+  it("preview re-synthesizes a draft WITHOUT writing the page", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    const originalFetch = global.fetch;
+    try {
+      mockedCallLLM.mockResolvedValue("CONCEPT: Topic\n\n# Topic\n\n## Summary\n\nv1 body.");
+      await ingest("Topic", "seed", { sourceUrl: "https://example.com/doc" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Map([["content-type", "text/html"]]) as unknown as Headers,
+        body: null,
+        text: () =>
+          Promise.resolve("<html><head><title>Doc</title></head><body><p>fresh</p></body></html>"),
+      });
+      mockedCallLLM.mockResolvedValue("CONCEPT: Topic\n\n# Topic\n\n## Summary\n\nv2 PREVIEW.");
+
+      const result = await reingest("topic", { preview: true });
+      expect(result.previewContent).toContain("v2 PREVIEW");
+      expect(result.indexUpdated).toBe(false);
+      // The stored page is untouched — still v1.
+      const page = await readWikiPageWithFrontmatter("topic");
+      expect(page!.content).toContain("v1 body");
+      expect(page!.content).not.toContain("v2 PREVIEW");
+    } finally {
+      global.fetch = originalFetch;
+      mockedHasLLMKey.mockReturnValue(false);
+      mockedCallLLM.mockReset();
+    }
+  });
+
+  it("commits a reviewed draft in place — an edited H1 doesn't fork the slug", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    const originalFetch = global.fetch;
+    try {
+      mockedCallLLM.mockResolvedValue("CONCEPT: Topic\n\n# Topic\n\n## Summary\n\nv1.");
+      await ingest("Topic", "seed", { sourceUrl: "https://example.com/doc" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Map([["content-type", "text/html"]]) as unknown as Headers,
+        body: null,
+        text: () =>
+          Promise.resolve("<html><head><title>Doc</title></head><body><p>fresh</p></body></html>"),
+      });
+
+      // Commit the reviewed draft with an edited H1 (different name).
+      const result = await reingest("topic", {
+        generatedContent: "# Renamed Topic\n\n## Summary\n\nEdited body.",
+      });
+
+      expect(result.primarySlug).toBe("topic"); // pinned — no fork to renamed-topic
+      expect(await readWikiPageWithFrontmatter("renamed-topic")).toBeNull();
+      const page = await readWikiPageWithFrontmatter("topic");
+      expect(page!.content).toContain("Edited body.");
+      // The title follows the edited H1.
+      const entries = await listWikiPages();
+      expect(entries.find((e) => e.slug === "topic")!.title).toBe("Renamed Topic");
+    } finally {
+      global.fetch = originalFetch;
+      mockedHasLLMKey.mockReturnValue(false);
+      mockedCallLLM.mockReset();
+    }
+  });
+
   it("dedups a re-ingested source by URL even when the type differs", async () => {
     // A PDF page re-fetched as a plain "url" must not create a second source
     // entry for the same URL (the bug behind the duplicated arxiv sources).

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -2974,6 +2974,72 @@ describe("reingest", () => {
     }
   });
 
+  it("commit with NO H1 in the draft preserves the existing title (not the source <title>)", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    const originalFetch = global.fetch;
+    try {
+      mockedCallLLM.mockResolvedValue("CONCEPT: Topic\n\n# Topic\n\n## Summary\n\nv1.");
+      await ingest("Topic", "seed", { sourceUrl: "https://example.com/doc" });
+
+      // The re-fetch returns a junk <title> ("Something Went Wrong").
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Map([["content-type", "text/html"]]) as unknown as Headers,
+        body: null,
+        text: () =>
+          Promise.resolve(
+            "<html><head><title>Something Went Wrong</title></head><body><p>x</p></body></html>",
+          ),
+      });
+
+      // Reviewed draft has NO H1 — title must NOT become the junk source title.
+      await reingest("topic", { generatedContent: "## Summary\n\nBody without a heading." });
+
+      const entries = await listWikiPages();
+      expect(entries.find((e) => e.slug === "topic")!.title).toBe("Topic");
+    } finally {
+      global.fetch = originalFetch;
+      mockedHasLLMKey.mockReturnValue(false);
+      mockedCallLLM.mockReset();
+    }
+  });
+
+  it("a pinned commit never clobbers a DIFFERENT existing page even if the edited H1 collides", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    const originalFetch = global.fetch;
+    try {
+      mockedCallLLM.mockResolvedValue("CONCEPT: Topic\n\n# Topic\n\n## Summary\n\nv1.");
+      await ingest("Topic", "seed", { sourceUrl: "https://example.com/doc" });
+      // A separate, pre-existing page the edited H1 would slugify onto.
+      mockedCallLLM.mockResolvedValue("CONCEPT: Other Page\n\n# Other Page\n\n## Summary\n\nOriginal other.");
+      await ingest("Other Page", "other seed");
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Map([["content-type", "text/html"]]) as unknown as Headers,
+        body: null,
+        text: () =>
+          Promise.resolve("<html><head><title>Doc</title></head><body><p>x</p></body></html>"),
+      });
+
+      // Re-ingest "topic" with an H1 that collides with the "other-page" slug.
+      const result = await reingest("topic", {
+        generatedContent: "# Other Page\n\n## Summary\n\nTopic's new body.",
+      });
+
+      expect(result.primarySlug).toBe("topic"); // stayed pinned
+      const other = await readWikiPageWithFrontmatter("other-page");
+      expect(other!.content).toContain("Original other."); // untouched
+      expect(other!.content).not.toContain("Topic's new body.");
+    } finally {
+      global.fetch = originalFetch;
+      mockedHasLLMKey.mockReturnValue(false);
+      mockedCallLLM.mockReset();
+    }
+  });
+
   it("dedups a re-ingested source by URL even when the type differs", async () => {
     // A PDF page re-fetched as a plain "url" must not create a second source
     // entry for the same URL (the bug behind the duplicated arxiv sources).

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -430,7 +430,15 @@ export async function ingestPdf(
  */
 export async function reingest(
   slug: string,
-  opts?: { author?: string; owner?: string; triggeredBy?: string },
+  opts?: {
+    author?: string;
+    owner?: string;
+    triggeredBy?: string;
+    /** Synthesize and return the draft WITHOUT writing (for a review step). */
+    preview?: boolean;
+    /** Commit a reviewed draft (skips the LLM, writes this body as-is). */
+    generatedContent?: string;
+  },
 ): Promise<IngestResult> {
   const page = await readWikiPageWithFrontmatter(slug);
   if (!page) {
@@ -1424,12 +1432,18 @@ export async function ingest(
   // deduped before synthesis).
   if (!isPreview && preGeneratedContent) {
     const h1 = wikiContent.match(/^#\s+(.+?)\s*$/m)?.[1]?.trim();
-    const conceptSlug = h1 ? slugify(h1) : "";
-    if (h1 && conceptSlug && conceptSlug !== slug) {
-      const taken = await readWikiPageWithFrontmatter(conceptSlug);
-      if (!taken) {
-        slug = conceptSlug;
-        pageTitle = h1;
+    if (options?.pinSlug) {
+      // Re-ingest (commit-from-preview): keep the page on its pinned slug — a
+      // user-edited H1 must never fork it — but let the TITLE follow the H1.
+      if (h1) pageTitle = h1;
+    } else {
+      const conceptSlug = h1 ? slugify(h1) : "";
+      if (h1 && conceptSlug && conceptSlug !== slug) {
+        const taken = await readWikiPageWithFrontmatter(conceptSlug);
+        if (!taken) {
+          slug = conceptSlug;
+          pageTitle = h1;
+        }
       }
     }
   }

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -1435,7 +1435,17 @@ export async function ingest(
     if (options?.pinSlug) {
       // Re-ingest (commit-from-preview): keep the page on its pinned slug — a
       // user-edited H1 must never fork it — but let the TITLE follow the H1.
-      if (h1) pageTitle = h1;
+      if (h1) {
+        pageTitle = h1;
+      } else {
+        // No H1 in the reviewed draft — preserve the EXISTING page's title
+        // rather than overwriting it with the re-fetched source <title>.
+        const existingPage = await readWikiPageWithFrontmatter(slug);
+        const existingTitle = existingPage?.body
+          ?.match(/^#\s+(.+?)\s*$/m)?.[1]
+          ?.trim();
+        if (existingTitle) pageTitle = existingTitle;
+      }
     } else {
       const conceptSlug = h1 ? slugify(h1) : "";
       if (h1 && conceptSlug && conceptSlug !== slug) {


### PR DESCRIPTION
## Why
The `/ingest` UI reviews the synthesized draft before publishing, but the direct **Re-ingest** action committed immediately — no chance to see or edit the re-synthesized result before it overwrote the page. (Requested follow-up.)

## What
Re-ingest now mirrors the `/ingest` flow: **preview → review → publish**, reusing the existing `IngestReview` component.

- **`reingest()`** (`src/lib/ingest.ts`): threads `preview` / `generatedContent` through to `ingest()` — `preview: true` re-fetches + synthesizes a draft **without writing**; `generatedContent` commits the reviewed body (LLM skipped). Both keep `pinSlug` (no fork).
- **Route** (`src/app/api/ingest/reingest/route.ts`): accepts + validates `preview` and `generatedContent`, passes them through. ACL unchanged (write permission required for both phases).
- **`ReingestButton`**: clicking re-fetches a draft, opens a modal with the editable `IngestReview`, and publishes on approve (re-fetch + commit). Discard closes it.
- **Slug-pin hardening** (`ingest.ts`): the commit-from-preview H1-rederive now respects `pinSlug` — editing the draft's H1 updates the **title** but never **forks the slug** (previously it could move the page).

## Tests
- Route: forwards `preview:true` and `generatedContent` to `reingest`; rejects a non-boolean `preview` / non-string `generatedContent` (400).
- `reingest()`: `preview` returns `previewContent` with `indexUpdated:false` and leaves the stored page untouched; committing a reviewed draft with an **edited H1** stays on the slug (no fork) and updates the title.
- Full suite: **2742 passed**; `pnpm build` clean.

Note: no component test for the modal (no React component-test harness in the repo) — the button is a thin orchestrator over the tested route + the already-tested `IngestReview`.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)