### PR TITLE
Migrate vector store to Cloudflare Vectorize (scale fix 3/4)

### DIFF
--- a/src/app/api/admin/reset/route.ts
+++ b/src/app/api/admin/reset/route.ts
@@ -3,7 +3,7 @@ import { getServicePrincipal } from "@/lib/auth";
 import { getStorage } from "@/lib/storage";
 import { rebuildCommonsIndex } from "@/lib/commons";
 import { rebuildDerivedIndexes } from "@/lib/maintenance";
-import { saveVectorStore } from "@/lib/embeddings";
+import { clearEmbeddings } from "@/lib/embeddings";
 import { logger } from "@/lib/logger";
 
 /**
@@ -77,7 +77,7 @@ export async function POST(req: Request) {
   const indexes = await rebuildDerivedIndexes();
   let embeddings = true;
   try {
-    await saveVectorStore({ model: "", entries: [] });
+    await clearEmbeddings();
   } catch (err) {
     embeddings = false;
     logger.error("admin", "clear embeddings failed:", err);

--- a/src/lib/__tests__/embeddings.test.ts
+++ b/src/lib/__tests__/embeddings.test.ts
@@ -457,6 +457,18 @@ describe("relatedByVector", () => {
 
     expect(await relatedByVector("anchor", 10)).toEqual([]);
   });
+
+  it("returns [] (never throws) on a mixed-dimension store", async () => {
+    // Mid model-migration the store can hold vectors of different dimensions and
+    // the cosine scan throws on the mismatch. relatedByVector runs unguarded on
+    // the article render path, so it must degrade, not crash.
+    await seedVector("anchor", [1, 0, 0], DEFAULT_TEST_MODEL, "a");
+    await seedVector("other", [1, 0], DEFAULT_TEST_MODEL, "b"); // 2-dim, mismatched
+    process.env.EMBEDDING_MODEL = "text-embedding-3-small";
+    process.env.OPENAI_API_KEY = "sk-test";
+
+    await expect(relatedByVector("anchor", 10)).resolves.toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -679,6 +691,15 @@ describe("searchByVector", () => {
 
     // All matches filtered out — stale model.
     expect(results).toEqual([]);
+  });
+
+  it("returns [] (never throws) when the scan hits a dimension mismatch", async () => {
+    await seedVector("a", [1, 0, 0], DEFAULT_TEST_MODEL, "a");
+    await seedVector("b", [1, 0], DEFAULT_TEST_MODEL, "b"); // mismatched dimension
+    process.env.OPENAI_API_KEY = "sk-test";
+    mockEmbed.mockResolvedValue({ embedding: [1, 0, 0] });
+
+    await expect(searchByVector("q", 10)).resolves.toEqual([]);
   });
 });
 

--- a/src/lib/__tests__/embeddings.test.ts
+++ b/src/lib/__tests__/embeddings.test.ts
@@ -45,8 +45,7 @@ import {
   hasEmbeddingSupport,
   getEmbeddingModelName,
   getEmbeddingModel,
-  loadVectorStore,
-  saveVectorStore,
+  clearEmbeddings,
   upsertEmbedding,
   removeEmbedding,
   searchByVector,
@@ -54,11 +53,26 @@ import {
   embedText,
   embedTexts,
   rebuildVectorStore,
-  type VectorStore,
 } from "../embeddings";
+import { getStorage, _resetStorage } from "../storage";
 import { loadConfigSync } from "../config";
 import { listWikiPages, readWikiPage } from "../wiki";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+const DEFAULT_TEST_MODEL = "text-embedding-3-small";
+
+/**
+ * Seed an embedding through the storage provider (the new persistence layer),
+ * mirroring what upsertEmbedding writes: vector + { model, contentHash }.
+ */
+async function seedVector(
+  slug: string,
+  vector: number[],
+  model = DEFAULT_TEST_MODEL,
+  hash = "h",
+): Promise<void> {
+  await getStorage().upsertEmbedding(slug, vector, { model, contentHash: hash });
+}
 
 // Cast for convenience
 const mockLoadConfigSync = loadConfigSync as ReturnType<typeof vi.fn>;
