### PR TITLE
Browse: server-side hybrid search + pagination

### DIFF
--- a/src/app/api/wiki/browse/route.ts
+++ b/src/app/api/wiki/browse/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { getPrincipal } from "@/lib/auth";
+import { searchCommons, BROWSE_PAGE_SIZE, type BrowseSort } from "@/lib/browse";
+
+/**
+ * GET /api/wiki/browse?q=&scope=all&tag=&sort=recent&page=1&pageSize=30
+ *
+ * Server-side hybrid (BM25 + vector) search + pagination for the Browse surface.
+ * Public-readable: returns the commons by default; `principal` is resolved only
+ * to expand a `vault:<id>` scope to the viewer's readable pages. Private and
+ * agent-scoped pages can never appear (the pool is pre-filtered in searchCommons).
+ */
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const q = url.searchParams.get("q");
+  const scope = url.searchParams.get("scope") || "all";
+  const tag = url.searchParams.get("tag");
+  const sortParam = url.searchParams.get("sort");
+  const sort: BrowseSort =
+    sortParam === "confidence" || sortParam === "sources" ? sortParam : "recent";
+  const page = Math.max(1, Number.parseInt(url.searchParams.get("page") ?? "1", 10) || 1);
+  const pageSize = Math.min(
+    100,
+    Math.max(1, Number.parseInt(url.searchParams.get("pageSize") ?? "", 10) || BROWSE_PAGE_SIZE),
+  );
+
+  const principal = await getPrincipal();
+  const data = await searchCommons(q, { scope, tag, sort, page, pageSize, principal });
+  return NextResponse.json({ ...data, page, pageSize });
+}

