### PR TITLE
Query BM25: size-gate full-body disk reads (scale fix 1/4)

### DIFF
--- a/src/lib/__tests__/query-search.test.ts
+++ b/src/lib/__tests__/query-search.test.ts
@@ -26,6 +26,7 @@ import {
   buildContext,
 } from "../query-search";
 import { writeWikiPage, ensureDirectories } from "../wiki";
+import * as wikiModule from "../wiki";
 
 const mockedHasLLMKey = vi.mocked(hasLLMKey);
 const mockedSearchByVector = vi.mocked(searchByVector);
@@ -518,5 +519,54 @@ describe("searchIndex — pre-filtered entries", () => {
     expect(result.length).toBeGreaterThan(0);
     // "relevant" should rank first — it has both "neural" and "networks" in title+summary
     expect(result[0]).toBe("relevant");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchIndex — full-body BM25 size gate
+// ---------------------------------------------------------------------------
+describe("searchIndex — full-body size gate", () => {
+  it("reads page bodies for a small corpus (≤ BM25_FULLBODY_MAX_PAGES)", async () => {
+    await ensureDirectories();
+    await writeWikiPage("nn", "# Neural Networks\n\nDeep learning architectures.");
+    await writeWikiPage("pasta", "# Pasta\n\nHow to cook pasta.");
+    const entries: IndexEntry[] = [
+      { slug: "nn", title: "Neural Networks", summary: "intro" },
+      { slug: "pasta", title: "Pasta", summary: "food" },
+    ];
+    const readSpy = vi.spyOn(wikiModule, "readWikiPage");
+
+    // Default fullBody=true and 2 ≤ 200 ⇒ full-body path reads each page.
+    const result = await searchIndex("neural networks", entries);
+    expect(readSpy).toHaveBeenCalled();
+    expect(result[0]).toBe("nn");
+    readSpy.mockRestore();
+  });
+
+  it("issues ZERO body reads above the gate, still ranking by title+summary", async () => {
+    // 201 > 200 ⇒ index-level BM25, no disk reads. No page files written.
+    const entries: IndexEntry[] = Array.from({ length: 201 }, (_, i) => ({
+      slug: `page-${i}`,
+      title: i === 0 ? "Neural Networks" : `Topic ${i}`,
+      summary: i === 0 ? "deep neural networks for learning" : `unrelated content ${i}`,
+    }));
+    const readSpy = vi.spyOn(wikiModule, "readWikiPage");
+
+    const result = await searchIndex("neural networks", entries);
+    expect(readSpy).not.toHaveBeenCalled();
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]).toBe("page-0");
+    readSpy.mockRestore();
+  });
+
+  it("honours an explicit fullBody=false even for a small corpus", async () => {
+    await ensureDirectories();
+    await writeWikiPage("a", "# A\n\nalpha body");
+    const entries: IndexEntry[] = [{ slug: "a", title: "A", summary: "alpha" }];
+    const readSpy = vi.spyOn(wikiModule, "readWikiPage");
+
+    await searchIndex("alpha", entries, false);
+    expect(readSpy).not.toHaveBeenCalled();
+    readSpy.mockRestore();
   });
 });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -59,6 +59,17 @@ export const MAX_BATCH_URLS = 20;
 export const MAX_CONTEXT_PAGES = 10;
 
 /**
+ * Page-count ceiling for full-body BM25 at query time.
+ *
+ * At or below this many candidate pages, BM25 reads every page body from disk
+ * for maximum keyword recall. Above it, BM25 scores index-level title+summary
+ * only (zero disk reads) and the dense/vector half of the hybrid retrieval
+ * carries body-level recall — keeping per-query cost flat as the wiki grows.
+ * A scoped query (vault/owner) under this size still gets full-body recall.
+ */
+export const BM25_FULLBODY_MAX_PAGES = 200;
+
+/**
  * BM25 term-frequency saturation parameter.
  *
  * Controls how quickly term frequency saturates. Higher values give more

--- a/src/lib/query-search.ts
+++ b/src/lib/query-search.ts
@@ -9,7 +9,7 @@ import { readWikiPage, readWikiPageWithFrontmatter } from "./wiki";
 import { tokenize, buildCorpusStats, bm25Score } from "./bm25";
 import { searchByVector } from "./embeddings";
 import { callLLM, hasLLMKey } from "./llm";
-import { MAX_CONTEXT_PAGES, RRF_K } from "./constants";
+import { MAX_CONTEXT_PAGES, RRF_K, BM25_FULLBODY_MAX_PAGES } from "./constants";
 import { logger } from "./logger";
 import type { IndexEntry } from "./types";
 
@@ -164,9 +164,14 @@ export async function searchIndex(
     return [];
   }
 
-  // Phase 1 — BM25 sparse scoring
+  // Phase 1 — BM25 sparse scoring.
+  // Full-body BM25 reads every page from disk, so above BM25_FULLBODY_MAX_PAGES
+  // we drop to index-level (title+summary) scoring — zero disk reads — and let
+  // the vector half of the fusion carry body-level recall. The gate only ever
+  // downgrades, so a small or scoped corpus keeps full-body recall.
   const questionTokens = tokenize(question);
-  const corpusStats = await buildCorpusStats(entries, { fullBody });
+  const useFullBody = fullBody && entries.length <= BM25_FULLBODY_MAX_PAGES;
+  const corpusStats = await buildCorpusStats(entries, { fullBody: useFullBody });
 
   const bm25Results = entries
     .map((entry) => ({


### PR DESCRIPTION
**Scaling PR 1 of 4** (plan: flatten per-query/ingest cost at 1000+ pages).

## Problem
`searchIndex` ran full-body BM25 by default → `buildCorpusStats({fullBody:true})` calls `readWikiPage` for **every** page on **every** query (`src/lib/bm25.ts`). The code's own comment: *"fine at tens to low hundreds of pages… bridge until vector search arrives."* At 1000 pages that's 1000 disk reads per query.

## Fix
Gate full-body BM25 by corpus size (`BM25_FULLBODY_MAX_PAGES = 200`):
- **≤ 200 pages** (or any scoped vault/owner set under it): full-body BM25, unchanged recall.
- **> 200 pages:** index-level title+summary BM25 — **zero disk reads** — and the vector half of the hybrid RRF carries body-level recall. This is the exact `fullBody:false` pattern `src/lib/browse.ts` already runs in production.

The gate only ever *downgrades* `fullBody`, so small/scoped corpora are unaffected. The LLM reranker still reads full bodies of the ≤20 fused candidates, so final ordering is unchanged.

## Tests
`query-search.test.ts` (+3, via a `readWikiPage` spy): small corpus reads bodies + ranks correctly; a 201-entry corpus issues **zero** body reads yet still ranks by title+summary; explicit `fullBody=false` honoured.

`pnpm build` clean · **2781 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)