### PR TITLE
Fix header-search snippets: no frontmatter leak, word-boundary cuts

### DIFF
--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -248,6 +248,54 @@ describe("searchWikiContent", () => {
     expect(results[0].snippet.startsWith("…")).toBe(false);
   });
 
+  it("never leaks YAML frontmatter into the snippet", async () => {
+    await ensureDirectories();
+    await writeWikiPage(
+      "fm-leak",
+      `---\ntags: [agentics, ml]\nsource_count: 1\nupdated: 2026-06-08\n---\n# Poke Assistant\n\nPoke is an AI assistant that uses an agent to triage notifications.`,
+    );
+
+    const results = await searchWikiContent("agent");
+    expect(results).toHaveLength(1);
+    const snippet = results[0].snippet;
+    // The term also appears in the `tags:` frontmatter, but the window must be
+    // drawn from the body — no frontmatter keys/values may appear.
+    expect(snippet).not.toContain("source_count");
+    expect(snippet).not.toContain("tags:");
+    expect(snippet).not.toContain("2026-06-08");
+    expect(snippet.toLowerCase()).toContain("agent");
+  });
+
+  it("cuts snippets on word boundaries (no mid-word fragments)", async () => {
+    await ensureDirectories();
+    const filler = "alpha beta gamma delta epsilon zeta eta theta iota kappa";
+    await writeWikiPage("word-cut", `# Word Cut\n\n${filler} keyword ${filler}`);
+
+    const results = await searchWikiContent("keyword");
+    const snippet = results[0].snippet.replace(/…/g, "");
+    const sourceWords = new Set(`Word Cut ${filler} keyword`.split(/\s+/));
+    // Every token in the snippet is a whole word from the source (nothing clipped).
+    for (const w of snippet.split(/\s+/).filter(Boolean)) {
+      expect(sourceWords.has(w)).toBe(true);
+    }
+    expect(snippet).toContain("keyword");
+  });
+
+  it("falls back to the clean summary when the term matched only in frontmatter", async () => {
+    await ensureDirectories();
+    await writeWikiPage(
+      "fm-only",
+      `---\ntags: [serverless]\n---\n# Cloud Topic\n\nA concise overview of deployment models.`,
+    );
+
+    const results = await searchWikiContent("serverless");
+    expect(results).toHaveLength(1);
+    // "serverless" is only in the frontmatter, so there's no body match to centre
+    // on — the snippet is the clean summary, not an empty/odd window.
+    expect(results[0].snippet).toBe(results[0].summary);
+    expect(results[0].snippet).toContain("concise overview");
+  });
+
   it("extracts title from first heading", async () => {
     await ensureDirectories();
     await writeWikiPage("heading-page", "# My Great Title\n\nSome content here.");

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -268,6 +268,42 @@ export interface ContentSearchResult {
   fuzzy?: boolean;
 }
 
+/** Strip a leading markdown heading marker (`#`/`>`/list bullets) from a line. */
+function stripLeadingMarkdown(text: string): string {
+  return text.replace(/^[#>\-*\s]+/, "");
+}
+
+/**
+ * Truncate to `max` chars on a WORD boundary (never mid-word), appending an
+ * ellipsis when the text was actually cut. Avoids fragments like "…es across".
+ */
+function truncateAtWord(text: string, max: number): string {
+  const clean = text.replace(/\s+/g, " ").trim();
+  if (clean.length <= max) return clean;
+  const cut = clean.slice(0, max);
+  const lastSpace = cut.lastIndexOf(" ");
+  // Keep the word-boundary cut unless it would throw away most of the budget.
+  const body = lastSpace > max * 0.6 ? cut.slice(0, lastSpace) : cut;
+  return body.trimEnd() + "…";
+}
+
+/**
+ * Build a match-context snippet from a page BODY (frontmatter already removed)
+ * centred on `matchIndex`, trimmed to whole words so neither end lands
+ * mid-word, with leading/trailing ellipses when the window is interior. Pass a
+ * body — never the raw file — so YAML frontmatter can't leak into the snippet.
+ */
+function contextSnippet(body: string, matchIndex: number, radius = 70): string {
+  const rawStart = Math.max(0, matchIndex - radius);
+  const rawEnd = Math.min(body.length, matchIndex + radius);
+  let chunk = body.slice(rawStart, rawEnd);
+  // Drop the partial words the window may have clipped at each interior edge.
+  if (rawStart > 0) chunk = chunk.replace(/^\S*\s+/, "");
+  if (rawEnd < body.length) chunk = chunk.replace(/\s+\S*$/, "");
+  chunk = stripLeadingMarkdown(chunk).replace(/\s+/g, " ").trim();
+  return (rawStart > 0 ? "…" : "") + chunk + (rawEnd < body.length ? "…" : "");
+}
+
 /**
  * Scope filter for search — restricts results to a set of known slugs.
  * The caller resolves agent IDs (or other scope sources) to slug lists
@@ -474,17 +510,23 @@ export async function searchWikiContent(
       .trim()
       .split("\n")
       .find((l) => l.trim().length > 0);
-    const summary = summaryLine
-      ? summaryLine.trim().slice(0, 120) + (summaryLine.length > 120 ? "…" : "")
-      : "";
+    const summary = summaryLine ? truncateAtWord(summaryLine, 120) : "";
 
-    // Build a snippet around the first match
-    const snippetRadius = 60;
-    const start = Math.max(0, firstMatchIndex - snippetRadius);
-    const end = Math.min(content.length, firstMatchIndex + snippetRadius);
-    let snippet = content.slice(start, end).replace(/\n/g, " ").trim();
-    if (start > 0) snippet = "…" + snippet;
-    if (end < content.length) snippet = snippet + "…";
+    // Snippet = match context from the BODY (frontmatter already stripped), cut
+    // on word boundaries. The match index is recomputed against the body so a
+    // term that matched only in the YAML frontmatter (tags, source_count, dates)
+    // can't drag the window into it; when the query matched only the
+    // frontmatter/title, fall back to the clean summary.
+    const lowerBody = body.toLowerCase();
+    let bodyMatchIndex = -1;
+    for (const term of terms) {
+      const idx = lowerBody.indexOf(term);
+      if (idx !== -1 && (bodyMatchIndex === -1 || idx < bodyMatchIndex)) {
+        bodyMatchIndex = idx;
+      }
+    }
+    const snippet =
+      bodyMatchIndex !== -1 ? contextSnippet(body, bodyMatchIndex) : summary;
 
     scored.push({ slug, title, summary, snippet, score });
   }
@@ -591,18 +633,14 @@ export async function fuzzySearchWikiContent(
       .trim()
       .split("\n")
       .find((l) => l.trim().length > 0);
-    const summary = summaryLine
-      ? summaryLine.trim().slice(0, 120) + (summaryLine.length > 120 ? "…" : "")
-      : "";
+    const summary = summaryLine ? truncateAtWord(summaryLine, 120) : "";
 
-    // For fuzzy results, use the beginning of the page as snippet
-    const snippetText = body
-      .replace(/^#\s+.+$/m, "")
-      .trim()
-      .slice(0, 120)
-      .replace(/\n/g, " ")
-      .trim();
-    const snippet = snippetText + (snippetText.length >= 120 ? "…" : "");
+    // Fuzzy matches have no exact term to centre on — use the page's opening
+    // prose (heading + frontmatter stripped, word-boundary cut) as the preview.
+    const snippet = truncateAtWord(
+      stripLeadingMarkdown(body.replace(/^#\s+.+$/m, "").trim()),
+      140,
+    );
 
     fuzzyResults.push({ slug, title, summary, snippet, score: 0, fuzzy: true });
   }

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -481,17 +481,12 @@ export async function searchWikiContent(
 
     const lower = content.toLowerCase();
 
-    // Count how many query terms appear
+    // Score = how many query terms appear anywhere in the raw file (title,
+    // frontmatter tags, or body) — keeps recall wide; the snippet is drawn from
+    // the body separately below.
     let score = 0;
-    let firstMatchIndex = -1;
     for (const term of terms) {
-      const idx = lower.indexOf(term);
-      if (idx !== -1) {
-        score++;
-        if (firstMatchIndex === -1 || idx < firstMatchIndex) {
-          firstMatchIndex = idx;
-        }
-      }
+      if (lower.includes(term)) score++;
     }
 
     if (score === 0) continue;


### PR DESCRIPTION
## What you saw

Typing in the top search box showed dropdown previews full of junk — `…2026-06-08 source_count: 1 t…`, `…[ai-engineering, large-languag…`, `…es across multiple turns of the…`. Those are **YAML frontmatter** (the `source_count`, `tags`, `updated` fields) and **mid-word fragments**, not the clean summary you see at the bottom of a wiki page.

## Why

The global search (`/api/wiki/search` → `fuzzySearchWikiContent` in `src/lib/search.ts`) builds each grey line by slicing a window of page text around the matched term:

1. The exact-match path sliced from the **raw file content**, which still has the frontmatter block at the top — so a term that matched there (or a window near the start of the file) pulled frontmatter keys/values into the snippet.
2. Both paths cut with a plain `.slice(n)`, so words got chopped mid-token.

## Fix (`src/lib/search.ts`)

- New helpers: **`contextSnippet`** (match context drawn from the **frontmatter-stripped body**, trimmed to whole words with ellipses), **`truncateAtWord`** (word-boundary cut), `stripLeadingMarkdown`.
- **Exact path:** recompute the match index against `parsed.body` (never the raw file). If the term matched only in the frontmatter/title (no body hit), fall back to the **clean summary** rather than an odd window.
- **Fuzzy path:** opening prose via `truncateAtWord` (heading + frontmatter stripped).
- Summaries also cut on word boundaries.

## Tests

`search.test.ts` (+3): frontmatter never leaks into a snippet; snippets cut on word boundaries (no clipped tokens); a frontmatter-only match falls back to the summary. Existing snippet tests still pass.

`pnpm build` clean · **2781 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)