### PR TITLE
Ingest: optional title for pasted text + hide batch-URLs mode

### DIFF
--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -90,14 +90,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(result);
     }
 
-    // Text path: require title + content
-    if (!title || typeof title !== "string" || title.trim().length === 0) {
-      return NextResponse.json(
-        { error: "title is required and must be a non-empty string (or provide a url)" },
-        { status: 400 },
-      );
-    }
-
+    // Text path: content is required; title is OPTIONAL — when omitted, ingest()
+    // derives it from the content (or the synthesized concept).
     if (
       !content ||
       typeof content !== "string" ||
@@ -108,8 +102,18 @@ export async function POST(request: NextRequest) {
         { status: 400 },
       );
     }
+    if (title !== undefined && typeof title !== "string") {
+      return NextResponse.json(
+        { error: "title must be a string if provided" },
+        { status: 400 },
+      );
+    }
 
-    const result = await ingest(title.trim(), content.trim(), options);
+    const result = await ingest(
+      typeof title === "string" ? title.trim() : "",
+      content.trim(),
+      options,
+    );
 
     return NextResponse.json(result);
   } catch (error) {

--- a/src/app/ingest/page.tsx
+++ b/src/app/ingest/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Alert } from "@/components/Alert";
-import { BatchIngestForm } from "@/components/BatchIngestForm";
 import { IngestSuccess } from "@/components/IngestSuccess";
 import { IngestReview } from "@/components/IngestReview";
 import { IngestStepper } from "@/components/IngestStepper";
@@ -15,7 +14,6 @@ const TABS: { mode: Mode; label: string }[] = [
   { mode: "xpost", label: "X post" },
   { mode: "text", label: "Paste text" },
   { mode: "image", label: "Image" },
-  { mode: "batch", label: "Batch URLs" },
 ];
 
 const FEATURES: [string, string][] = [
@@ -211,15 +209,15 @@ export default function IngestPage() {
             <form onSubmit={handleSourceSubmit} className="space-y-5">
               <div>
                 <label htmlFor="title" className="block text-sm font-medium mb-2">
-                  Title
+                  Title{" "}
+                  <span className="text-foreground/40">(optional)</span>
                 </label>
                 <input
                   id="title"
                   type="text"
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
-                  required
-                  placeholder="e.g. Transformer Architecture"
+                  placeholder="Leave blank to derive it from the content"
                   className="w-full rounded-lg border border-foreground/20 bg-transparent px-4 py-2.5 text-sm placeholder:text-foreground/40 focus:border-foreground/50 focus:outline-none transition-colors"
                 />
               </div>
@@ -361,9 +359,6 @@ export default function IngestPage() {
               </button>
             </form>
           )}
-
-          {/* Batch */}
-          {mode === "batch" && <BatchIngestForm />}
 
           {/* What ingestion guarantees */}
           <div

--- a/src/hooks/useIngest.ts
+++ b/src/hooks/useIngest.ts
@@ -71,11 +71,12 @@ export function validateIngestInput(
       return "Please enter a valid URL (e.g. https://example.com)";
     }
   } else {
-    if (!title.trim()) {
-      return "Please enter a title";
-    }
     if (!content.trim()) {
       return "Please enter some content";
+    }
+    // Pasted text derives its title from the content; image/PDF still want one.
+    if (mode !== "text" && !title.trim()) {
+      return "Please enter a title";
     }
   }
   return null;
