### PR TITLE
Label re-ingests as "re-ingested" in the trail

### DIFF
--- a/src/lib/__tests__/lifecycle.test.ts
+++ b/src/lib/__tests__/lifecycle.test.ts
@@ -764,7 +764,28 @@ describe("recent trail action labeling", () => {
       .filter((e) => e.slug === "test-page")
       .map((e) => e.action);
     expect(actions).toHaveLength(2);
-    expect(actions).toContain("ingested"); // the first ingest
-    expect(actions).toContain("re-ingested"); // the second (page already existed)
+    // Exactly one of each — an inverted ternary would yield two of one label.
+    expect(actions.filter((a) => a === "ingested")).toHaveLength(1);
+    expect(actions.filter((a) => a === "re-ingested")).toHaveLength(1);
+  });
+
+  it("labels a manual edit 'edited', not re-ingested", async () => {
+    const { getRecentIndex } = await import("../recent-index");
+    await getStorage().putIndex("recent", []);
+
+    await writeWikiPageWithSideEffects(
+      makeOpts({ author: "alice", content: "# Test Page\n\nv1." }),
+    );
+    await writeWikiPageWithSideEffects(
+      makeOpts({ author: "alice", logOp: "edit", content: "# Test Page\n\nedited." }),
+    );
+
+    const idx = (await getRecentIndex()) ?? [];
+    const actions = idx
+      .filter((e) => e.slug === "test-page")
+      .map((e) => e.action);
+    expect(actions).toContain("ingested");
+    expect(actions).toContain("edited");
+    expect(actions).not.toContain("re-ingested");
   });
 });

--- a/src/lib/__tests__/lifecycle.test.ts
+++ b/src/lib/__tests__/lifecycle.test.ts
@@ -742,3 +742,29 @@ describe("per-tenant silo mirror", () => {
     ).toBe(false);
   });
 });
+
+// ===========================================================================
+// Recent-trail action labeling — ingested vs re-ingested
+// ===========================================================================
+describe("recent trail action labeling", () => {
+  it("labels a first ingest 'ingested' and a re-ingest 're-ingested'", async () => {
+    const { getRecentIndex } = await import("../recent-index");
+    // Seed an empty-but-present index so the incremental push isn't a no-op.
+    await getStorage().putIndex("recent", []);
+
+    await writeWikiPageWithSideEffects(
+      makeOpts({ author: "alice", content: "# Test Page\n\nv1." }),
+    );
+    await writeWikiPageWithSideEffects(
+      makeOpts({ author: "alice", content: "# Test Page\n\nv2, re-ingested." }),
+    );
+
+    const idx = (await getRecentIndex()) ?? [];
+    const actions = idx
+      .filter((e) => e.slug === "test-page")
+      .map((e) => e.action);
+    expect(actions).toHaveLength(2);
+    expect(actions).toContain("ingested"); // the first ingest
+    expect(actions).toContain("re-ingested"); // the second (page already existed)
+  });
+});

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -462,7 +462,14 @@ async function runPageLifecycleOp(
           when: new Date(now).toISOString(),
           actor: op.author,
           isAgent: isAgentHandle(op.author),
-          action: logOp === "ingest" ? "ingested" : "edited",
+          // An ingest onto a page that already existed is a re-ingest — label
+          // it distinctly (prevContent is undefined only for a brand-new page).
+          action:
+            logOp === "ingest"
+              ? prevContent
+                ? "re-ingested"
+                : "ingested"
+              : "edited",
           ...(sourceType ? { sourceType } : {}),
           slug,
           title: op.title,

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -16,7 +16,7 @@ export interface TrailEvent {
   /** True when the actor is an autonomous agent (e.g. `yoyo`). */
   isAgent: boolean;
   /** What happened. */
-  action: "ingested" | "edited";
+  action: "ingested" | "re-ingested" | "edited";
   /** For ingests, the kind of source. */
   sourceType?: SourceEntry["type"];
   slug: string;


### PR DESCRIPTION
## Why
The trail labeled **every** ingest "ingested", so a page re-ingested several times showed three identical `@yuanhao ingested · Agentic Systems` rows. A re-ingest should read differently.

## What
An ingest onto a page that **already existed** is a re-ingest. The incremental recent-index push (`lifecycle.ts`) now labels it **"re-ingested"** — `prevContent` (captured before the overwrite) is `undefined` only for a brand-new page, so it's the exact create-vs-update signal. Added `"re-ingested"` to the `TrailEvent.action` union; the `Trail` component renders `e.action` verbatim, so no UI change is needed.

## Tests
- `lifecycle`: a first ingest pushes action `"ingested"`; a second ingest of the same slug pushes `"re-ingested"`.
- Full suite: **2745 passed**; `pnpm build` clean.

## Note
This fixes the incremental homepage trail (what's served). The daily `scanTrail` rebuild reconstructs events from `sources[]` (which keep one entry per URL) + revisions, so it's inherently lossier for re-ingest count — out of scope here.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)