### PR TITLE
Rebalance confidence weights so a lone URL isn't 0.70

### DIFF
--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -470,8 +470,8 @@ describe("ingest — Phase 1 frontmatter fields", () => {
     const page = await readWikiPageWithFrontmatter("phase1-new");
     expect(page).not.toBeNull();
 
-    // Heuristic: a single text source → 0.55 (no longer a constant 0.7).
-    expect(page!.frontmatter.confidence).toBe(0.55);
+    // Heuristic: a single text source → 0.50 (no longer a constant 0.7).
+    expect(page!.frontmatter.confidence).toBe(0.5);
     expect(page!.frontmatter.disputed).toBe(false);
     expect(page!.frontmatter.authors).toEqual(["system"]);
     expect(page!.frontmatter.contributors).toEqual([]);
@@ -578,8 +578,8 @@ describe("ingest — Phase 1 frontmatter fields", () => {
     const page = await readWikiPageWithFrontmatter("phase1-lowconf");
     expect(page).not.toBeNull();
 
-    // Recomputed from the single text source (0.55) — not the manual 0.5.
-    expect(page!.frontmatter.confidence).toBe(0.55);
+    // Recomputed from the single text source (0.50) — not the manual 0.5.
+    expect(page!.frontmatter.confidence).toBe(0.5);
   });
 });
 
@@ -771,8 +771,8 @@ describe("ingest — structured sources[] provenance", () => {
     expect(sources).toHaveLength(2);
     expect(sources[0].url).toBe("https://example.com/a");
     expect(sources[1].url).toBe("https://example.com/b");
-    // Corroboration: a 2nd distinct source URL raises confidence (0.7 → 0.75).
-    expect(page!.frontmatter.confidence).toBe(0.75);
+    // Corroboration: a 2nd distinct source URL raises confidence (0.6 → 0.65).
+    expect(page!.frontmatter.confidence).toBe(0.65);
   });
 
   it("preview confidence matches what the commit writes (corroborating re-ingest)", async () => {
@@ -791,7 +791,7 @@ describe("ingest — structured sources[] provenance", () => {
       sourceUrl: "https://example.com/b",
     });
     const page = await readWikiPageWithFrontmatter("preview-conf");
-    expect(preview.preview!.confidence).toBe(0.75);
+    expect(preview.preview!.confidence).toBe(0.65);
     expect(page!.frontmatter.confidence).toBe(preview.preview!.confidence);
   });
 
@@ -1863,19 +1863,19 @@ describe("computeConfidence", () => {
   });
 
   it("scores by the strongest source type present", () => {
-    expect(computeConfidence([src("text", "text-paste")], false)).toBe(0.55);
-    expect(computeConfidence([src("url", "https://a.com")], false)).toBe(0.7);
-    expect(computeConfidence([src("pdf", "https://a.com/p.pdf")], false)).toBe(0.75);
+    expect(computeConfidence([src("text", "text-paste")], false)).toBe(0.5);
+    expect(computeConfidence([src("url", "https://a.com")], false)).toBe(0.6);
+    expect(computeConfidence([src("pdf", "https://a.com/p.pdf")], false)).toBe(0.68);
     // strongest type wins (same URL → no corroboration bonus)
     expect(
       computeConfidence([src("text", "https://a.com"), src("pdf", "https://a.com")], false),
-    ).toBe(0.75);
+    ).toBe(0.68);
   });
 
   it("adds corroboration for additional distinct source URLs (capped)", () => {
     expect(
       computeConfidence([src("url", "https://a.com"), src("url", "https://b.com")], false),
-    ).toBe(0.75); // 0.7 + 0.05
+    ).toBe(0.65); // 0.6 + 0.05
     expect(
       computeConfidence(
         [
@@ -1887,12 +1887,12 @@ describe("computeConfidence", () => {
         ],
         false,
       ),
-    ).toBe(0.85); // 0.7 + capped 0.15
+    ).toBe(0.75); // 0.6 + capped 0.15
   });
 
-  it("caps a disputed page at 0.5 and falls back to 0.6 for no sources", () => {
+  it("caps a disputed page at 0.5 and falls back to 0.5 for no sources", () => {
     expect(computeConfidence([src("pdf", "https://a.com/p.pdf")], true)).toBe(0.5);
-    expect(computeConfidence([], false)).toBe(0.6);
+    expect(computeConfidence([], false)).toBe(0.5);
   });
 });
 

