### PR TITLE
Ingest: vector-prefilter findRelatedPages candidates (scale fix 4/4)

### DIFF
--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -3,18 +3,22 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 
-// Mock the LLM module — search.ts imports callLLM/hasLLMKey at module level
-// for findRelatedPages, but we don't test that function here.
+// Mock the LLM module — search.ts imports callLLM/hasLLMKey at module level for
+// findRelatedPages (default off; the findRelatedPages tests opt in).
 vi.mock("../llm", () => ({
   hasLLMKey: vi.fn(() => false),
   callLLM: vi.fn(async () => "[]"),
 }));
 
-// Stub the vector primitive so findSimilarPages tests control the ranking
-// without a real embedding store; keep every other embeddings export real.
+// Stub the vector primitives so findSimilarPages / findRelatedPages tests control
+// the ranking without a real embedding store; keep every other export real.
 vi.mock("../embeddings", async (orig) => {
   const actual = await orig<typeof import("../embeddings")>();
-  return { ...actual, relatedByVector: vi.fn(async () => []) };
+  return {
+    ...actual,
+    relatedByVector: vi.fn(async () => []),
+    searchByVector: vi.fn(async () => []),
+  };
 });
 
 import {
@@ -27,6 +31,7 @@ import {
   searchWikiContent,
   findBacklinks,
   findSimilarPages,
+  findRelatedPages,
   updateRelatedPages,
   fuzzyMatch,
   levenshteinDistance,
@@ -37,15 +42,20 @@ import {
 } from "../search";
 import type { SearchScope } from "../search";
 import type { Principal } from "../auth";
+import type { IndexEntry } from "../types";
 import { registerAgent, ensureAgentsDir } from "../agents";
 import { createVault, addToVault, vaultIdFor } from "../vault";
 import { serializeFrontmatter } from "../frontmatter";
 import { isAgentScopedType } from "../wiki";
 import type { AgentProfile } from "../types";
 import { _resetStorage } from "../storage";
-import { relatedByVector } from "../embeddings";
+import { relatedByVector, searchByVector } from "../embeddings";
+import { hasLLMKey, callLLM } from "../llm";
 
 const mockedRelatedByVector = vi.mocked(relatedByVector);
+const mockedSearchByVector = vi.mocked(searchByVector);
+const mockedHasLLMKey = vi.mocked(hasLLMKey);
+const mockedCallLLM = vi.mocked(callLLM);
 
 let tmpDir: string;
 let originalWikiDir: string | undefined;
@@ -1109,5 +1119,77 @@ describe("resolveScopeSlugs", () => {
   it("an unresolvable scope → error", async () => {
     const r = await resolveScopeSlugs("user:bogus", alice);
     expect(r.error).toMatch(/Invalid scope/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findRelatedPages — ingest-time candidate prefilter
+// ---------------------------------------------------------------------------
+
+describe("findRelatedPages — candidate prefilter", () => {
+  beforeEach(() => {
+    mockedHasLLMKey.mockReturnValue(true);
+    mockedSearchByVector.mockReset();
+    mockedSearchByVector.mockResolvedValue([]);
+    mockedCallLLM.mockReset();
+    mockedCallLLM.mockResolvedValue("[]");
+  });
+
+  afterEach(() => {
+    // Restore the suite-wide default so later describes see no LLM.
+    mockedHasLLMKey.mockReturnValue(false);
+  });
+
+  function makeEntries(n: number): IndexEntry[] {
+    return Array.from({ length: n }, (_, i) => ({
+      slug: `page-${i}`,
+      title: `Page ${i}`,
+      summary: `Summary ${i}`,
+    }));
+  }
+
+  const indexLines = (msg: string) => msg.match(/^- page-\d+:/gm) ?? [];
+
+  it("narrows the LLM candidate list to the vector hits on a large wiki", async () => {
+    const entries = makeEntries(100);
+    // The vector store says only these three are semantically near.
+    mockedSearchByVector.mockResolvedValue([
+      { slug: "page-1", score: 0.9 },
+      { slug: "page-2", score: 0.8 },
+      { slug: "page-3", score: 0.7 },
+    ]);
+    mockedCallLLM.mockResolvedValue('["page-1"]');
+
+    const related = await findRelatedPages("new-page", "some new content", entries);
+
+    expect(mockedSearchByVector).toHaveBeenCalled();
+    const userMessage = mockedCallLLM.mock.calls[0][1] as string;
+    expect(userMessage).toContain("- page-1:");
+    expect(userMessage).toContain("- page-3:");
+    expect(userMessage).not.toContain("- page-50:");
+    // Bounded by the hits — not all 100 pages.
+    expect(indexLines(userMessage)).toHaveLength(3);
+    expect(related).toEqual(["page-1"]);
+  });
+
+  it("falls back to the full index when the vector store is empty", async () => {
+    const entries = makeEntries(100);
+    mockedSearchByVector.mockResolvedValue([]); // empty / no-embedding store
+
+    await findRelatedPages("new-page", "content", entries);
+
+    const userMessage = mockedCallLLM.mock.calls[0][1] as string;
+    expect(userMessage).toContain("- page-99:"); // a distant page is present
+    expect(indexLines(userMessage)).toHaveLength(100);
+  });
+
+  it("does not prefilter a small wiki (≤ candidate pool)", async () => {
+    const entries = makeEntries(10);
+
+    await findRelatedPages("new-page", "content", entries);
+
+    expect(mockedSearchByVector).not.toHaveBeenCalled();
+    const userMessage = mockedCallLLM.mock.calls[0][1] as string;
+    expect(indexLines(userMessage)).toHaveLength(10);
   });
 });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -127,6 +127,15 @@ export const QUERY_MAX_OUTPUT_TOKENS = 8192;
 export const RELATED_PAGES_LIMIT = 6;
 
 /**
+ * Candidate pool size for the ingest-time cross-reference (`findRelatedPages`).
+ * On a wiki larger than this, the candidate list handed to the LLM is first
+ * narrowed to the nearest pages by vector similarity, so the classify prompt
+ * stays bounded (O(K)) instead of listing every page (O(all pages)). Comfortably
+ * larger than RELATED_PAGES_LIMIT so the LLM still has room to choose.
+ */
+export const RELATED_CANDIDATE_POOL = 30;
+
+/**
  * Minimum cosine similarity for a page to count as "related". Tuned for
  * bge-m3: distinct-but-related pages sit well above this, while unrelated
  * pages fall below — so weak matches don't pad the section.

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -23,8 +23,8 @@ import { getVault } from "./vault";
 import { getStorage } from "./storage";
 import { getOwnerIndex } from "./owner-index";
 import { getBacklinkIndex, syncBacklinksForPage } from "./backlink-index";
-import { relatedByVector } from "./embeddings";
-import { RELATED_PAGES_LIMIT, RELATED_MIN_SCORE } from "./constants";
+import { relatedByVector, searchByVector } from "./embeddings";
+import { RELATED_PAGES_LIMIT, RELATED_MIN_SCORE, RELATED_CANDIDATE_POOL } from "./constants";
 
 // ---------------------------------------------------------------------------
 // Cross-referencing helpers
@@ -49,9 +49,35 @@ export async function findRelatedPages(
     return [];
   }
 
-  // Build a user message with the index and the new page's content
-  const indexList = existingEntries
-    .filter((e) => e.slug !== newSlug)
+  let candidates = existingEntries.filter((e) => e.slug !== newSlug);
+
+  // On a large wiki, narrow the candidate list to the nearest pages by vector
+  // similarity BEFORE asking the LLM, so the classify prompt stays bounded
+  // (~RELATED_CANDIDATE_POOL lines) instead of listing every page. Fail-soft:
+  // if the vector store is empty or errors, fall back to the full list (so small
+  // wikis and no-embedding setups behave exactly as before).
+  if (candidates.length > RELATED_CANDIDATE_POOL) {
+    try {
+      const allowed = new Set(candidates.map((e) => e.slug));
+      const hits = (await searchByVector(newContent, RELATED_CANDIDATE_POOL))
+        .filter((h) => allowed.has(h.slug));
+      if (hits.length > 0) {
+        const bySlug = new Map(candidates.map((e) => [e.slug, e]));
+        candidates = hits
+          .map((h) => bySlug.get(h.slug))
+          .filter((e): e is IndexEntry => e !== undefined);
+      }
+    } catch (err) {
+      logger.warn(
+        "wiki",
+        "findRelatedPages vector prefilter failed; using the full index:",
+        err,
+      );
+    }
+  }
+
+  // Build a user message with the (possibly narrowed) index and the new page.
+  const indexList = candidates
     .map((e) => `- ${e.slug}: ${e.title} — ${e.summary}`)
     .join("\n");
 


### PR DESCRIPTION
**Scaling PR 4 of 4** — the one place Grok's "routing" idea genuinely applies.

## Problem
`findRelatedPages` (the ingest-time cross-reference step) built its classify prompt from **every** index entry (`slug — title — summary`), so each source ingested fired one LLM call whose prompt grows O(pages). At 1000 pages that's a ~1000-line prompt per ingest.

## Fix
On a wiki larger than `RELATED_CANDIDATE_POOL` (30), narrow the candidate list with `searchByVector(newContent, 30)` **before** building the prompt — the LLM then picks from the nearest pages instead of the whole index. Bounded at O(K).

Fail-soft: an empty vector store or a vector error falls back to the full index, so small wikis and no-embedding setups behave exactly as today. (After PR #487's Vectorize migration, this prefilter is a cheap ANN lookup; embeds `newContent`, not the slug, so it's correct regardless of whether the new page is embedded yet.)

## Tests
`search.test.ts` (+3): a 100-page wiki narrows the prompt to just the vector hits; an empty store falls back to the full 100-page list; a 10-page wiki isn't prefiltered (searchByVector not called).

`pnpm build` clean · **2781 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)