@@ -158,7 +159,9 @@ export function useIngest(): UseIngestReturn {
         slug: data.primarySlug,
         previewContent: data.previewContent ?? "",
         relatedPages: data.relatedUpdated ?? [],
-        title: usesUrl ? data.preview?.title ?? data.primarySlug : title,
+        // Prefer the synthesized title (the concept) so a title-less paste
+        // shows the derived name on the review card and commits with it.
+        title: data.preview?.title ?? (usesUrl ? data.primarySlug : title),
         content: usesUrl ? "" : content,
         url: usesUrl ? url.trim() : undefined,
         meta: data.preview,

--- a/src/lib/__tests__/ingest-helpers.test.ts
+++ b/src/lib/__tests__/ingest-helpers.test.ts
@@ -63,8 +63,11 @@ describe("validateIngestInput", () => {
 
   // ── batch mode (falls through to text branch) ────────────────────────
 
-  it("batch mode without title → error (uses text branch)", () => {
-    expect(validateIngestInput("batch", "", "content", "")).toBe(
+  it("image/pdf mode without title → error (title still required there)", () => {
+    expect(validateIngestInput("image", "", "content", "")).toBe(
+      "Please enter a title",
+    );
+    expect(validateIngestInput("pdf", "", "content", "")).toBe(
       "Please enter a title",
     );
   });

--- a/src/lib/__tests__/ingest-helpers.test.ts
+++ b/src/lib/__tests__/ingest-helpers.test.ts
@@ -35,16 +35,12 @@ describe("validateIngestInput", () => {
 
   // ── Text mode ─────────────────────────────────────────────────────────
 
-  it("text mode with empty title → error", () => {
-    expect(validateIngestInput("text", "", "some content", "")).toBe(
-      "Please enter a title",
-    );
+  it("text mode with empty title → null (title is optional, derived from content)", () => {
+    expect(validateIngestInput("text", "", "some content", "")).toBeNull();
   });
 
-  it("text mode with whitespace-only title → error", () => {
-    expect(validateIngestInput("text", "   ", "some content", "")).toBe(
-      "Please enter a title",
-    );
+  it("text mode with whitespace-only title → null (title optional)", () => {
+    expect(validateIngestInput("text", "   ", "some content", "")).toBeNull();
   });
 
   it("text mode with empty content → error", () => {
@@ -73,11 +69,11 @@ describe("validateIngestInput", () => {
     );
   });
 
-  // ── title is checked before content ───────────────────────────────────
+  // ── text title is optional, so content is the blocking field ──────────
 
-  it("text mode with both empty → title error takes precedence", () => {
+  it("text mode with both empty → content error (title is optional)", () => {
     expect(validateIngestInput("text", "", "", "")).toBe(
-      "Please enter a title",
+      "Please enter some content",
     );
   });
 });

--- a/src/lib/__tests__/ingest-routes.test.ts
+++ b/src/lib/__tests__/ingest-routes.test.ts
@@ -79,6 +79,28 @@ const fakeResult: IngestResult = {
 // ===========================================================================
 // POST /api/ingest — error → HTTP status mapping
 // ===========================================================================
+describe("POST /api/ingest — text title optional", () => {
+  it("accepts a text ingest with no title (derived from content)", async () => {
+    mockedIngest.mockResolvedValue(fakeResult);
+    const res = await POST(
+      makeRequest("http://localhost/api/ingest", { content: "Some pasted content." }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedIngest).toHaveBeenCalledWith(
+      "",
+      "Some pasted content.",
+      expect.anything(),
+    );
+  });
+
+  it("still requires content", async () => {
+    const res = await POST(
+      makeRequest("http://localhost/api/ingest", { title: "Only a title" }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
 describe("POST /api/ingest — error status mapping", () => {
   it("maps a ClientInputError (e.g. deleted/private X post) to 400 + the message", async () => {
     mockedIngestUrl.mockRejectedValue(

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -136,6 +136,10 @@ describe("ingest — title derivation", () => {
     const result = await ingest("", "Distributed Systems\n\nSome content about consensus.");
     // First non-empty line becomes the provisional title (no LLM in this test).
     expect(result.primarySlug).toBe("distributed-systems");
+    // The written body must use the derived title, not an empty `# ` heading.
+    const page = await readWikiPageWithFrontmatter("distributed-systems");
+    expect(page!.content).toContain("# Distributed Systems");
+    expect(page!.content).not.toMatch(/^#\s*$/m);
   });
 
   it("derives from a markdown H1 when the title is empty", async () => {

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -12,6 +12,7 @@ import {
   parseConceptMarker,
   parseDisputedMarker,
   normalizeTags,
+  deriveTitleFromContent,
   collectTagVocabulary,
   computeConfidence,
   tokenizeSourceImages,
@@ -115,23 +116,36 @@ describe("slugify", () => {
 // ingest — empty slug guard
 // ---------------------------------------------------------------------------
 
-describe("ingest — empty slug guard", () => {
-  it('rejects empty title (slug would be "")', async () => {
-    await expect(ingest("", "some content")).rejects.toThrow(
-      /empty slug/,
-    );
+describe("deriveTitleFromContent", () => {
+  it("prefers a markdown H1", () => {
+    expect(deriveTitleFromContent("# My Heading\n\nbody")).toBe("My Heading");
+  });
+  it("falls back to the first non-empty line, markers stripped", () => {
+    expect(deriveTitleFromContent("\n\n- First bullet line\nmore")).toBe("First bullet line");
+  });
+  it("truncates at a sentence boundary", () => {
+    expect(deriveTitleFromContent("This is a sentence. And more.")).toBe("This is a sentence");
+  });
+  it("returns '' when there's no usable line", () => {
+    expect(deriveTitleFromContent("   \n  ###  ")).toBe("");
+  });
+});
+
+describe("ingest — title derivation", () => {
+  it("derives the title/slug from the content when the title is empty", async () => {
+    const result = await ingest("", "Distributed Systems\n\nSome content about consensus.");
+    // First non-empty line becomes the provisional title (no LLM in this test).
+    expect(result.primarySlug).toBe("distributed-systems");
   });
 
-  it("rejects title that produces empty slug after stripping special chars", async () => {
-    await expect(ingest("!!!", "some content")).rejects.toThrow(
-      /empty slug/,
-    );
+  it("derives from a markdown H1 when the title is empty", async () => {
+    const result = await ingest("", "# Vector Databases\n\nThey store embeddings.");
+    expect(result.primarySlug).toBe("vector-databases");
   });
 
-  it("rejects whitespace-only title", async () => {
-    await expect(ingest("   ", "some content")).rejects.toThrow(
-      /empty slug/,
-    );
+  it("throws only when neither a title nor content yields a usable slug", async () => {
+    await expect(ingest("!!!", "###  \n  ")).rejects.toThrow(/could be derived/);
+    await expect(ingest("   ", "   ")).rejects.toThrow(/could be derived/);
   });
 });
 

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -151,6 +151,47 @@ describe("ingest — title derivation", () => {
     await expect(ingest("!!!", "###  \n  ")).rejects.toThrow(/could be derived/);
     await expect(ingest("   ", "   ")).rejects.toThrow(/could be derived/);
   });
+
+  it("a title-less paste with an LLM CONCEPT lands on the concept slug + records the derived title as an alias", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    try {
+      mockedCallLLM.mockResolvedValue(
+        "CONCEPT: Vector Databases\nALIASES: none\n\n# Vector Databases\n\n## Summary\n\nThey store embeddings.",
+      );
+      const result = await ingest(
+        "",
+        "Vector search systems store embeddings for similarity.",
+      );
+      // Concept slug wins over the first-line-derived provisional slug.
+      expect(result.primarySlug).toBe("vector-databases");
+      const page = await readWikiPageWithFrontmatter("vector-databases");
+      const aliases = (page!.frontmatter.aliases ?? []) as string[];
+      // The derived provisional title becomes an alias; no empty string leaks.
+      expect(aliases).toContain(
+        "Vector search systems store embeddings for similarity",
+      );
+      expect(aliases).not.toContain("");
+    } finally {
+      mockedHasLLMKey.mockReturnValue(false);
+      mockedCallLLM.mockReset();
+    }
+  });
+
+  it("commit-from-preview for a title-less paste stays on the concept slug (no fork)", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    try {
+      // Commit a reviewed draft (generatedContent) with no title — the body H1
+      // drives the slug, not the empty/derived title.
+      const result = await ingest("", "some pasted content here.", {
+        generatedContent: "# Topic X\n\n## Summary\n\nApproved body.",
+      });
+      expect(result.primarySlug).toBe("topic-x");
+      expect(await readWikiPageWithFrontmatter("topic-x")).not.toBeNull();
+    } finally {
+      mockedHasLLMKey.mockReturnValue(false);
+      mockedCallLLM.mockReset();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -241,6 +241,26 @@ export async function ingestUrl(
   return ingest(title, content, { ...options, sourceUrl: url });
 }
 
+/**
+ * Provisional title for a title-less pasted-text ingest: the first markdown H1,
+ * else the first non-empty line (leading heading/list markers stripped), capped.
+ * Returns `""` only when the content has no usable line. The synthesis CONCEPT
+ * (or, on commit-from-preview, the body H1) overrides this for the final title.
+ */
+export function deriveTitleFromContent(content: string): string {
+  const h1 = content.match(/^#\s+(.+?)\s*$/m)?.[1]?.trim();
+  if (h1) return h1.slice(0, 120).trim();
+  const firstLine = content
+    .split("\n")
+    .map((l) => l.replace(/^[#>\-*\d.\s)]+/, "").trim())
+    .find((l) => l.length > 0);
+  if (!firstLine) return "";
+  let t = firstLine;
+  const end = t.search(/[.!?。！？]/);
+  if (end >= 8 && end < 100) t = t.slice(0, end);
+  return t.slice(0, 120).trim();
+}
+
 /** Derive a concise page title from the vision description's first meaningful
  *  line (e.g. a transcribed headline). Returns undefined if nothing usable. */
 function deriveImageTitle(visionText?: string): string | undefined {
@@ -1281,26 +1301,29 @@ export async function ingest(
   options?: IngestOptions,
 ): Promise<IngestResult> {
   const startedAt = new Date().toISOString();
-  const rawSlug = slugify(title);
+  // Title is optional for pasted text — derive a provisional one from the
+  // content (the synthesis CONCEPT/H1 still drives the final slug + title below).
+  const effectiveTitle = title.trim() || deriveTitleFromContent(content);
+  const rawSlug = slugify(effectiveTitle);
 
   if (rawSlug === "") {
     throw new Error(
-      "Cannot ingest: title produces an empty slug",
+      "Cannot ingest: no title was given and none could be derived from the content",
     );
   }
 
   // --- Alias resolution: check if title matches an existing page's aliases ---
   // This prevents duplicate pages when the same concept appears under different
   // names (e.g. "React.js" vs a page with aliases: ["React.js"]).
-  const resolvedSlug = await resolveAlias(title);
+  const resolvedSlug = await resolveAlias(effectiveTitle);
   // Provisional slug from the title. On the direct ingest path this is later
   // replaced by a content-derived *concept* slug (see the CONCEPT marker below),
   // so the same concept under different headlines converges onto one page.
   // `pinSlug` (re-ingest) overrides everything: stay on the known page.
   let slug = options?.pinSlug ?? resolvedSlug ?? rawSlug;
   // The page title written to the index/log. Becomes the canonical concept name
-  // when one is derived; otherwise stays the source title.
-  let pageTitle = title;
+  // when one is derived; otherwise stays the (derived) source title.
+  let pageTitle = effectiveTitle;
 
   const isPreview = options?.preview === true;
   const preGeneratedContent = options?.generatedContent;
@@ -1764,12 +1787,12 @@ export async function ingest(
   // under any of those names resolves here (extends convergence beyond the
   // content hash to the title/synonym routes). Merges with any existing
   // aliases; deduped case-insensitively; never aliases the concept to itself.
-  if (pageTitle !== title) {
+  if (pageTitle !== effectiveTitle) {
     const aliasList = Array.isArray(frontmatter.aliases)
       ? [...frontmatter.aliases]
       : [];
     const seen = new Set(aliasList.map((a) => a.toLowerCase()));
-    for (const candidate of [title, ...conceptAliases]) {
+    for (const candidate of [effectiveTitle, ...conceptAliases]) {
       const trimmed = candidate.trim();
       const key = trimmed.toLowerCase();
       if (trimmed === "" || key === pageTitle.toLowerCase() || seen.has(key)) {

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -1400,7 +1400,8 @@ export async function ingest(
     // Restore the kept [[IMG:n]] tokens to real refs (omitted ones are dropped).
     wikiContent = restoreImageTokens(wikiContent, imageRefs);
   } else {
-    wikiContent = generateFallbackPage(title, content);
+    // Use the derived title so a title-less paste doesn't emit an empty `# ` H1.
+    wikiContent = generateFallbackPage(effectiveTitle, content);
   }
 
   // Pull the leading `CONCEPT:` / `ALIASES:` header lines the synthesis prompt


### PR DESCRIPTION
## Why
1. For **pasted text**, requiring a title is redundant — the synthesis derives the title/concept from the content anyway.
2. **Batch URLs** adds UI complexity that isn't needed right now.

## What
**Optional title for pasted text:**
- Form: the title field is now **optional** ("Leave blank to derive it from the content"); `required` removed.
- `validateIngestInput`: text mode no longer requires a title (content is the blocking field); image/PDF still require one.
- `/api/ingest` text path: title is optional (validates type if present); passes `""` through when omitted.
- `ingest()`: new `deriveTitleFromContent` produces a provisional title (first markdown H1, else first non-empty line, capped) when none is given. The synthesis `CONCEPT` (or commit-from-preview body H1) still drives the **final** slug + title, so a title-less paste lands on a proper concept page. Throws only when neither a title nor the content yields a usable slug.
- `useIngest`: the review card prefers the **synthesized** title, so a title-less paste shows the derived name and commits with it.

**Hide Batch URLs:**
- Removed the "Batch URLs" tab + form from `/ingest` (and the now-unused import). The `/api/ingest/batch` route is **untouched** — this is a UI-only simplification.

## Tests
- `deriveTitleFromContent`: H1 preference, first-line fallback (markers stripped), sentence-boundary truncation, empty.
- `ingest`: derives slug/title from content (H1 + first line) when title empty; throws only when neither yields a usable slug.
- `validateIngestInput`: text with empty title → null; both empty → content error; image/PDF still require title.
- Route: text ingest with no title → 200 + `ingest("", content, …)`; still 400 without content.
- Full suite: **2756 passed**; `pnpm build` clean.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)