--- a/src/app/api/wiki/browse/route.ts
+++ b/src/app/api/wiki/browse/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { getPrincipal } from "@/lib/auth";
-import { searchCommons, BROWSE_PAGE_SIZE, type BrowseSort } from "@/lib/browse";
+import {
+  searchCommons,
+  BROWSE_PAGE_SIZE,
+  type BrowseSort,
+  type BrowsePayload,
+} from "@/lib/browse";
 import { logger } from "@/lib/logger";
 
 /**
@@ -8,8 +13,10 @@ import { logger } from "@/lib/logger";
  *
  * Server-side hybrid (BM25 + vector) search + pagination for the Browse surface.
  * Public-readable: returns the commons by default; `principal` is resolved only
- * to expand a `vault:<id>` scope to the viewer's readable pages. Private and
- * agent-scoped pages can never appear (the pool is pre-filtered in searchCommons).
+ * to expand a `vault:<id>` scope to the viewer's readable pages. The pool is
+ * pre-filtered in searchCommons, so a search never surfaces another user's
+ * private page or any agent-scoped page (a `vault:<id>` scope may include the
+ * viewer's OWN private pages — visible only to them).
  */
 export async function GET(req: Request) {
   const url = new URL(req.url);
@@ -28,7 +35,8 @@ export async function GET(req: Request) {
   try {
     const principal = await getPrincipal();
     const data = await searchCommons(q, { scope, tag, sort, page, pageSize, principal });
-    return NextResponse.json({ ...data, page, pageSize });
+    const payload: BrowsePayload = { ...data, page, pageSize };
+    return NextResponse.json(payload);
   } catch (err) {
     // A failure here (KV read, auth context, vector store) must be traceable
     // with the request context — otherwise it surfaces as an opaque 500 that the

--- a/src/app/api/wiki/browse/route.ts
+++ b/src/app/api/wiki/browse/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getPrincipal } from "@/lib/auth";
 import { searchCommons, BROWSE_PAGE_SIZE, type BrowseSort } from "@/lib/browse";
+import { logger } from "@/lib/logger";
 
 /**
  * GET /api/wiki/browse?q=&scope=all&tag=&sort=recent&page=1&pageSize=30
@@ -24,7 +25,15 @@ export async function GET(req: Request) {
     Math.max(1, Number.parseInt(url.searchParams.get("pageSize") ?? "", 10) || BROWSE_PAGE_SIZE),
   );
 
-  const principal = await getPrincipal();
-  const data = await searchCommons(q, { scope, tag, sort, page, pageSize, principal });
-  return NextResponse.json({ ...data, page, pageSize });
+  try {
+    const principal = await getPrincipal();
+    const data = await searchCommons(q, { scope, tag, sort, page, pageSize, principal });
+    return NextResponse.json({ ...data, page, pageSize });
+  } catch (err) {
+    // A failure here (KV read, auth context, vector store) must be traceable
+    // with the request context — otherwise it surfaces as an opaque 500 that the
+    // client silently maps to "no change". Log it and return a real error status.
+    logger.error("browse", `searchCommons failed (scope=${scope} q=${q ?? ""} page=${page}):`, err);
+    return NextResponse.json({ error: "Browse search failed" }, { status: 500 });
+  }
 }

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -1,10 +1,6 @@
-import { listReadableWikiPages } from "@/lib/wiki";
-import { listCommonsPages } from "@/lib/commons";
-import type { IndexEntry } from "@/lib/types";
-import { getVault } from "@/lib/vault";
 import { listVaults } from "@/lib/vault";
-import { getDiscussionStatsForSlugs } from "@/lib/talk";
 import { getPrincipal } from "@/lib/auth";
+import { searchCommons, BROWSE_PAGE_SIZE } from "@/lib/browse";
 import { BrowseClient } from "@/components/BrowseClient";
 
 export default async function WikiIndex({
@@ -23,40 +19,24 @@ export default async function WikiIndex({
   // filter over public content, not access control. A `vault:<id>` scope is a
   // curated reference lens (public vaults only resolve via scope).
   const effectiveScope = scopeParam ?? "all";
-  const vaultId = effectiveScope.startsWith("vault:")
-    ? effectiveScope.slice("vault:".length)
-    : null;
 
   // The signed-in user's own vaults drive the lens pills (and the per-row Remove
   // when viewing one of their own vaults).
   const myVaults = myHandle ? await listVaults(myHandle) : [];
 
-  let pages: IndexEntry[];
-  if (vaultId) {
-    // Vault lens: a public vault's referenced commons pages, intersected with
-    // what the viewer may read. Private vaults never resolve via scope.
-    const vault = await getVault(vaultId);
-    if (!vault || vault.visibility !== "public") {
-      pages = [];
-    } else {
-      const refs = new Set(vault.slugs);
-      pages = (await listReadableWikiPages(principal)).filter((p) =>
-        refs.has(p.slug),
-      );
-    }
-  } else {
-    // "Public" scope = the public commons (read from the commons index).
-    pages = await listCommonsPages();
-  }
-
-  const slugs = pages.map((p) => p.slug);
-  const statsMap = await getDiscussionStatsForSlugs(slugs);
-  const discussionStats: Record<string, { total: number; open: number }> = {};
-  for (const [slug, stats] of statsMap) discussionStats[slug] = stats;
+  // First page, server-rendered (no query) — the client takes over from here,
+  // re-fetching `/api/wiki/browse` on every search / sort / tag / page change.
+  const initial = await searchCommons(null, {
+    scope: effectiveScope,
+    tag: tagParam ?? null,
+    sort: "recent",
+    page: 1,
+    pageSize: BROWSE_PAGE_SIZE,
+    principal,
+  });
 
   return (
     <BrowseClient
-      pages={pages}
       myHandle={myHandle}
       activeScope={effectiveScope}
       myVaults={myVaults.map((v) => ({
@@ -64,7 +44,11 @@ export default async function WikiIndex({
         name: v.name,
         visibility: v.visibility,
       }))}
-      discussionStats={discussionStats}
+      initialResults={initial.results}
+      initialTotal={initial.total}
+      initialTags={initial.tags}
+      initialDiscussionStats={initial.discussionStats}
+      pageSize={BROWSE_PAGE_SIZE}
       initialTag={tagParam ?? null}
     />
   );

--- a/src/components/BrowseClient.tsx
+++ b/src/components/BrowseClient.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import type { IndexEntry } from "@/lib/types";
+import type { BrowsePayload, DiscussionStats, TagFacet } from "@/lib/browse";
 import { formatRelativeTime } from "@/lib/format";
 import { commonsPath, pagePath, ownerToTenant } from "@/lib/links";
 import { Icon } from "@/components/folio/icons";
@@ -17,8 +18,6 @@ interface VaultLite {
   visibility: "public" | "private";
 }
 
-type DiscussionStats = Record<string, { total: number; open: number }>;
-
 interface BrowseClientProps {
   myHandle: string | null;
   /** The active lens scope: `"all"` (Public) or `"vault:<id>"`. */
@@ -30,7 +29,7 @@ interface BrowseClientProps {
   /** Total matches for the initial (unsearched) scope — drives pagination. */
   initialTotal: number;
   /** Tag facets across the whole scope pool, by count desc (stable rail). */
-  initialTags: [string, number][];
+  initialTags: TagFacet[];
   initialDiscussionStats: DiscussionStats;
   pageSize: number;
   /** Initial tag filter (from `?tag=` — e.g. a tag chip on an article). */
@@ -264,7 +263,11 @@ export function BrowseClient({
     params.set("page", String(page));
     params.set("pageSize", String(pageSize));
     fetch(`/api/wiki/browse?${params.toString()}`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then((r) =>
+        r.ok
+          ? (r.json() as Promise<BrowsePayload>)
+          : Promise.reject(new Error(`HTTP ${r.status}`)),
+      )
       .then((data) => {
         if (!active) return;
         setResults(data.results ?? []);

--- a/src/components/BrowseClient.tsx
+++ b/src/components/BrowseClient.tsx
@@ -231,6 +231,10 @@ export function BrowseClient({
   const [total, setTotal] = useState(initialTotal);
   const [discussionStats, setDiscussionStats] = useState(initialDiscussionStats);
   const [loading, setLoading] = useState(false);
+  const [fetchError, setFetchError] = useState(false);
+  // Bumped to force the fetch effect to re-run on a manual "Retry" without
+  // otherwise changing the query/sort/tag/page inputs.
+  const [retryTick, setRetryTick] = useState(0);
 
   const searching = debouncedQ.trim().length > 0;
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
@@ -260,15 +264,18 @@ export function BrowseClient({
     params.set("page", String(page));
     params.set("pageSize", String(pageSize));
     fetch(`/api/wiki/browse?${params.toString()}`)
-      .then((r) => (r.ok ? r.json() : null))
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((data) => {
-        if (!active || !data) return;
+        if (!active) return;
         setResults(data.results ?? []);
         setTotal(data.total ?? 0);
         setDiscussionStats(data.discussionStats ?? {});
+        setFetchError(false);
       })
       .catch(() => {
-        /* transient fetch error — keep the last results rather than blanking */
+        // Keep the last results rather than blanking, but surface the failure so
+        // a persistent outage doesn't masquerade as "no change".
+        if (active) setFetchError(true);
       })
       .finally(() => {
         if (active) setLoading(false);
@@ -276,7 +283,7 @@ export function BrowseClient({
     return () => {
       active = false;
     };
-  }, [debouncedQ, sort, tag, page, activeScope, pageSize]);
+  }, [debouncedQ, sort, tag, page, activeScope, pageSize, retryTick]);
 
   // A filter change always returns to page 1 — reset imperatively (alongside the
   // change) so a fetch never fires with a stale page number.
@@ -495,6 +502,42 @@ export function BrowseClient({
 
         {/* Results */}
         <div>
+          {fetchError && (
+            <div
+              className="row"
+              style={{
+                gap: 12,
+                alignItems: "center",
+                justifyContent: "space-between",
+                marginBottom: 14,
+                padding: "10px 14px",
+                borderRadius: 10,
+                border: "1px solid var(--rust)",
+                background: "var(--rust-soft)",
+              }}
+            >
+              <span style={{ fontSize: 13, color: "var(--rust)" }}>
+                Couldn&apos;t refresh results — showing the last set.
+              </span>
+              <button
+                type="button"
+                onClick={() => setRetryTick((t) => t + 1)}
+                disabled={loading}
+                className="receipt"
+                style={{
+                  fontSize: 12.5,
+                  padding: "4px 12px",
+                  borderRadius: 999,
+                  border: "1px solid var(--rust)",
+                  background: "transparent",
+                  color: "var(--rust)",
+                  cursor: loading ? "default" : "pointer",
+                }}
+              >
+                Retry
+              </button>
+            </div>
+          )}
           {tag && (
             <div
               className="row"

--- a/src/components/BrowseClient.tsx
+++ b/src/components/BrowseClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { IndexEntry } from "@/lib/types";
 import { formatRelativeTime } from "@/lib/format";
 import { commonsPath, pagePath, ownerToTenant } from "@/lib/links";
@@ -17,14 +17,22 @@ interface VaultLite {
   visibility: "public" | "private";
 }
 
+type DiscussionStats = Record<string, { total: number; open: number }>;
+
 interface BrowseClientProps {
-  pages: IndexEntry[];
   myHandle: string | null;
   /** The active lens scope: `"all"` (Public) or `"vault:<id>"`. */
   activeScope: string;
   /** The signed-in user's own vaults — one lens pill each. */
   myVaults: VaultLite[];
-  discussionStats?: Record<string, { total: number; open: number }>;
+  /** First page (server-rendered, no query) — the client re-fetches from here. */
+  initialResults: IndexEntry[];
+  /** Total matches for the initial (unsearched) scope — drives pagination. */
+  initialTotal: number;
+  /** Tag facets across the whole scope pool, by count desc (stable rail). */
+  initialTags: [string, number][];
+  initialDiscussionStats: DiscussionStats;
+  pageSize: number;
   /** Initial tag filter (from `?tag=` — e.g. a tag chip on an article). */
   initialTag?: string | null;
 }
@@ -44,9 +52,9 @@ function PageRow({
   const agentOwned = !!owner && owner.includes("--");
   const rel = page.updated ? formatRelativeTime(page.updated) : null;
   const openCount = discussion?.open ?? 0;
-  // The "Mine" lens can include the viewer's PRIVATE pages — those have no
-  // global URL (and `/wiki/<slug>` 404s them), so only PUBLIC commons pages link
-  // to the global `/wiki/<slug>`; private/agent pages stay owner-scoped.
+  // The vault lens can include the viewer's PRIVATE pages — those have no global
+  // URL (and `/wiki/<slug>` 404s them), so only PUBLIC commons pages link to the
+  // global `/wiki/<slug>`; private/agent pages stay owner-scoped.
   const isCommons =
     page.visibility !== "private" && !page.type?.startsWith("agent-");
   const href = isCommons
@@ -152,14 +160,16 @@ function FilterRow({
   options,
   value,
   onChange,
+  disabled,
 }: {
   label: string;
   options: { id: Sort; label: string }[];
   value: Sort;
   onChange: (v: Sort) => void;
+  disabled?: boolean;
 }) {
   return (
-    <div className="stack" style={{ gap: 9 }}>
+    <div className="stack" style={{ gap: 9, opacity: disabled ? 0.45 : 1 }}>
       <span className="fmark">{label}</span>
       <div className="row" style={{ gap: 6, flexWrap: "wrap" }}>
         {options.map((o) => {
@@ -167,6 +177,7 @@ function FilterRow({
           return (
             <button
               key={o.id}
+              disabled={disabled}
               onClick={() => onChange(o.id)}
               style={{
                 fontSize: 13,
@@ -174,6 +185,7 @@ function FilterRow({
                 borderRadius: 999,
                 transition: "all .15s",
                 whiteSpace: "nowrap",
+                cursor: disabled ? "not-allowed" : "pointer",
                 border: `1px solid ${active ? "var(--ink)" : "var(--rule)"}`,
                 background: active ? "var(--ink)" : "transparent",
                 color: active ? "var(--paper)" : "var(--ink-2)",
@@ -189,11 +201,14 @@ function FilterRow({
 }
 
 export function BrowseClient({
-  pages,
   myHandle,
   activeScope,
   myVaults,
-  discussionStats,
+  initialResults,
+  initialTotal,
+  initialTags,
+  initialDiscussionStats,
+  pageSize,
   initialTag,
 }: BrowseClientProps) {
   // The active vault id (if the lens is a vault scope) and whether it's one of
@@ -207,43 +222,85 @@ export function BrowseClient({
   const ownVaultLens = activeVault ?? null;
 
   const [q, setQ] = useState("");
+  const [debouncedQ, setDebouncedQ] = useState("");
   const [sort, setSort] = useState<Sort>("recent");
   const [tag, setTag] = useState<string | null>(initialTag ?? null);
+  const [page, setPage] = useState(1);
 
-  const allTags = useMemo(() => {
-    const f = new Map<string, number>();
-    for (const p of pages) for (const t of p.tags ?? []) f.set(t, (f.get(t) ?? 0) + 1);
-    return [...f.entries()].sort((a, b) => b[1] - a[1]);
-  }, [pages]);
+  const [results, setResults] = useState(initialResults);
+  const [total, setTotal] = useState(initialTotal);
+  const [discussionStats, setDiscussionStats] = useState(initialDiscussionStats);
+  const [loading, setLoading] = useState(false);
 
-  const filtered = useMemo(() => {
-    const needle = q.trim().toLowerCase();
-    const r = pages.filter((p) => {
-      if (
-        needle &&
-        !`${p.title} ${p.summary} ${(p.tags ?? []).join(" ")}`
-          .toLowerCase()
-          .includes(needle)
-      )
-        return false;
-      if (tag && !(p.tags ?? []).includes(tag)) return false;
-      return true;
-    });
-    r.sort((a, b) =>
-      sort === "confidence"
-        ? (b.confidence ?? 0) - (a.confidence ?? 0)
-        : sort === "sources"
-          ? (b.sourceCount ?? 0) - (a.sourceCount ?? 0)
-          : (b.updated ?? "").localeCompare(a.updated ?? ""),
-    );
-    return r;
-  }, [pages, q, sort, tag]);
+  const searching = debouncedQ.trim().length > 0;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  // Debounce the search box so we fetch on a settled query, not per keystroke.
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQ(q), 300);
+    return () => clearTimeout(id);
+  }, [q]);
+
+  // Server-driven results: re-fetch whenever the query/sort/tag/page changes.
+  // Skip the very first run — the server already rendered page 1 (with any
+  // `?tag=`) into `initialResults`, so re-fetching it on mount would only flash.
+  const firstRun = useRef(true);
+  useEffect(() => {
+    if (firstRun.current) {
+      firstRun.current = false;
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (debouncedQ.trim()) params.set("q", debouncedQ.trim());
+    params.set("scope", activeScope);
+    if (tag) params.set("tag", tag);
+    params.set("sort", sort);
+    params.set("page", String(page));
+    params.set("pageSize", String(pageSize));
+    fetch(`/api/wiki/browse?${params.toString()}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!active || !data) return;
+        setResults(data.results ?? []);
+        setTotal(data.total ?? 0);
+        setDiscussionStats(data.discussionStats ?? {});
+      })
+      .catch(() => {
+        /* transient fetch error — keep the last results rather than blanking */
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [debouncedQ, sort, tag, page, activeScope, pageSize]);
+
+  // A filter change always returns to page 1 — reset imperatively (alongside the
+  // change) so a fetch never fires with a stale page number.
+  const onSearchChange = (v: string) => {
+    setQ(v);
+    setPage(1);
+  };
+  const onSortChange = (v: Sort) => {
+    setSort(v);
+    setPage(1);
+  };
+  const onTagChange = (v: string | null) => {
+    setTag(v);
+    setPage(1);
+  };
 
   // Lens links switch the Public/vault scope only (a server navigation that
-  // re-fetches the page set). The active topic is local UI state, so it
+  // re-renders with a fresh page set). The active topic is local UI state, so it
   // intentionally resets when the scope changes.
   const lensHref = (scope: string) =>
     `/wiki?scope=${encodeURIComponent(scope)}`;
+
+  const from = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const to = Math.min(page * pageSize, total);
 
   return (
     <div className="fade">
@@ -278,10 +335,8 @@ export function BrowseClient({
               whiteSpace: "nowrap",
             }}
           >
-            <span style={{ color: "var(--ink)", fontSize: 15 }}>
-              {filtered.length}
-            </span>{" "}
-            of {pages.length} pages
+            <span style={{ color: "var(--ink)", fontSize: 15 }}>{total}</span>{" "}
+            {searching ? (total === 1 ? "result" : "results") : "pages"}
           </p>
         </div>
 
@@ -302,8 +357,8 @@ export function BrowseClient({
           </span>
           <input
             value={q}
-            onChange={(e) => setQ(e.target.value)}
-            placeholder="Search titles, summaries, topics…"
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search the commons — by meaning or keyword…"
             style={{
               flex: 1,
               border: 0,
@@ -313,9 +368,17 @@ export function BrowseClient({
               color: "var(--ink)",
             }}
           />
+          {loading && (
+            <span
+              className="receipt"
+              style={{ fontSize: 11.5, color: "var(--faint)", whiteSpace: "nowrap" }}
+            >
+              searching…
+            </span>
+          )}
           {q && (
             <button
-              onClick={() => setQ("")}
+              onClick={() => onSearchChange("")}
               className="receipt"
               style={{
                 background: "transparent",
@@ -378,27 +441,38 @@ export function BrowseClient({
             </div>
           )}
 
-          <FilterRow
-            label="sort by"
-            value={sort}
-            onChange={setSort}
-            options={[
-              { id: "recent", label: "Recent" },
-              { id: "confidence", label: "Confidence" },
-              { id: "sources", label: "Sources" },
-            ]}
-          />
+          <div className="stack" style={{ gap: 6 }}>
+            <FilterRow
+              label="sort by"
+              value={sort}
+              onChange={onSortChange}
+              disabled={searching}
+              options={[
+                { id: "recent", label: "Recent" },
+                { id: "confidence", label: "Confidence" },
+                { id: "sources", label: "Sources" },
+              ]}
+            />
+            {searching && (
+              <span
+                className="receipt"
+                style={{ fontSize: 11, color: "var(--faint)" }}
+              >
+                ranked by relevance
+              </span>
+            )}
+          </div>
 
-          {allTags.length > 0 && (
+          {initialTags.length > 0 && (
             <div className="stack" style={{ gap: 9 }}>
               <span className="fmark">topics</span>
               <div className="row" style={{ gap: 7, flexWrap: "wrap" }}>
-                {allTags.map(([t, n]) => {
+                {initialTags.map(([t, n]) => {
                   const active = tag === t;
                   return (
                     <button
                       key={t}
-                      onClick={() => setTag(active ? null : t)}
+                      onClick={() => onTagChange(active ? null : t)}
                       className="receipt"
                       style={{
                         fontSize: 11.5,
@@ -437,7 +511,7 @@ export function BrowseClient({
               </span>
               <button
                 type="button"
-                onClick={() => setTag(null)}
+                onClick={() => onTagChange(null)}
                 className="receipt"
                 style={{
                   fontSize: 12,
@@ -452,7 +526,7 @@ export function BrowseClient({
               </button>
             </div>
           )}
-          {filtered.length === 0 ? (
+          {results.length === 0 ? (
             <div style={{ padding: "60px 0", textAlign: "center" }}>
               <p style={{ fontSize: 22, color: "var(--ink-2)" }}>
                 Nothing in the commons matches.
@@ -473,23 +547,82 @@ export function BrowseClient({
               </p>
             </div>
           ) : (
-            <ul
-              style={{
-                listStyle: "none",
-                margin: 0,
-                padding: 0,
-                borderTop: "1px solid var(--rule)",
-              }}
-            >
-              {filtered.map((p) => (
-                <PageRow
-                  key={p.slug}
-                  page={p}
-                  discussion={discussionStats?.[p.slug]}
-                  removeVaultId={ownVaultLens ? ownVaultLens.id : undefined}
-                />
-              ))}
-            </ul>
+            <>
+              <ul
+                style={{
+                  listStyle: "none",
+                  margin: 0,
+                  padding: 0,
+                  borderTop: "1px solid var(--rule)",
+                  opacity: loading ? 0.55 : 1,
+                  transition: "opacity .15s",
+                }}
+              >
+                {results.map((p) => (
+                  <PageRow
+                    key={p.slug}
+                    page={p}
+                    discussion={discussionStats?.[p.slug]}
+                    removeVaultId={ownVaultLens ? ownVaultLens.id : undefined}
+                  />
+                ))}
+              </ul>
+
+              {totalPages > 1 && (
+                <div
+                  className="row"
+                  style={{
+                    gap: 16,
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    paddingTop: 26,
+                    marginTop: 8,
+                    borderTop: "1px solid var(--rule)",
+                  }}
+                >
+                  <button
+                    type="button"
+                    disabled={page <= 1 || loading}
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    className="receipt"
+                    style={{
+                      fontSize: 13,
+                      padding: "6px 14px",
+                      borderRadius: 999,
+                      border: "1px solid var(--rule)",
+                      background: "transparent",
+                      color: page <= 1 ? "var(--faint)" : "var(--ink-2)",
+                      cursor: page <= 1 ? "default" : "pointer",
+                    }}
+                  >
+                    ← Prev
+                  </button>
+                  <span
+                    className="receipt"
+                    style={{ fontSize: 12.5, color: "var(--muted)" }}
+                  >
+                    {from}–{to} of {total} · page {page} of {totalPages}
+                  </span>
+                  <button
+                    type="button"
+                    disabled={page >= totalPages || loading}
+                    onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                    className="receipt"
+                    style={{
+                      fontSize: 13,
+                      padding: "6px 14px",
+                      borderRadius: 999,
+                      border: "1px solid var(--rule)",
+                      background: "transparent",
+                      color: page >= totalPages ? "var(--faint)" : "var(--ink-2)",
+                      cursor: page >= totalPages ? "default" : "pointer",
+                    }}
+                  >
+                    Next →
+                  </button>
+                </div>
+              )}
+            </>
           )}
         </div>
       </section>

--- a/src/lib/__tests__/browse-route.test.ts
+++ b/src/lib/__tests__/browse-route.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the browse library — we only test the route's param parsing + wiring.
+vi.mock("@/lib/browse", async () => {
+  const actual = await vi.importActual<typeof import("../browse")>("../browse");
+  return {
+    ...actual, // keep the real BROWSE_PAGE_SIZE constant + types
+    searchCommons: vi.fn(async () => ({
+      results: [],
+      total: 0,
+      discussionStats: {},
+      tags: [],
+    })),
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  getPrincipal: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+import { searchCommons, BROWSE_PAGE_SIZE } from "../browse";
+import { logger } from "../logger";
+import { GET } from "@/app/api/wiki/browse/route";
+
+const mockedSearch = vi.mocked(searchCommons);
+
+function call(query: string) {
+  return GET(new Request(`http://localhost/api/wiki/browse${query}`));
+}
+
+/** Return the options object the route passed to searchCommons. */
+function lastOpts() {
+  return mockedSearch.mock.calls[mockedSearch.mock.calls.length - 1][1]!;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedSearch.mockResolvedValue({
+    results: [],
+    total: 0,
+    discussionStats: {},
+    tags: [],
+  });
+});
+
+describe("GET /api/wiki/browse — param parsing", () => {
+  it("passes the query and defaults scope/sort/page", async () => {
+    await call("?q=transformers");
+    expect(mockedSearch).toHaveBeenCalledWith("transformers", expect.anything());
+    const opts = lastOpts();
+    expect(opts.scope).toBe("all");
+    expect(opts.sort).toBe("recent");
+    expect(opts.page).toBe(1);
+    expect(opts.pageSize).toBe(BROWSE_PAGE_SIZE);
+  });
+
+  it("falls back to 'recent' for an unknown sort, passes valid ones through", async () => {
+    await call("?sort=garbage");
+    expect(lastOpts().sort).toBe("recent");
+    await call("?sort=confidence");
+    expect(lastOpts().sort).toBe("confidence");
+    await call("?sort=sources");
+    expect(lastOpts().sort).toBe("sources");
+  });
+
+  it("parses + clamps page (NaN→1, negative→1)", async () => {
+    await call("?page=abc");
+    expect(lastOpts().page).toBe(1);
+    await call("?page=-5");
+    expect(lastOpts().page).toBe(1);
+    await call("?page=3");
+    expect(lastOpts().page).toBe(3);
+  });
+
+  it("parses + clamps pageSize (over-max→100, missing→default)", async () => {
+    await call("?pageSize=9999");
+    expect(lastOpts().pageSize).toBe(100);
+    await call("?pageSize=10");
+    expect(lastOpts().pageSize).toBe(10);
+    await call("");
+    expect(lastOpts().pageSize).toBe(BROWSE_PAGE_SIZE);
+  });
+
+  it("forwards scope and tag", async () => {
+    await call("?scope=vault:v1&tag=ml");
+    const opts = lastOpts();
+    expect(opts.scope).toBe("vault:v1");
+    expect(opts.tag).toBe("ml");
+  });
+
+  it("echoes page + pageSize back in the payload", async () => {
+    const res = await call("?page=2&pageSize=5");
+    const body = await res.json();
+    expect(body).toMatchObject({ page: 2, pageSize: 5, total: 0, results: [] });
+  });
+});
+
+describe("GET /api/wiki/browse — error path", () => {
+  it("logs with request context and returns 500 when searchCommons throws", async () => {
+    mockedSearch.mockRejectedValue(new Error("KV down"));
+    const res = await call("?q=boom&scope=all&page=1");
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Browse search failed" });
+    expect(logger.error).toHaveBeenCalled();
+    const msg = vi.mocked(logger.error).mock.calls[0].join(" ");
+    expect(msg).toContain("boom"); // the query is in the logged context
+  });
+});

--- a/src/lib/__tests__/browse.test.ts
+++ b/src/lib/__tests__/browse.test.ts
@@ -150,6 +150,18 @@ describe("searchCommons — pagination", () => {
     const p2 = await searchCommons(null, { sort: "recent", page: 2, pageSize: 2 });
     expect(p2.results.map((p) => p.slug)).toEqual(["backpropagation"]);
   });
+
+  it("returns an empty slice but the true total for a page beyond the end", async () => {
+    const r = await searchCommons(null, { page: 99, pageSize: 2 });
+    expect(r.results).toEqual([]);
+    expect(r.total).toBe(3);
+  });
+
+  it("handles an empty pool without throwing", async () => {
+    mockedCommons.mockResolvedValue([]);
+    const r = await searchCommons("anything", {});
+    expect(r).toMatchObject({ results: [], total: 0, tags: [] });
+  });
 });
 
 describe("searchCommons — vault scope", () => {

--- a/src/lib/__tests__/browse.test.ts
+++ b/src/lib/__tests__/browse.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { IndexEntry } from "../types";
+
+// Mock only the data SOURCES — BM25, RRF and the constants stay real, so these
+// tests exercise the actual hybrid ranking + pagination logic in searchCommons.
+vi.mock("../commons", () => ({
+  listCommonsPages: vi.fn(async () => [] as IndexEntry[]),
+}));
+vi.mock("../wiki", () => ({
+  listReadableWikiPages: vi.fn(async () => [] as IndexEntry[]),
+  // Agent pages are `type: agent-*` — mirror the real predicate.
+  isAgentScopedType: (t?: string) => !!t && t.startsWith("agent-"),
+}));
+vi.mock("../vault", () => ({
+  getVault: vi.fn(async () => null),
+}));
+vi.mock("../talk", () => ({
+  getDiscussionStatsForSlugs: vi.fn(async () => new Map()),
+}));
+vi.mock("../embeddings", () => ({
+  searchByVector: vi.fn(async () => [] as Array<{ slug: string; score: number }>),
+}));
+
+import { searchCommons } from "../browse";
+import { listCommonsPages } from "../commons";
+import { listReadableWikiPages } from "../wiki";
+import { getVault } from "../vault";
+import { searchByVector } from "../embeddings";
+
+const mockedCommons = vi.mocked(listCommonsPages);
+const mockedReadable = vi.mocked(listReadableWikiPages);
+const mockedGetVault = vi.mocked(getVault);
+const mockedVector = vi.mocked(searchByVector);
+
+function entry(slug: string, over: Partial<IndexEntry> = {}): IndexEntry {
+  return {
+    slug,
+    title: slug,
+    summary: "",
+    owner: "alice",
+    ...over,
+  } as IndexEntry;
+}
+
+const POOL: IndexEntry[] = [
+  entry("backpropagation", {
+    title: "Backpropagation",
+    summary: "Training neural networks by gradient descent.",
+    tags: ["ml", "training"],
+    confidence: 0.9,
+    sourceCount: 3,
+    updated: "2026-06-01",
+  }),
+  entry("transformers", {
+    title: "Transformers",
+    summary: "Attention-based sequence models.",
+    tags: ["ml", "nlp"],
+    confidence: 0.7,
+    sourceCount: 5,
+    updated: "2026-06-05",
+  }),
+  entry("vector-databases", {
+    title: "Vector Databases",
+    summary: "Storage for embeddings and similarity search.",
+    tags: ["infra"],
+    confidence: 0.6,
+    sourceCount: 1,
+    updated: "2026-06-03",
+  }),
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedCommons.mockResolvedValue(POOL);
+  mockedReadable.mockResolvedValue([]);
+  mockedGetVault.mockResolvedValue(null);
+  mockedVector.mockResolvedValue([]);
+});
+
+describe("searchCommons — list mode (no query)", () => {
+  it("returns the whole commons sorted by recent, with a stable total", async () => {
+    const r = await searchCommons(null, { sort: "recent" });
+    expect(r.total).toBe(3);
+    expect(r.results.map((p) => p.slug)).toEqual([
+      "transformers", // 2026-06-05
+      "vector-databases", // 2026-06-03
+      "backpropagation", // 2026-06-01
+    ]);
+  });
+
+  it("sorts by confidence and by sources", async () => {
+    const byConf = await searchCommons(null, { sort: "confidence" });
+    expect(byConf.results[0].slug).toBe("backpropagation"); // 0.9
+    const bySrc = await searchCommons(null, { sort: "sources" });
+    expect(bySrc.results[0].slug).toBe("transformers"); // 5
+  });
+
+  it("exposes tag facets across the full pool, by count desc", async () => {
+    const r = await searchCommons(null, {});
+    expect(r.tags).toEqual([
+      ["ml", 2],
+      ["training", 1],
+      ["nlp", 1],
+      ["infra", 1],
+    ]);
+  });
+
+  it("filters by tag but keeps the facet counts from the unfiltered pool", async () => {
+    const r = await searchCommons(null, { tag: "infra" });
+    expect(r.results.map((p) => p.slug)).toEqual(["vector-databases"]);
+    expect(r.total).toBe(1);
+    // Facets still reflect the whole pool so the rail doesn't collapse.
+    expect(r.tags.find(([t]) => t === "ml")).toEqual(["ml", 2]);
+  });
+});
+
+describe("searchCommons — query mode (hybrid)", () => {
+  it("ranks BM25 keyword matches and drops non-matches", async () => {
+    const r = await searchCommons("attention sequence", {});
+    expect(r.results[0].slug).toBe("transformers");
+    expect(r.results.map((p) => p.slug)).not.toContain("backpropagation");
+  });
+
+  it("surfaces a semantic-only match via vector fusion (no keyword overlap)", async () => {
+    // "embeddings" doesn't keyword-match the query, but the vector store says
+    // vector-databases is semantically closest — hybrid must surface it.
+    mockedVector.mockResolvedValue([{ slug: "vector-databases", score: 0.95 }]);
+    const r = await searchCommons("similarity storage", {});
+    expect(r.results.map((p) => p.slug)).toContain("vector-databases");
+  });
+
+  it("falls back to BM25 ranking when vector search throws", async () => {
+    mockedVector.mockRejectedValue(new Error("no embedding provider"));
+    const r = await searchCommons("neural networks", {});
+    expect(r.results[0].slug).toBe("backpropagation");
+  });
+
+  it("ignores the sort facet when a query is present (relevance order wins)", async () => {
+    // "sources" sort would put transformers first; the query targets backprop.
+    const r = await searchCommons("gradient descent", { sort: "sources" });
+    expect(r.results[0].slug).toBe("backpropagation");
+  });
+});
+
+describe("searchCommons — pagination", () => {
+  it("slices to the requested page and reports the full total", async () => {
+    const p1 = await searchCommons(null, { sort: "recent", page: 1, pageSize: 2 });
+    expect(p1.total).toBe(3);
+    expect(p1.results.map((p) => p.slug)).toEqual(["transformers", "vector-databases"]);
+    const p2 = await searchCommons(null, { sort: "recent", page: 2, pageSize: 2 });
+    expect(p2.results.map((p) => p.slug)).toEqual(["backpropagation"]);
+  });
+});
+
+describe("searchCommons — vault scope", () => {
+  it("returns nothing for a private (non-resolving) vault", async () => {
+    mockedGetVault.mockResolvedValue({
+      id: "v1",
+      visibility: "private",
+      slugs: ["transformers"],
+    } as never);
+    const r = await searchCommons(null, { scope: "vault:v1" });
+    expect(r.total).toBe(0);
+    expect(r.results).toEqual([]);
+  });
+
+  it("intersects a public vault's refs with readable pages and excludes agent pages", async () => {
+    mockedGetVault.mockResolvedValue({
+      id: "v1",
+      visibility: "public",
+      slugs: ["transformers", "agent-note"],
+    } as never);
+    mockedReadable.mockResolvedValue([
+      entry("transformers", { title: "Transformers", updated: "2026-06-05" }),
+      entry("agent-note", { type: "agent-knowledge", updated: "2026-06-06" }),
+      entry("unreferenced", { updated: "2026-06-07" }),
+    ]);
+    const r = await searchCommons(null, { scope: "vault:v1" });
+    // Only the referenced, non-agent page survives.
+    expect(r.results.map((p) => p.slug)).toEqual(["transformers"]);
+  });
+});

--- a/src/lib/browse.ts
+++ b/src/lib/browse.ts
@@ -1,0 +1,170 @@
+/**
+ * Server-side browse search for the `/wiki` (Browse the commons) surface.
+ *
+ * Replaces the old client-side substring filter, which only worked because the
+ * page shipped the ENTIRE commons to the browser. That breaks the moment the
+ * commons is paginated (the client would only ever search the page it holds).
+ * Here the whole scope pool is ranked on the server: a HYBRID of BM25 (exact
+ * keyword/title) fused with bge-m3 vector similarity (semantic) via RRF when a
+ * query is present, or a plain facet sort when it isn't — then paginated.
+ *
+ * The vector store is global; every path intersects it against the already
+ * visibility-/agent-filtered candidate pool, so a search can never surface a
+ * private or agent-scoped page (same guard as the /query retrieval).
+ */
+
+import type { IndexEntry } from "./types";
+import type { Principal } from "./auth";
+import { listCommonsPages } from "./commons";
+import { listReadableWikiPages, isAgentScopedType } from "./wiki";
+import { getVault } from "./vault";
+import { getDiscussionStatsForSlugs } from "./talk";
+import { tokenize, buildCorpusStats, bm25Score } from "./bm25";
+import { searchByVector } from "./embeddings";
+import { reciprocalRankFusion } from "./query-search";
+import { RRF_K } from "./constants";
+import { logger } from "./logger";
+
+export type BrowseSort = "recent" | "confidence" | "sources";
+
+export interface BrowseOptions {
+  /** Lens scope: `"all"` (the public commons) or `"vault:<id>"`. */
+  scope?: string;
+  /** Restrict to pages carrying this tag (applied before ranking). */
+  tag?: string | null;
+  /** Facet order when there is no query (ignored when ranking by relevance). */
+  sort?: BrowseSort;
+  /** 1-based page number. */
+  page?: number;
+  pageSize?: number;
+  /** Viewer — only used to resolve their readable pages for a vault scope. */
+  principal?: Principal | null;
+}
+
+export interface BrowseResponse {
+  /** The current page's slice of ranked results. */
+  results: IndexEntry[];
+  /** Total matches across all pages (drives the pagination controls). */
+  total: number;
+  discussionStats: Record<string, { total: number; open: number }>;
+  /**
+   * Tag facets for the rail — counts across the full SCOPE pool (before the tag
+   * filter or query), so the topic list stays stable while you search/filter.
+   */
+  tags: [string, number][];
+}
+
+export const BROWSE_PAGE_SIZE = 30;
+
+/**
+ * Resolve the candidate pool for a scope. `"all"` → the public commons (already
+ * public + non-agent by construction). `"vault:<id>"` → a PUBLIC vault's
+ * referenced pages the viewer may read, with agent-scoped pages excluded (the
+ * readable set can include the owner's own agent/private pages, the commons
+ * cannot — so re-apply the agent filter here).
+ */
+async function resolveCandidates(
+  scope: string,
+  principal: Principal | null,
+): Promise<IndexEntry[]> {
+  if (scope.startsWith("vault:")) {
+    const vaultId = scope.slice("vault:".length);
+    const vault = await getVault(vaultId);
+    if (!vault || vault.visibility !== "public") return [];
+    const refs = new Set(vault.slugs);
+    return (await listReadableWikiPages(principal))
+      .filter((p) => refs.has(p.slug))
+      .filter((p) => !isAgentScopedType(p.type));
+  }
+  return listCommonsPages();
+}
+
+function sortEntries(entries: IndexEntry[], sort: BrowseSort): IndexEntry[] {
+  return [...entries].sort((a, b) =>
+    sort === "confidence"
+      ? (b.confidence ?? 0) - (a.confidence ?? 0)
+      : sort === "sources"
+        ? (b.sourceCount ?? 0) - (a.sourceCount ?? 0)
+        : (b.updated ?? "").localeCompare(a.updated ?? ""),
+  );
+}
+
+/**
+ * Rank candidates for a query: BM25 over title+summary (cheap — no per-page disk
+ * read) fused with vector similarity via RRF. Pure BM25 when the vector store is
+ * empty/unavailable. Returns slugs in relevance order (only pages that matched).
+ */
+async function hybridRank(q: string, entries: IndexEntry[]): Promise<string[]> {
+  const queryTokens = tokenize(q);
+  const corpusStats = await buildCorpusStats(entries, { fullBody: false });
+  const bm25Results = entries
+    .map((e) => ({ slug: e.slug, score: bm25Score(e, queryTokens, corpusStats) }))
+    .filter((r) => r.score > 0)
+    .sort((a, b) => b.score - a.score);
+
+  const allowedSlugs = new Set(entries.map((e) => e.slug));
+  let vectorResults: Array<{ slug: string; score: number }> = [];
+  try {
+    // Ask for a generous head so semantic-only matches reach the first result
+    // pages; deeper pages still fall back to the full BM25 match set.
+    const limit = Math.min(allowedSlugs.size, Math.max(64, BROWSE_PAGE_SIZE * 4));
+    const raw = await searchByVector(q, limit);
+    vectorResults = raw.filter((r) => allowedSlugs.has(r.slug));
+  } catch (err) {
+    logger.warn("browse", "vector search failed; ranking by BM25 only:", err);
+  }
+
+  const fused =
+    vectorResults.length > 0
+      ? reciprocalRankFusion(bm25Results, vectorResults, RRF_K)
+      : bm25Results;
+  return fused.map((r) => r.slug);
+}
+
+/**
+ * Search/browse the commons (or a vault lens), ranked and paginated server-side.
+ * When `query` is non-empty results are ordered by hybrid relevance (the `sort`
+ * facet is ignored); otherwise by the chosen facet.
+ */
+export async function searchCommons(
+  query: string | null,
+  opts: BrowseOptions = {},
+): Promise<BrowseResponse> {
+  const scope = opts.scope || "all";
+  const principal = opts.principal ?? null;
+  const sort = opts.sort ?? "recent";
+  const page = Math.max(1, opts.page ?? 1);
+  const pageSize = Math.min(100, Math.max(1, opts.pageSize ?? BROWSE_PAGE_SIZE));
+  const q = query?.trim() || "";
+
+  const pool = await resolveCandidates(scope, principal);
+
+  // Tag facets from the full scope pool — stable while searching/filtering.
+  const tagFreq = new Map<string, number>();
+  for (const p of pool) for (const t of p.tags ?? []) tagFreq.set(t, (tagFreq.get(t) ?? 0) + 1);
+  const tags = [...tagFreq.entries()].sort((a, b) => b[1] - a[1]);
+
+  const tag = opts.tag?.trim() || null;
+  const filtered = tag ? pool.filter((p) => (p.tags ?? []).includes(tag)) : pool;
+
+  let ranked: IndexEntry[];
+  if (q) {
+    const bySlug = new Map(filtered.map((e) => [e.slug, e]));
+    const slugs = await hybridRank(q, filtered);
+    ranked = slugs
+      .map((s) => bySlug.get(s))
+      .filter((e): e is IndexEntry => e !== undefined);
+  } else {
+    ranked = sortEntries(filtered, sort);
+  }
+
+  const total = ranked.length;
+  const start = (page - 1) * pageSize;
+  const slice = ranked.slice(start, start + pageSize);
+
+  const statsMap = await getDiscussionStatsForSlugs(slice.map((p) => p.slug));
+  const discussionStats: Record<string, { total: number; open: number }> = {};
+  for (const [slug, stats] of statsMap) discussionStats[slug] = stats;
+
+  return { results: slice, total, discussionStats, tags };
+}

--- a/src/lib/browse.ts
+++ b/src/lib/browse.ts
@@ -9,8 +9,12 @@
  * query is present, or a plain facet sort when it isn't — then paginated.
  *
  * The vector store is global; every path intersects it against the already
- * visibility-/agent-filtered candidate pool, so a search can never surface a
- * private or agent-scoped page (same guard as the /query retrieval).
+ * visibility-scoped candidate pool, so a search never WIDENS visibility beyond
+ * what the scope's pool already allows (same guard as the /query retrieval). For
+ * `scope=all` that pool is public + non-agent by construction; for a `vault:<id>`
+ * scope it's the viewer's readable vault refs with agent-scoped pages excluded —
+ * so a viewer's OWN private page in their public vault stays visible to them (and
+ * only them), but no search can surface another user's private page.
  */
 
 import type { IndexEntry } from "./types";
@@ -26,6 +30,12 @@ import { RRF_K } from "./constants";
 import { logger } from "./logger";
 
 export type BrowseSort = "recent" | "confidence" | "sources";
+
+/** Discussion counts for a slug — `{ total, open }` (open ≤ total). */
+export type DiscussionStats = Record<string, { total: number; open: number }>;
+
+/** A topic facet: `[tag, count]`. */
+export type TagFacet = [string, number];
 
 export interface BrowseOptions {
   /** Lens scope: `"all"` (the public commons) or `"vault:<id>"`. */
@@ -46,12 +56,18 @@ export interface BrowseResponse {
   results: IndexEntry[];
   /** Total matches across all pages (drives the pagination controls). */
   total: number;
-  discussionStats: Record<string, { total: number; open: number }>;
+  discussionStats: DiscussionStats;
   /**
    * Tag facets for the rail — counts across the full SCOPE pool (before the tag
    * filter or query), so the topic list stays stable while you search/filter.
    */
-  tags: [string, number][];
+  tags: TagFacet[];
+}
+
+/** The `/api/wiki/browse` JSON shape: a {@link BrowseResponse} plus the echoed page cursor. */
+export interface BrowsePayload extends BrowseResponse {
+  page: number;
+  pageSize: number;
 }
 
 export const BROWSE_PAGE_SIZE = 30;
@@ -163,7 +179,7 @@ export async function searchCommons(
   const slice = ranked.slice(start, start + pageSize);
 
   const statsMap = await getDiscussionStatsForSlugs(slice.map((p) => p.slug));
-  const discussionStats: Record<string, { total: number; open: number }> = {};
+  const discussionStats: DiscussionStats = {};
   for (const [slug, stats] of statsMap) discussionStats[slug] = stats;
 
   return { results: slice, total, discussionStats, tags };


### PR DESCRIPTION
## What & why

The `/browse` search was a **client-side substring filter** over the *entire* commons shipped to the browser. That only works while every page fits in one payload — it **silently breaks the moment the list paginates** (the client would only search the slice it holds). You flagged exactly this.

This moves search **server-side** and makes it **hybrid + semantic**, so it scales and matches by meaning, not just literal substring.

## How

- **`searchCommons()`** (`src/lib/browse.ts`) — resolves the scope pool (commons, or a *public* vault's readable refs with agent pages excluded), then:
  - **with a query →** HYBRID ranking: BM25 over title+summary **fused with bge-m3 vector similarity via RRF** (the same retrieval `/query` uses). Keyword *and* semantic matches.
  - **without a query →** the recent / confidence / sources facet sort.
  - then tag-filtered + paginated. The global vector store is intersected against the pre-filtered pool, so **private/agent pages can never leak**.
- **`GET /api/wiki/browse`** (`q, scope, tag, sort, page, pageSize`) → `{ results, total, discussionStats, tags, page, pageSize }`. Public-readable.
- **`BrowseClient`** is now server-driven: 300ms-debounced fetch on query/sort/tag/page change, skip-first-run guard (no flash over the server-rendered first page), loading state, **Prev/Next pagination**, and a *"ranked by relevance"* hint that disables the sort facet while searching. Tag facets come from the full scope pool (stable rail).
- `wiki/page.tsx` server-renders page 1 via `searchCommons`.

## Tests

11 new in `browse.test.ts` (real BM25+RRF, mocked data sources): list sort/facets, tag filter with stable facets, BM25 ranking + non-match exclusion, **semantic-only match via vector fusion**, **BM25 fallback on vector failure**, relevance-over-sort, pagination slicing, and vault scope (private→empty, public→refs ∩ readable, agent excluded).

`pnpm build` clean · **2769 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)