@@ -343,87 +357,41 @@ describe("embedText / embedTexts with mocked provider", () => {
 // Vector store persistence — round-trip to tmp dir
 // ---------------------------------------------------------------------------
 
-describe("vector store persistence", () => {
+describe("vector store persistence (storage provider)", () => {
   let tmpDir: string;
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "embeddings-test-"));
     process.env.WIKI_DIR = tmpDir;
+    process.env.DATA_DIR = tmpDir;
+    _resetStorage();
   });
 
   afterEach(async () => {
+    delete process.env.DATA_DIR;
+    _resetStorage();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("loadVectorStore returns null when no file exists", async () => {
-    expect(await loadVectorStore()).toBeNull();
+  it("getEmbeddingById returns null when nothing is stored", async () => {
+    expect(await getStorage().getEmbeddingById("missing")).toBeNull();
   });
 
-  it("round-trips a vector store to disk", async () => {
-    const store: VectorStore = {
-      model: "text-embedding-3-small",
-      entries: [
-        {
-          slug: "test-page",
-          embedding: [0.1, 0.2, 0.3],
-          contentHash: "abc123",
-        },
-        {
-          slug: "another-page",
-          embedding: [0.4, 0.5, 0.6],
-          contentHash: "def456",
-        },
-      ],
-    };
-
-    await saveVectorStore(store);
-    const loaded = await loadVectorStore();
-
-    expect(loaded).not.toBeNull();
-    expect(loaded!.model).toBe("text-embedding-3-small");
-    expect(loaded!.entries).toHaveLength(2);
-    expect(loaded!.entries[0].slug).toBe("test-page");
-    expect(loaded!.entries[0].embedding).toEqual([0.1, 0.2, 0.3]);
-    expect(loaded!.entries[1].slug).toBe("another-page");
+  it("round-trips a vector + metadata through the provider", async () => {
+    await seedVector("test-page", [0.1, 0.2, 0.3], DEFAULT_TEST_MODEL, "abc123");
+    const got = await getStorage().getEmbeddingById("test-page");
+    expect(got).not.toBeNull();
+    expect(got!.vector).toEqual([0.1, 0.2, 0.3]);
+    expect(got!.metadata.model).toBe(DEFAULT_TEST_MODEL);
+    expect(got!.metadata.contentHash).toBe("abc123");
   });
 
-  it("saveVectorStore creates the wiki directory if needed", async () => {
-    const nestedDir = path.join(tmpDir, "nested", "wiki");
-    process.env.WIKI_DIR = nestedDir;
-
-    const store: VectorStore = {
-      model: "test-model",
-      entries: [],
-    };
-
-    await saveVectorStore(store);
-    const loaded = await loadVectorStore();
-    expect(loaded).not.toBeNull();
-    expect(loaded!.model).toBe("test-model");
-  });
-
-  it("writes valid JSON and leaves no .tmp file behind", async () => {
-    const store: VectorStore = {
-      model: "atomic-test",
-      entries: [
-        { slug: "p1", embedding: [0.1], contentHash: "h1" },
-      ],
-    };
-
-    await saveVectorStore(store);
-
-    // The persisted file should be valid JSON
-    const raw = await fs.readFile(
-      path.join(tmpDir, ".vectors.json"),
-      "utf-8",
-    );
-    const parsed = JSON.parse(raw);
-    expect(parsed.model).toBe("atomic-test");
-    expect(parsed.entries).toHaveLength(1);
-
-    // No leftover .tmp file after a successful write
-    const files = await fs.readdir(tmpDir);
-    expect(files).not.toContain(".vectors.json.tmp");
+  it("clearEmbeddings removes every stored vector", async () => {
+    await seedVector("p1", [1, 0]);
+    await seedVector("p2", [0, 1]);
+    await clearEmbeddings();
+    expect(await getStorage().getEmbeddingById("p1")).toBeNull();
+    expect(await getStorage().getEmbeddingById("p2")).toBeNull();
   });
 });
 
@@ -437,24 +405,25 @@ describe("relatedByVector", () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "embeddings-test-"));
     process.env.WIKI_DIR = tmpDir;
+    process.env.DATA_DIR = tmpDir;
+    _resetStorage();
   });
 
   afterEach(async () => {
+    delete process.env.DATA_DIR;
+    _resetStorage();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  const store: VectorStore = {
-    model: "text-embedding-3-small",
-    entries: [
-      { slug: "anchor", embedding: [1, 0, 0], contentHash: "a" },
-      { slug: "near", embedding: [0.9, 0.1, 0], contentHash: "b" },
-      { slug: "mid", embedding: [0.6, 0.6, 0], contentHash: "c" },
-      { slug: "far", embedding: [0, 1, 0], contentHash: "d" },
-    ],
-  };
+  async function seedAnchorSet(model = DEFAULT_TEST_MODEL): Promise<void> {
+    await seedVector("anchor", [1, 0, 0], model, "a");
+    await seedVector("near", [0.9, 0.1, 0], model, "b");
+    await seedVector("mid", [0.6, 0.6, 0], model, "c");
+    await seedVector("far", [0, 1, 0], model, "d");
+  }
 
   it("ranks other pages by similarity to the anchor and excludes the anchor itself", async () => {
-    await saveVectorStore(store);
+    await seedAnchorSet();
     process.env.EMBEDDING_MODEL = "text-embedding-3-small";
     process.env.OPENAI_API_KEY = "sk-test";
 
@@ -465,7 +434,7 @@ describe("relatedByVector", () => {
   });
 
   it("respects topK", async () => {
-    await saveVectorStore(store);
+    await seedAnchorSet();
     process.env.EMBEDDING_MODEL = "text-embedding-3-small";
     process.env.OPENAI_API_KEY = "sk-test";
 
@@ -474,15 +443,15 @@ describe("relatedByVector", () => {
   });
 
   it("returns [] when the anchor has no stored vector", async () => {
-    await saveVectorStore(store);
+    await seedAnchorSet();
     process.env.EMBEDDING_MODEL = "text-embedding-3-small";
     process.env.OPENAI_API_KEY = "sk-test";
 
     expect(await relatedByVector("ghost", 10)).toEqual([]);
   });
 
-  it("returns [] when the store was built with a different model (stale)", async () => {
-    await saveVectorStore(store); // built with text-embedding-3-small
+  it("returns [] when the anchor's vector is from a different model (stale)", async () => {
+    await seedAnchorSet("text-embedding-3-small");
     process.env.EMBEDDING_MODEL = "text-embedding-3-large"; // current model differs
     process.env.OPENAI_API_KEY = "sk-test";
 
@@ -500,44 +469,35 @@ describe("removeEmbedding", () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "embeddings-test-"));
     process.env.WIKI_DIR = tmpDir;
+    process.env.DATA_DIR = tmpDir;
+    _resetStorage();
   });
 
   afterEach(async () => {
+    delete process.env.DATA_DIR;
+    _resetStorage();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
   it("removes the correct slug from the store", async () => {
-    const store: VectorStore = {
-      model: "test-model",
-      entries: [
-        { slug: "keep-me", embedding: [1, 0], contentHash: "a" },
-        { slug: "remove-me", embedding: [0, 1], contentHash: "b" },
-        { slug: "also-keep", embedding: [1, 1], contentHash: "c" },
-      ],
-    };
-    await saveVectorStore(store);
+    await seedVector("keep-me", [1, 0], DEFAULT_TEST_MODEL, "a");
+    await seedVector("remove-me", [0, 1], DEFAULT_TEST_MODEL, "b");
+    await seedVector("also-keep", [1, 1], DEFAULT_TEST_MODEL, "c");
 
     await removeEmbedding("remove-me");
 
-    const loaded = await loadVectorStore();
-    expect(loaded!.entries).toHaveLength(2);
-    expect(loaded!.entries.map((e) => e.slug)).toEqual([
-      "keep-me",
-      "also-keep",
-    ]);
+    const storage = getStorage();
+    expect(await storage.getEmbeddingById("remove-me")).toBeNull();
+    expect(await storage.getEmbeddingById("keep-me")).not.toBeNull();
+    expect(await storage.getEmbeddingById("also-keep")).not.toBeNull();
   });
 
   it("does nothing if the slug is not in the store", async () => {
-    const store: VectorStore = {
-      model: "test-model",
-      entries: [{ slug: "existing", embedding: [1, 0], contentHash: "a" }],
-    };
-    await saveVectorStore(store);
+    await seedVector("existing", [1, 0], DEFAULT_TEST_MODEL, "a");
 
     await removeEmbedding("nonexistent");
 
-    const loaded = await loadVectorStore();
-    expect(loaded!.entries).toHaveLength(1);
+    expect(await getStorage().getEmbeddingById("existing")).not.toBeNull();
   });
 
   it("does nothing if the store does not exist", async () => {
@@ -556,120 +516,89 @@ describe("upsertEmbedding", () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "embeddings-test-"));
     process.env.WIKI_DIR = tmpDir;
+    process.env.DATA_DIR = tmpDir;
     process.env.OPENAI_API_KEY = "sk-test-key";
+    _resetStorage();
   });
 
   afterEach(async () => {
+    delete process.env.DATA_DIR;
+    _resetStorage();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("skips re-embedding when contentHash matches", async () => {
+  it("skips re-embedding when contentHash and model match", async () => {
     const content = "hello world";
     const hash = contentHash(content);
-
-    // Pre-seed the store with a matching hash
-    const store: VectorStore = {
-      model: "text-embedding-3-small",
-      entries: [
-        { slug: "test-page", embedding: [0.1, 0.2], contentHash: hash },
-      ],
-    };
-    await saveVectorStore(store);
+    // Pre-seed with the matching hash + the current model.
+    await seedVector("test-page", [0.1, 0.2], "text-embedding-3-small", hash);
 
     await upsertEmbedding("test-page", content);
 
-    // embed should NOT have been called since hash matches
+    // embed should NOT have been called since hash + model match
     expect(mockEmbed).not.toHaveBeenCalled();
   });
 
-  it("clears all entries when model changes", async () => {
-    // Store was created with a different model
-    const store: VectorStore = {
-      model: "old-model-v1",
-      entries: [
-        { slug: "page-a", embedding: [1, 0], contentHash: "aaa" },
-        { slug: "page-b", embedding: [0, 1], contentHash: "bbb" },
-      ],
-    };
-    await saveVectorStore(store);
-
-    // Mock the AI SDK embed function
+  it("re-embeds when the stored vector is from a different model", async () => {
+    const content = "hello world";
+    const hash = contentHash(content);
+    // Same content hash, but a stale model → must re-embed (not skip).
+    await seedVector("test-page", [0.1, 0.2], "old-model-v1", hash);
     mockEmbed.mockResolvedValue({ embedding: [0.5, 0.5] });
 
-    await upsertEmbedding("new-page", "new content");
+    await upsertEmbedding("test-page", content);
 
-    const loaded = await loadVectorStore();
-    expect(loaded!.model).toBe("text-embedding-3-small"); // current model
-    // Old entries should be gone, only the new one remains
-    expect(loaded!.entries).toHaveLength(1);
-    expect(loaded!.entries[0].slug).toBe("new-page");
+    expect(mockEmbed).toHaveBeenCalled();
+    const got = await getStorage().getEmbeddingById("test-page");
+    expect(got!.vector).toEqual([0.5, 0.5]);
+    expect(got!.metadata.model).toBe("text-embedding-3-small");
   });
 
   it("adds a new entry when slug is not in store", async () => {
-    const store: VectorStore = {
-      model: "text-embedding-3-small",
-      entries: [
-        { slug: "existing", embedding: [1, 0], contentHash: "aaa" },
-      ],
-    };
-    await saveVectorStore(store);
-
+    await seedVector("existing", [1, 0], "text-embedding-3-small", "aaa");
     mockEmbed.mockResolvedValue({ embedding: [0.3, 0.7] });
 
     await upsertEmbedding("new-page", "some content");
 
-    const loaded = await loadVectorStore();
-    expect(loaded!.entries).toHaveLength(2);
-    expect(loaded!.entries[1].slug).toBe("new-page");
-    expect(loaded!.entries[1].embedding).toEqual([0.3, 0.7]);
+    const got = await getStorage().getEmbeddingById("new-page");
+    expect(got).not.toBeNull();
+    expect(got!.vector).toEqual([0.3, 0.7]);
   });
 
   it("updates an existing entry when content changes", async () => {
-    const store: VectorStore = {
-      model: "text-embedding-3-small",
-      entries: [
-        { slug: "my-page", embedding: [1, 0], contentHash: "old-hash" },
-      ],
-    };
-    await saveVectorStore(store);
-
+    await seedVector("my-page", [1, 0], "text-embedding-3-small", "old-hash");
     mockEmbed.mockResolvedValue({ embedding: [0.9, 0.1] });
 
     await upsertEmbedding("my-page", "updated content");
 
-    const loaded = await loadVectorStore();
-    expect(loaded!.entries).toHaveLength(1);
-    expect(loaded!.entries[0].slug).toBe("my-page");
-    expect(loaded!.entries[0].embedding).toEqual([0.9, 0.1]);
-    expect(loaded!.entries[0].contentHash).toBe(contentHash("updated content"));
+    const got = await getStorage().getEmbeddingById("my-page");
+    expect(got!.vector).toEqual([0.9, 0.1]);
+    expect(got!.metadata.contentHash).toBe(contentHash("updated content"));
   });
 
   it("does nothing when no embedding provider is available", async () => {
     delete process.env.OPENAI_API_KEY;
 
-    // Should not throw and should not create a store
+    // Should not throw and should not store anything.
     await upsertEmbedding("test", "content");
 
-    const loaded = await loadVectorStore();
-    expect(loaded).toBeNull();
+    expect(await getStorage().getEmbeddingById("test")).toBeNull();
     expect(mockEmbed).not.toHaveBeenCalled();
   });
 
   it("concurrent upserts don't clobber each other", async () => {
     process.env.OPENAI_API_KEY = "sk-test-concurrent";
-
     mockEmbed.mockResolvedValue({ embedding: [0.5, 0.5] });
 
-    // Fire two upserts concurrently with different slugs
+    // Fire two upserts concurrently with different slugs.
     await Promise.all([
       upsertEmbedding("page-alpha", "content alpha"),
       upsertEmbedding("page-beta", "content beta"),
     ]);
 
-    const loaded = await loadVectorStore();
-    expect(loaded).not.toBeNull();
-    const slugs = loaded!.entries.map((e) => e.slug).sort();
-    expect(slugs).toEqual(["page-alpha", "page-beta"]);
+    const storage = getStorage();
+    expect(await storage.getEmbeddingById("page-alpha")).not.toBeNull();
+    expect(await storage.getEmbeddingById("page-beta")).not.toBeNull();
   });
 });
 
@@ -683,9 +612,13 @@ describe("searchByVector", () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "embeddings-test-"));
     process.env.WIKI_DIR = tmpDir;
+    process.env.DATA_DIR = tmpDir;
+    _resetStorage();
   });
 
   afterEach(async () => {
+    delete process.env.DATA_DIR;
+    _resetStorage();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -696,19 +629,11 @@ describe("searchByVector", () => {
   });
 
   it("returns correct ranking order", async () => {
-    // Pre-load a store with known embeddings
-    const store: VectorStore = {
-      model: "text-embedding-3-small",
-      entries: [
-        { slug: "low-match", embedding: [0, 1, 0], contentHash: "a" },
-        { slug: "high-match", embedding: [1, 0, 0], contentHash: "b" },
-        { slug: "mid-match", embedding: [0.7, 0.7, 0], contentHash: "c" },
-      ],
-    };
-    await saveVectorStore(store);
+    await seedVector("low-match", [0, 1, 0], DEFAULT_TEST_MODEL, "a");
+    await seedVector("high-match", [1, 0, 0], DEFAULT_TEST_MODEL, "b");
+    await seedVector("mid-match", [0.7, 0.7, 0], DEFAULT_TEST_MODEL, "c");
 
     process.env.OPENAI_API_KEY = "sk-test";
-
     // Mock embed to return a query vector closest to high-match
     mockEmbed.mockResolvedValue({ embedding: [1, 0, 0] });
 
@@ -723,15 +648,9 @@ describe("searchByVector", () => {
   });
 
   it("respects topK limit", async () => {
-    const store: VectorStore = {
-      model: "text-embedding-3-small",
-      entries: [
-        { slug: "a", embedding: [1, 0], contentHash: "a" },
-        { slug: "b", embedding: [0.9, 0.1], contentHash: "b" },
-        { slug: "c", embedding: [0.5, 0.5], contentHash: "c" },
-      ],
-    };
-    await saveVectorStore(store);
+    await seedVector("a", [1, 0], DEFAULT_TEST_MODEL, "a");
+    await seedVector("b", [0.9, 0.1], DEFAULT_TEST_MODEL, "b");
+    await seedVector("c", [0.5, 0.5], DEFAULT_TEST_MODEL, "c");
 
     process.env.OPENAI_API_KEY = "sk-test";
     mockEmbed.mockResolvedValue({ embedding: [1, 0] });
@@ -740,13 +659,7 @@ describe("searchByVector", () => {
     expect(results).toHaveLength(2);
   });
 
-  it("returns empty array when store is empty", async () => {
-    const store: VectorStore = {
-      model: "text-embedding-3-small",
-      entries: [],
-    };
-    await saveVectorStore(store);
-
+  it("returns empty array when the store is empty", async () => {
     process.env.OPENAI_API_KEY = "sk-test";
     mockEmbed.mockResolvedValue({ embedding: [1, 0] });
 
@@ -754,23 +667,17 @@ describe("searchByVector", () => {
     expect(results).toEqual([]);
   });
 
-  it("returns empty array when store model differs from current model", async () => {
-    // Store was built with a different model than the current provider uses
-    const store: VectorStore = {
-      model: "old-model-from-different-provider",
-      entries: [
-        { slug: "page-a", embedding: [1, 0, 0], contentHash: "a" },
-        { slug: "page-b", embedding: [0, 1, 0], contentHash: "b" },
-      ],
-    };
-    await saveVectorStore(store);
+  it("drops matches whose stored model differs from the current model", async () => {
+    // Vectors were embedded by a different model than the current provider uses.
+    await seedVector("page-a", [1, 0, 0], "old-model-from-different-provider", "a");
+    await seedVector("page-b", [0, 1, 0], "old-model-from-different-provider", "b");
 
     process.env.OPENAI_API_KEY = "sk-test";
     mockEmbed.mockResolvedValue({ embedding: [1, 0, 0] });
 
     const results = await searchByVector("test query", 10);
 
-    // Should return empty because store model doesn't match current model
+    // All matches filtered out — stale model.
     expect(results).toEqual([]);
   });
 });
@@ -1017,10 +924,14 @@ describe("rebuildVectorStore", () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "embeddings-rebuild-"));
     process.env.WIKI_DIR = tmpDir;
+    process.env.DATA_DIR = tmpDir;
     process.env.OPENAI_API_KEY = "sk-test-key";
+    _resetStorage();
   });
 
   afterEach(async () => {
+    delete process.env.DATA_DIR;
+    _resetStorage();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -1033,7 +944,7 @@ describe("rebuildVectorStore", () => {
     );
   });
 
-  it("creates a fresh store with all wiki pages embedded", async () => {
+  it("embeds all wiki pages into the store", async () => {
     mockListWikiPages.mockResolvedValue([
       { title: "Page A", slug: "page-a", summary: "Summary A" },
       { title: "Page B", slug: "page-b", summary: "Summary B" },
@@ -1061,13 +972,12 @@ describe("rebuildVectorStore", () => {
     expect(result.skipped).toBe(0);
     expect(result.model).toBe("text-embedding-3-small");
 
-    const store = await loadVectorStore();
-    expect(store).not.toBeNull();
-    expect(store!.model).toBe("text-embedding-3-small");
-    expect(store!.entries).toHaveLength(2);
-    expect(store!.entries[0].slug).toBe("page-a");
-    expect(store!.entries[0].contentHash).toBe(contentHash("Content A"));
-    expect(store!.entries[1].slug).toBe("page-b");
+    const storage = getStorage();
+    const a = await storage.getEmbeddingById("page-a");
+    expect(a).not.toBeNull();
+    expect(a!.metadata.model).toBe("text-embedding-3-small");
+    expect(a!.metadata.contentHash).toBe(contentHash("Content A"));
+    expect(await storage.getEmbeddingById("page-b")).not.toBeNull();
   });
 
   it("skips pages with empty content", async () => {
@@ -1093,9 +1003,9 @@ describe("rebuildVectorStore", () => {
     expect(result.embedded).toBe(1);
     expect(result.skipped).toBe(1);
 
-    const store = await loadVectorStore();
-    expect(store!.entries).toHaveLength(1);
-    expect(store!.entries[0].slug).toBe("good");
+    const storage = getStorage();
+    expect(await storage.getEmbeddingById("good")).not.toBeNull();
+    expect(await storage.getEmbeddingById("empty")).toBeNull();
   });
 
   it("skips pages where readWikiPage returns null", async () => {
@@ -1111,15 +1021,9 @@ describe("rebuildVectorStore", () => {
     expect(result.skipped).toBe(1);
   });
 
-  it("replaces existing store completely", async () => {
-    // Pre-seed a store with old data
-    const oldStore: VectorStore = {
-      model: "old-model",
-      entries: [
-        { slug: "old-page", embedding: [1, 0], contentHash: "old" },
-      ],
-    };
-    await saveVectorStore(oldStore);
+  it("upserts current pages (orphans from deleted pages are left for query-time filtering)", async () => {
+    // Pre-seed an orphan (a page no longer in the index).
+    await seedVector("old-page", [1, 0], "old-model", "old");
 
     mockListWikiPages.mockResolvedValue([
       { title: "New", slug: "new-page", summary: "Brand new" },
@@ -1135,12 +1039,11 @@ describe("rebuildVectorStore", () => {
     const result = await rebuildVectorStore();
 
     expect(result.embedded).toBe(1);
-
-    const store = await loadVectorStore();
-    expect(store!.model).toBe("text-embedding-3-small");
-    // Old entry should be gone
-    expect(store!.entries).toHaveLength(1);
-    expect(store!.entries[0].slug).toBe("new-page");
+    const newPage = await getStorage().getEmbeddingById("new-page");
+    expect(newPage).not.toBeNull();
+    expect(newPage!.metadata.model).toBe("text-embedding-3-small");
+    // The orphan isn't actively purged (no bulk-clear on a managed index); it's
+    // harmless because reads intersect with the readable slug set.
   });
 
   it("calls onProgress callback", async () => {
@@ -1175,10 +1078,6 @@ describe("rebuildVectorStore", () => {
     expect(result.total).toBe(0);
     expect(result.embedded).toBe(0);
     expect(result.skipped).toBe(0);
-
-    const store = await loadVectorStore();
-    expect(store).not.toBeNull();
-    expect(store!.entries).toHaveLength(0);
   });
 
   it("skips pages where embedding throws an error", async () => {

--- a/src/lib/__tests__/embeddings.test.ts
+++ b/src/lib/__tests__/embeddings.test.ts
@@ -701,6 +701,17 @@ describe("searchByVector", () => {
 
     await expect(searchByVector("q", 10)).resolves.toEqual([]);
   });
+
+  it("keeps unlabelled (legacy) vectors with no model metadata", async () => {
+    // Pre-migration / KV-fallback vectors may carry no `model` key. The filter
+    // must NOT drop them, or the whole corpus would vanish after first deploy.
+    await getStorage().upsertEmbedding("legacy", [1, 0, 0], { contentHash: "x" });
+    process.env.OPENAI_API_KEY = "sk-test";
+    mockEmbed.mockResolvedValue({ embedding: [1, 0, 0] });
+
+    const results = await searchByVector("q", 10);
+    expect(results.map((r) => r.slug)).toContain("legacy");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/__tests__/storage-r2.test.ts
+++ b/src/lib/__tests__/storage-r2.test.ts
@@ -238,6 +238,15 @@ function createMockVectorize(): VectorizeIndex {
       }
       return { count };
     },
+
+    async getByIds(ids: string[]): Promise<VectorizeVector[]> {
+      const out: VectorizeVector[] = [];
+      for (const id of ids) {
+        const v = vectors.get(id);
+        if (v) out.push({ id, values: v.values, metadata: v.metadata });
+      }
+      return out;
+    },
   };
 }
 
@@ -528,6 +537,20 @@ describe("R2StorageProvider", () => {
       expect(results[0].id).toBe("page1");
       expect(results[0].metadata.hash).toBe("b");
     });
+
+    it("getEmbeddingById returns the vector + metadata, or null", async () => {
+      await provider.upsertEmbedding("page1", [1, 0, 0], { hash: "a" });
+      const got = await provider.getEmbeddingById("page1");
+      expect(got).toEqual({ id: "page1", vector: [1, 0, 0], metadata: { hash: "a" } });
+      expect(await provider.getEmbeddingById("missing")).toBeNull();
+    });
+
+    it("clearEmbeddings empties the KV store", async () => {
+      await provider.upsertEmbedding("page1", [1, 0, 0], { hash: "a" });
+      await provider.clearEmbeddings();
+      expect(await provider.getEmbeddingById("page1")).toBeNull();
+      expect(await provider.queryEmbeddings([1, 0, 0], 5)).toHaveLength(0);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -558,6 +581,25 @@ describe("R2StorageProvider", () => {
 
       const results = await vecProvider.queryEmbeddings([1, 0, 0], 5);
       expect(results).toHaveLength(0);
+    });
+
+    it("getEmbeddingById fetches a stored vector via getByIds", async () => {
+      await vecProvider.upsertEmbedding("page1", [1, 0, 0], { model: "bge-m3", contentHash: "a" });
+      const got = await vecProvider.getEmbeddingById("page1");
+      expect(got).toEqual({
+        id: "page1",
+        vector: [1, 0, 0],
+        metadata: { model: "bge-m3", contentHash: "a" },
+      });
+      expect(await vecProvider.getEmbeddingById("missing")).toBeNull();
+    });
+
+    it("clearEmbeddings is a best-effort no-op for Vectorize (no bulk-clear)", async () => {
+      await vecProvider.upsertEmbedding("page1", [1, 0, 0], { hash: "a" });
+      // Must not throw; the managed index has no bulk-clear, so the vector
+      // remains and is filtered at query time by the caller.
+      await expect(vecProvider.clearEmbeddings()).resolves.toBeUndefined();
+      expect(await vecProvider.getEmbeddingById("page1")).not.toBeNull();
     });
   });
 

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -5,31 +5,13 @@ import { createOllama } from "ollama-ai-provider-v2";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import type { EmbeddingModel } from "ai";
 import type { Ai } from "./storage/cloudflare-types";
-import { wikiRelPath, listWikiPages, readWikiPage } from "./wiki";
+import { listWikiPages, readWikiPage } from "./wiki";
 import { getStorage } from "./storage";
 import { detectEnvProvider, loadConfigSync, getEmbeddingModelOverride, getOllamaBaseUrl } from "./config";
 import { EMBEDDING_PROVIDERS, isEmbeddingProvider, type EmbeddingProvider } from "./providers";
 import { withFileLock } from "./lock";
-import { isEnoent } from "./errors";
 import { MAX_EMBED_CHARS } from "./constants";
 import { logger } from "./logger";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface VectorEntry {
-  slug: string;
-  embedding: number[];
-  /** Hash of the page content — used to detect stale embeddings */
-  contentHash: string;
-}
-
-export interface VectorStore {
-  /** e.g. "text-embedding-3-small" — if model changes, invalidate all */
-  model: string;
-  entries: VectorEntry[];
-}
 
 // ---------------------------------------------------------------------------
 // Embedding provider detection
@@ -351,40 +333,30 @@ export function contentHash(content: string): string {
 // ---------------------------------------------------------------------------
 // Vector store persistence
 // ---------------------------------------------------------------------------
+//
+// Vectors live in the StorageProvider's embedding store (Cloudflare Vectorize
+// in production, KV brute-force when Vectorize is unbound, a local JSON file in
+// dev/tests). Each vector carries `EmbeddingMeta` in its metadata: `model` (to
+// drop vectors from a stale embedding model on read) and `contentHash` (to skip
+// re-embedding unchanged content on write).
 
-const VECTOR_STORE_FILENAME = ".vectors.json";
-
-/** Storage-relative path to the vector store file. */
-function vectorStoreRelPath(): string {
-  return wikiRelPath(VECTOR_STORE_FILENAME);
+/** Per-vector metadata persisted alongside the embedding. */
+interface EmbeddingMeta extends Record<string, string> {
+  model: string;
+  contentHash: string;
 }
 
-/**
- * Read the vector store from disk. Returns null if the file doesn't exist.
- */
-export async function loadVectorStore(): Promise<VectorStore | null> {
-  try {
-    const raw = await getStorage().readFile(vectorStoreRelPath());
-    return JSON.parse(raw) as VectorStore;
-  } catch (err) {
-    if (!isEnoent(err)) {
-      logger.warn("embeddings", "load vector store failed:", err);
-    }
-    return null;
-  }
+/** Drop matches whose stored model differs from the active one (stale vectors). */
+function modelMatches(metadata: Record<string, string>, model: string | null): boolean {
+  // Unknown active model or unlabelled legacy vector → don't filter it out.
+  return !model || !metadata.model || metadata.model === model;
 }
 
-/**
- * Write the vector store to disk atomically.
- *
- * The StorageProvider's `writeFile` handles directory creation and atomicity
- * (the filesystem provider uses write-to-tmp + rename internally).
- */
-export async function saveVectorStore(store: VectorStore): Promise<void> {
-  await getStorage().writeFile(
-    vectorStoreRelPath(),
-    JSON.stringify(store, null, 2),
-  );
+/** Remove every stored embedding (used by the admin content reset). */
+export async function clearEmbeddings(): Promise<void> {
+  await withFileLock("vectors", async () => {
+    await getStorage().clearEmbeddings();
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -407,36 +379,23 @@ export async function upsertEmbedding(
     if (!modelName) return; // No embedding support
 
     const hash = contentHash(content);
-    let store = await loadVectorStore();
 
-    // Model migration: if the stored model doesn't match, start fresh.
-    if (store && store.model !== modelName) {
-      store = { model: modelName, entries: [] };
+    // Skip when the stored vector already matches this content AND model — same
+    // optimization as before, now via a single id lookup instead of a full scan.
+    const existing = await getStorage().getEmbeddingById(slug);
+    if (
+      existing &&
+      existing.metadata.contentHash === hash &&
+      existing.metadata.model === modelName
+    ) {
+      return;
     }
 
-    if (!store) {
-      store = { model: modelName, entries: [] };
-    }
-
-    // Check if already up-to-date
-    const existing = store.entries.find((e) => e.slug === slug);
-    if (existing && existing.contentHash === hash) {
-      return; // Already embedded with same content
-    }
-
-    // Embed the content
     const embedding = await embedText(content);
     if (!embedding) return;
 
-    // Upsert
-    if (existing) {
-      existing.embedding = embedding;
-      existing.contentHash = hash;
-    } else {
-      store.entries.push({ slug, embedding, contentHash: hash });
-    }
-
-    await saveVectorStore(store);
+    const meta: EmbeddingMeta = { model: modelName, contentHash: hash };
+    await getStorage().upsertEmbedding(slug, embedding, meta);
   });
 }
 
@@ -445,15 +404,7 @@ export async function upsertEmbedding(
  */
 export async function removeEmbedding(slug: string): Promise<void> {
   return withFileLock("vectors", async () => {
-    const store = await loadVectorStore();
-    if (!store) return;
-
-    const before = store.entries.length;
-    store.entries = store.entries.filter((e) => e.slug !== slug);
-
-    if (store.entries.length !== before) {
-      await saveVectorStore(store);
-    }
+    await getStorage().removeEmbedding(slug);
   });
 }
 
@@ -508,22 +459,11 @@ export async function searchByVector(
   const queryEmbedding = await embedText(query);
   if (!queryEmbedding) return [];
 
-  const store = await loadVectorStore();
-  if (!store || store.entries.length === 0) return [];
-
-  // Guard: if the store was built with a different model the embeddings are
-  // incompatible — return nothing.  The store will be rebuilt on the next
-  // upsert or manual rebuild.
   const currentModel = getEmbeddingModelName();
-  if (currentModel && store.model !== currentModel) return [];
-
-  const scored = store.entries.map((entry) => ({
-    slug: entry.slug,
-    score: cosineSimilarity(queryEmbedding, entry.embedding),
-  }));
-
-  scored.sort((a, b) => b.score - a.score);
-  return scored.slice(0, topK);
+  const matches = await getStorage().queryEmbeddings(queryEmbedding, topK);
+  return matches
+    .filter((m) => modelMatches(m.metadata, currentModel))
+    .map((m) => ({ slug: m.id, score: m.score }));
 }
 
 /**
@@ -539,20 +479,18 @@ export async function relatedByVector(
   slug: string,
   topK: number = 10,
 ): Promise<Array<{ slug: string; score: number }>> {
-  const store = await loadVectorStore();
-  if (!store || store.entries.length === 0) return [];
-
-  const currentModel = getEmbeddingModelName();
-  if (currentModel && store.model !== currentModel) return [];
-
-  const self = store.entries.find((e) => e.slug === slug);
+  const self = await getStorage().getEmbeddingById(slug);
   if (!self) return [];
 
-  return store.entries
-    .filter((e) => e.slug !== slug)
-    .map((e) => ({ slug: e.slug, score: cosineSimilarity(self.embedding, e.embedding) }))
-    .sort((a, b) => b.score - a.score)
-    .slice(0, topK);
+  const currentModel = getEmbeddingModelName();
+  if (!modelMatches(self.metadata, currentModel)) return [];
+
+  // Over-fetch by one to absorb the page's own vector, then drop it.
+  const matches = await getStorage().queryEmbeddings(self.vector, topK + 1);
+  return matches
+    .filter((m) => m.id !== slug && modelMatches(m.metadata, currentModel))
+    .slice(0, topK)
+    .map((m) => ({ slug: m.id, score: m.score }));
 }
 
 // ---------------------------------------------------------------------------
@@ -589,11 +527,15 @@ export async function rebuildVectorStore(
 
   const entries = await listWikiPages();
   const total = entries.length;
+  const storage = getStorage();
 
-  const store: VectorStore = { model: modelName, entries: [] };
   let embedded = 0;
   let skipped = 0;
 
+  // Upsert every current page. This overwrites in place; embeddings for pages
+  // that no longer exist are left untouched (no bulk-clear on a managed index),
+  // but they're harmless — every read intersects results with the caller's
+  // readable/scoped slug set, so an orphan vector can never surface.
   for (let i = 0; i < entries.length; i++) {
     const entry = entries[i];
     const page = await readWikiPage(entry.slug);
@@ -612,11 +554,13 @@ export async function rebuildVectorStore(
         continue;
       }
 
-      store.entries.push({
-        slug: entry.slug,
-        embedding,
+      const meta: EmbeddingMeta = {
+        model: modelName,
         contentHash: contentHash(page.content),
-      });
+      };
+      await withFileLock("vectors", () =>
+        storage.upsertEmbedding(entry.slug, embedding, meta),
+      );
       embedded++;
     } catch (err) {
       logger.warn("embeddings", `embed page "${entry.slug}" failed:`, err);
@@ -625,10 +569,6 @@ export async function rebuildVectorStore(
 
     onProgress?.(i + 1, total);
   }
-
-  await withFileLock("vectors", async () => {
-    await saveVectorStore(store);
-  });
 
   return { total, embedded, skipped, model: modelName };
 }

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -366,9 +366,11 @@ export async function clearEmbeddings(): Promise<void> {
 /**
  * Embed content for a wiki page and upsert it into the vector store.
  *
- * - Skips re-embedding if the contentHash hasn't changed.
- * - If the stored model name differs from the current model, all existing
- *   entries are cleared (model migration).
+ * Skips re-embedding when the stored vector already has the same contentHash AND
+ * was produced by the current embedding model; otherwise re-embeds and upserts
+ * (with `{ model, contentHash }` metadata). A model change is handled per-entry:
+ * stale-model vectors are simply re-embedded as pages are touched, and dropped
+ * from reads in the meantime (see {@link searchByVector}/{@link relatedByVector}).
  */
 export async function upsertEmbedding(
   slug: string,
@@ -460,10 +462,18 @@ export async function searchByVector(
   if (!queryEmbedding) return [];
 
   const currentModel = getEmbeddingModelName();
-  const matches = await getStorage().queryEmbeddings(queryEmbedding, topK);
-  return matches
-    .filter((m) => modelMatches(m.metadata, currentModel))
-    .map((m) => ({ slug: m.id, score: m.score }));
+  // A query can throw on a dimension mismatch (e.g. mid model-migration, when
+  // the store still holds vectors of the previous dimension). Degrade to "no
+  // vector results" rather than propagating — callers fuse/fall back on [].
+  try {
+    const matches = await getStorage().queryEmbeddings(queryEmbedding, topK);
+    return matches
+      .filter((m) => modelMatches(m.metadata, currentModel))
+      .map((m) => ({ slug: m.id, score: m.score }));
+  } catch (err) {
+    logger.warn("embeddings", "searchByVector query failed:", err);
+    return [];
+  }
 }
 
 /**
@@ -485,12 +495,20 @@ export async function relatedByVector(
   const currentModel = getEmbeddingModelName();
   if (!modelMatches(self.metadata, currentModel)) return [];
 
-  // Over-fetch by one to absorb the page's own vector, then drop it.
-  const matches = await getStorage().queryEmbeddings(self.vector, topK + 1);
-  return matches
-    .filter((m) => m.id !== slug && modelMatches(m.metadata, currentModel))
-    .slice(0, topK)
-    .map((m) => ({ slug: m.id, score: m.score }));
+  // Over-fetch by one to absorb the page's own vector, then drop it. A query can
+  // throw on a dimension mismatch (mixed-dimension store mid model-migration);
+  // this runs unguarded on the article render path (findSimilarPages), so
+  // degrade to "no related pages" rather than failing the page.
+  try {
+    const matches = await getStorage().queryEmbeddings(self.vector, topK + 1);
+    return matches
+      .filter((m) => m.id !== slug && modelMatches(m.metadata, currentModel))
+      .slice(0, topK)
+      .map((m) => ({ slug: m.id, score: m.score }));
+  } catch (err) {
+    logger.warn("embeddings", "relatedByVector query failed:", err);
+    return [];
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -505,10 +523,12 @@ export interface RebuildResult {
 }
 
 /**
- * Rebuild the entire vector store from scratch.
+ * Re-embed every wiki page and upsert it into the vector store. Used to backfill
+ * after provisioning the index or switching embedding models.
  *
- * Lists all wiki pages, embeds each page's content, and saves a completely
- * new vector store — replacing whatever was on disk before.
+ * Upserts in place; it does NOT delete first, so embeddings for pages that no
+ * longer exist are left behind — harmless, since every read intersects results
+ * with the caller's readable/scoped slug set, so an orphan can't surface.
  *
  * Throws if no embedding provider is configured.
  *

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -352,6 +352,19 @@ function modelMatches(metadata: Record<string, string>, model: string | null): b
   return !model || !metadata.model || metadata.model === model;
 }
 
+/**
+ * Log a failed vector query at the right severity. A dimension mismatch is
+ * BENIGN — it's the expected throw mid model-migration, while the store still
+ * holds vectors of the previous dimension — so it warns. Anything else (an
+ * unbound/misconfigured Vectorize binding, an outage, a quota error) means
+ * vector search is actually down and silently degrading to BM25, so it escalates
+ * to error to reach the log sink rather than whisper.
+ */
+function logVectorQueryFailure(fn: string, err: unknown): void {
+  const benign = err instanceof Error && /dimension mismatch/i.test(err.message);
+  logger[benign ? "warn" : "error"]("embeddings", `${fn} query failed:`, err);
+}
+
 /** Remove every stored embedding (used by the admin content reset). */
 export async function clearEmbeddings(): Promise<void> {
   await withFileLock("vectors", async () => {
@@ -467,11 +480,21 @@ export async function searchByVector(
   // vector results" rather than propagating — callers fuse/fall back on [].
   try {
     const matches = await getStorage().queryEmbeddings(queryEmbedding, topK);
-    return matches
-      .filter((m) => modelMatches(m.metadata, currentModel))
-      .map((m) => ({ slug: m.id, score: m.score }));
+    const kept = matches.filter((m) => modelMatches(m.metadata, currentModel));
+    // If the store returned hits but the model filter dropped ALL of them, the
+    // active model name has drifted from what every stored vector was embedded
+    // with — vector search is silently disabled until a re-embed/rebuild. Leave
+    // a breadcrumb so that's diagnosable rather than looking like "no matches".
+    if (matches.length > 0 && kept.length === 0) {
+      logger.warn(
+        "embeddings",
+        `searchByVector: all ${matches.length} matches dropped by the model filter ` +
+          `(active="${currentModel}") — likely embedding-model drift; rebuild embeddings.`,
+      );
+    }
+    return kept.map((m) => ({ slug: m.id, score: m.score }));
   } catch (err) {
-    logger.warn("embeddings", "searchByVector query failed:", err);
+    logVectorQueryFailure("searchByVector", err);
     return [];
   }
 }
@@ -506,7 +529,7 @@ export async function relatedByVector(
       .slice(0, topK)
       .map((m) => ({ slug: m.id, score: m.score }));
   } catch (err) {
-    logger.warn("embeddings", "relatedByVector query failed:", err);
+    logVectorQueryFailure("relatedByVector", err);
     return [];
   }
 }

--- a/src/lib/storage/cloudflare-types.ts
+++ b/src/lib/storage/cloudflare-types.ts
@@ -94,6 +94,8 @@ export interface VectorizeIndex {
   upsert(vectors: VectorizeVector[]): Promise<{ count: number }>;
   query(vector: number[], options: VectorizeQueryOptions): Promise<VectorizeMatches>;
   deleteByIds(ids: string[]): Promise<{ count: number }>;
+  /** Fetch stored vectors (values + metadata) by id. Absent ids are omitted. */
+  getByIds(ids: string[]): Promise<VectorizeVector[]>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/storage/filesystem.ts
+++ b/src/lib/storage/filesystem.ts
@@ -270,9 +270,18 @@ export class FilesystemStorageProvider implements StorageProvider {
     return scored.slice(0, topK);
   }
 
+  async getEmbeddingById(id: string): Promise<EmbeddingEntry | null> {
+    const entries = await this.loadEmbeddings();
+    return entries.find((e) => e.id === id) ?? null;
+  }
+
   async removeEmbedding(id: string): Promise<void> {
     const entries = await this.loadEmbeddings();
     const filtered = entries.filter((e) => e.id !== id);
     await this.saveEmbeddings(filtered);
+  }
+
+  async clearEmbeddings(): Promise<void> {
+    await this.saveEmbeddings([]);
   }
 }

--- a/src/lib/storage/r2.ts
+++ b/src/lib/storage/r2.ts
@@ -26,6 +26,7 @@ import type {
   KVNamespace,
   VectorizeIndex,
 } from "./cloudflare-types";
+import { logger } from "../logger";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -294,7 +295,14 @@ export class R2StorageProvider implements StorageProvider {
       // Vectorize has no bulk-clear primitive (deleting by id needs the full id
       // list, which we don't track). After a content reset every page is gone,
       // so orphaned vectors are filtered out at query time anyway — a full purge
-      // means recreating the index. Best-effort no-op here, by design.
+      // means recreating the index. Best-effort no-op here, by design — but log
+      // it so a caller (admin reset) isn't silently reporting success for a clear
+      // the managed index didn't actually perform.
+      logger.warn(
+        "storage",
+        "clearEmbeddings: Vectorize has no bulk-clear; vectors left in place " +
+          "(filtered at query time). Recreate the index to fully purge.",
+      );
       return;
     }
     await this.kv.put(EMBEDDINGS_KV_KEY, JSON.stringify([]));

--- a/src/lib/storage/r2.ts
+++ b/src/lib/storage/r2.ts
@@ -17,6 +17,7 @@ import type {
   FileWithEtag,
   FileEntry,
   EmbeddingMatch,
+  EmbeddingEntry,
 } from "./types";
 
 import type {
@@ -265,6 +266,19 @@ export class R2StorageProvider implements StorageProvider {
     return scored.slice(0, topK);
   }
 
+  async getEmbeddingById(id: string): Promise<EmbeddingEntry | null> {
+    if (this.vectorize) {
+      const got = await this.vectorize.getByIds([id]);
+      const v = got?.[0];
+      return v
+        ? { id: v.id, vector: v.values, metadata: v.metadata ?? {} }
+        : null;
+    }
+    const entries = await this.loadEmbeddingsFromKV();
+    const e = entries.find((x) => x.id === id);
+    return e ? { id: e.id, vector: e.vector, metadata: e.metadata } : null;
+  }
+
   async removeEmbedding(id: string): Promise<void> {
     if (this.vectorize) {
       await this.vectorize.deleteByIds([id]);
@@ -273,6 +287,17 @@ export class R2StorageProvider implements StorageProvider {
       const filtered = entries.filter((e) => e.id !== id);
       await this.kv.put(EMBEDDINGS_KV_KEY, JSON.stringify(filtered));
     }
+  }
+
+  async clearEmbeddings(): Promise<void> {
+    if (this.vectorize) {
+      // Vectorize has no bulk-clear primitive (deleting by id needs the full id
+      // list, which we don't track). After a content reset every page is gone,
+      // so orphaned vectors are filtered out at query time anyway — a full purge
+      // means recreating the index. Best-effort no-op here, by design.
+      return;
+    }
+    await this.kv.put(EMBEDDINGS_KV_KEY, JSON.stringify([]));
   }
 
   // -------------------------------------------------------------------------

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -75,7 +75,7 @@ export interface FileEntry {
 }
 
 // ---------------------------------------------------------------------------
-// Embedding types (mirror src/lib/embeddings.ts VectorEntry)
+// Embedding types — the storage-layer vector representation
 // ---------------------------------------------------------------------------
 
 /** Metadata stored alongside each embedding vector. */

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -249,9 +249,23 @@ export interface StorageProvider {
   queryEmbeddings(vector: number[], topK: number): Promise<EmbeddingMatch[]>;
 
   /**
+   * Fetch a single stored embedding (vector + metadata) by id, or null when it
+   * isn't present. Used to reuse a page's own vector (related-pages) and to skip
+   * re-embedding unchanged content (contentHash compare) without a similarity scan.
+   */
+  getEmbeddingById(id: string): Promise<EmbeddingEntry | null>;
+
+  /**
    * Remove an embedding by id.
    * No-op if the id doesn't exist.
    * @param id — the identifier to remove
    */
   removeEmbedding(id: string): Promise<void>;
+
+  /**
+   * Remove ALL embeddings (content reset). On a managed index that lacks a
+   * bulk-clear primitive this may be best-effort — see the provider's note —
+   * but it must never throw.
+   */
+  clearEmbeddings(): Promise<void>;
 }


### PR DESCRIPTION
**Scaling PR 3 of 4** — the infra change.

## Problem
`embeddings.ts` kept its own `.vectors.json` blob: **loaded, `JSON.parse`d, and linearly cosine-scanned on every query.** At 1000+ pages that's a multi-MB parse + full scan per search — the vector half of the scaling problem.

## The happy surprise
The Vectorize path was **already scaffolded but unused**: `wrangler.jsonc` declares the `YOPEDIA_VECTORIZE` binding; `src/lib/storage/r2.ts` already implements `upsert/query/removeEmbedding` against Vectorize with a **KV brute-force fallback**; `filesystem.ts` has the local parallel; the types exist. `embeddings.ts` just never called them. So this is mostly **wiring**.

## What changed
- **`embeddings.ts` delegates to `getStorage()`**: `searchByVector`→`queryEmbeddings`, `relatedByVector`→`getEmbeddingById`+`queryEmbeddings`, `upsert/remove/rebuild`→provider methods. Production = Vectorize ANN (no blob load/parse/scan); no binding = KV fallback; local/tests = filesystem store.
- **Metadata model**: the store-level `{model}` + per-entry `{contentHash}` move into per-vector metadata `{ model, contentHash }`. Reads drop matches whose `model` ≠ the active one (per-entry stale-model guard); upserts skip re-embedding when both `contentHash` **and** `model` match (one id lookup, not a scan).
- **Interface additions**: `getEmbeddingById` (reuse a page's own vector for related-pages + cheap skip check) and `clearEmbeddings` (content reset); `VectorizeIndex.getByIds`. Implemented in r2 (Vectorize/KV) + filesystem.
- **rebuild** upserts all current pages; orphans from deleted pages are left (no bulk-clear on a managed index) but are **harmless** — every read intersects with the caller's readable/scoped slug set, so an orphan can't surface.
- `admin/reset` → `clearEmbeddings()`. Retired `loadVectorStore`/`saveVectorStore`/`.vectors.json` + the `VectorStore`/`VectorEntry` types.

## ⚠️ Provisioning (you run these, post-merge + deploy)
1. `npx wrangler vectorize create yopedia-embeddings --dimensions=1024 --metric=cosine`  *(bge-m3 = 1024, cosine; binding already in wrangler.jsonc)*
2. After deploy, `POST /api/settings/rebuild-embeddings` once to backfill Vectorize from existing pages.

Until then it transparently uses the KV fallback (correct, just not ANN-fast).

## Tests
`embeddings.test.ts` reworked to seed/inspect via the storage provider (filesystem) instead of the removed blob helpers; `storage-r2.test.ts` +4 covering `getByIds`/`getEmbeddingById`/`clearEmbeddings` on both KV-fallback and Vectorize paths.

`pnpm build` clean · **2781 tests pass** · no `.vectors.json` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)