### PR TITLE
Query prompt: cap the other-pages index listing (scale fix 2/4)

### DIFF
--- a/src/lib/__tests__/query.test.ts
+++ b/src/lib/__tests__/query.test.ts
@@ -768,6 +768,33 @@ describe("query", () => {
     const systemPrompt = mockedCallLLM.mock.calls[1][0];
     expect(systemPrompt).toContain("other pages");
   });
+
+  it("caps the other-pages listing on a large wiki (does not list all)", async () => {
+    const entries: IndexEntry[] = Array.from({ length: 45 }, (_, i) => ({
+      slug: `page-${i}`,
+      title: `Page ${i}`,
+      summary: `Summary ${i}`,
+    }));
+    // Select page-0; the other 44 exceed the LISTED_OTHER_PAGES (30) cap.
+    const prompt = await buildQuerySystemPrompt("ctx", entries, ["page-0"]);
+
+    // A late page is omitted, the cap is acknowledged, and the loaded page
+    // isn't re-listed as an "other" page.
+    expect(prompt).not.toContain("Page 44");
+    expect(prompt).toMatch(/and \d+ more pages not listed/);
+    expect(prompt).not.toContain("[Page 0](page-0.md)");
+  });
+
+  it("lists every other page when under the cap", async () => {
+    const entries: IndexEntry[] = Array.from({ length: 6 }, (_, i) => ({
+      slug: `p${i}`,
+      title: `P ${i}`,
+      summary: `s${i}`,
+    }));
+    const prompt = await buildQuerySystemPrompt("ctx", entries, ["p0"]);
+    expect(prompt).toContain("[P 5](p5.md)");
+    expect(prompt).not.toMatch(/more pages not listed/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -70,6 +70,15 @@ export const MAX_CONTEXT_PAGES = 10;
 export const BM25_FULLBODY_MAX_PAGES = 200;
 
 /**
+ * Cap on the "other pages (not loaded in full)" listing in the query system
+ * prompt. The full wiki index is helpful context on a small wiki, but listing
+ * every title+summary makes the prompt grow O(pages) — and cost with it — on a
+ * large one. At or below this many *other* pages the listing is exhaustive;
+ * above it, only the first N are named (plus a "…and M more" count).
+ */
+export const LISTED_OTHER_PAGES = 30;
+
+/**
  * BM25 term-frequency saturation parameter.
  *
  * Controls how quickly term frequency saturates. Higher values give more

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,5 +1,5 @@
 import { callLLM, hasLLMKey } from "./llm";
-import { QUERY_MAX_OUTPUT_TOKENS } from "./constants";
+import { QUERY_MAX_OUTPUT_TOKENS, LISTED_OTHER_PAGES } from "./constants";
 import {
   listReadableWikiPages,
   writeWikiPageWithSideEffects,
@@ -116,15 +116,25 @@ export async function buildQuerySystemPrompt(
   selectedSlugs: string[],
   format: QueryFormat = "prose",
 ): Promise<string> {
-  // Build the full index listing so the LLM knows what else exists
-  const indexListing = entries
-    .map((e) => `- [${e.title}](${e.slug}.md) — ${e.summary}`)
-    .join("\n");
-
-  const indexSection =
-    entries.length > selectedSlugs.length
-      ? `\nThe wiki also contains these other pages (not loaded in full):\n${indexListing}\n`
-      : "";
+  // List the OTHER pages (those not loaded in full) so the LLM knows what else
+  // exists. On a large wiki this would be O(pages) of prompt tokens every query,
+  // so cap it at LISTED_OTHER_PAGES and summarise the remainder as a count. The
+  // loaded pages live in `context`; the answer is grounded there and citations
+  // are validated against the full slug set by the caller, so capping the
+  // "what else exists" hint costs awareness, not correctness.
+  const selectedSet = new Set(selectedSlugs);
+  const others = entries.filter((e) => !selectedSet.has(e.slug));
+  let indexSection = "";
+  if (others.length > 0) {
+    const listed = others.slice(0, LISTED_OTHER_PAGES);
+    const indexListing = listed
+      .map((e) => `- [${e.title}](${e.slug}.md) — ${e.summary}`)
+      .join("\n");
+    const remainder = others.length - listed.length;
+    const moreLine =
+      remainder > 0 ? `\n…and ${remainder} more pages not listed here.\n` : "\n";
+    indexSection = `\nThe wiki also contains these other pages (not loaded in full):\n${indexListing}\n${moreLine}`;
+  }
 
   let systemPrompt = SYSTEM_PROMPT_TEMPLATE
     .replace("{context}", context)


### PR DESCRIPTION
**Scaling PR 2 of 4.**

## Problem
`buildQuerySystemPrompt` listed **every** page's title+summary as "other pages (not loaded in full)" in the system prompt — O(pages) tokens (and $) on **every** query. At 1000 pages that's ~1000 lines per query, just for a "what else exists" hint. (Page *bodies* are already bounded to ≤10 by `buildContext`; this is the remaining O(N) per-query cost.)

## Fix
Cap the listing at `LISTED_OTHER_PAGES = 30`: name the other (non-selected) pages up to the cap, then summarise the rest as *"…and N more pages not listed here."* Below the cap it stays exhaustive (small wikis unchanged). Also stop re-listing the loaded/selected pages as "other" — they're already in `context` in full.

**Grounding/safety unchanged:** the answer is built from the loaded pages in context, and citations are validated against the full readable slug set by the caller (`query()`), so capping the hint costs *awareness of distant pages*, not correctness.

## Tests
`query.test.ts` (+2): a 45-page wiki omits a late page, emits the "N more" line, and doesn't re-list the selected page; a 6-page wiki lists all with no "more" line. Existing large-wiki + format tests still pass.

`pnpm build` clean · **2780 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)