--- a/src/lib/__tests__/x-mention-integration.test.ts
+++ b/src/lib/__tests__/x-mention-integration.test.ts
@@ -172,8 +172,8 @@ describe("X-mention integration", () => {
 
     // Authors defaults to ["system"] on new pages
     expect(page!.frontmatter.authors).toEqual(["system"]);
-    // Heuristic confidence for a single x-mention source → 0.55
-    expect(page!.frontmatter.confidence).toBe(0.55);
+    // Heuristic confidence for a single x-mention source → 0.50
+    expect(page!.frontmatter.confidence).toBe(0.5);
   });
 
   it("handles fetch failure (404) gracefully", async () => {

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -60,30 +60,31 @@ function mergeSourceEntry(sources: SourceEntry[], entry: SourceEntry): SourceEnt
  * documents/articles, lower for social/unverified provenance.
  */
 const SOURCE_TYPE_WEIGHT: Record<SourceEntry["type"], number> = {
-  pdf: 0.75,
-  "wiki-ref": 0.72,
-  url: 0.7,
-  youtube: 0.62,
-  image: 0.55,
-  text: 0.55,
-  "x-mention": 0.55,
+  pdf: 0.68,
+  "wiki-ref": 0.65,
+  url: 0.6,
+  youtube: 0.55,
+  image: 0.5,
+  text: 0.5,
+  "x-mention": 0.5,
 };
 
 /**
  * Heuristic page confidence from real provenance signals — replaces the old
- * constant 0.7:
+ * constant 0.7. A lone source sits BELOW 0.7 so corroboration can earn its way
+ * up (a single URL reads ~0.60, not the old default):
  *  - authority of the STRONGEST source type present,
  *  - corroboration: +0.05 per additional DISTINCT source URL (cap +0.15),
  *  - a `disputed` page is capped at 0.5.
- * Clamped to [0.3, 0.95], rounded to 2 decimals. An empty source set → 0.6.
+ * Clamped to [0.3, 0.95], rounded to 2 decimals. An empty source set → 0.5.
  */
 export function computeConfidence(
   sources: SourceEntry[],
   disputed: boolean,
 ): number {
-  if (sources.length === 0) return 0.6;
+  if (sources.length === 0) return 0.5;
   const base = Math.max(
-    ...sources.map((s) => SOURCE_TYPE_WEIGHT[s.type] ?? 0.6),
+    ...sources.map((s) => SOURCE_TYPE_WEIGHT[s.type] ?? 0.5),
   );
   const distinctUrls = new Set(sources.map((s) => s.url)).size;
   const corroboration = Math.min(0.15, Math.max(0, distinctUrls - 1) * 0.05);


### PR DESCRIPTION
## Why
After #466, confidence *is* signal-based — but a **single URL source scored exactly 0.70**, the same as the old hardcoded constant. Since most pages have one URL source, confidence *looked* unchanged ("why is everything 0.70 again?").

Validation of the live data confirmed the heuristic runs (text/x-mention pages read 0.55, agent pages 0.90), and that two pages at 0.70 were simply **stale** (ingested before #466 deployed). The real issue was purely that `url`'s base weight equalled the old default.

## What
Lowered the per-source-type base weights so a lone source sits **below 0.70**, leaving room for corroboration to raise it:

| type | was | now |
|---|---|---|
| pdf | 0.75 | **0.68** |
| wiki-ref | 0.72 | 0.65 |
| url | 0.70 | **0.60** |
| youtube | 0.62 | 0.55 |
| image / text / x-mention | 0.55 | **0.50** |
| empty / unknown | 0.6 | 0.50 |

So a typical single-URL page now reads **~0.60** (clearly different from the old constant), a PDF ~0.68, a multi-source page higher (+0.05 per additional distinct URL, cap +0.15), and a disputed page is still capped at 0.5. Corroboration and the disputed cap are unchanged.

## Tests
- `computeConfidence` unit tests updated to the new weights (single-type, corroboration cap, disputed, empty fallback).
- Integration tests updated (single text → 0.50, single x-mention → 0.50, 2-distinct-URL re-ingest → 0.65, preview==commit → 0.65).
- Full suite: **2750 passed**; `pnpm build` clean.

## Rollout note
Only **new / re-ingested** pages get the rebalanced score (it's computed at ingest). Existing pages keep their stored value until re-ingested.

**Not merged — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)