### PR TITLE
Add service-token /api/admin/rebuild-embeddings (prod Vectorize backfill)

### DIFF
--- a/src/app/api/admin/rebuild-embeddings/route.ts
+++ b/src/app/api/admin/rebuild-embeddings/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { getServicePrincipal } from "@/lib/auth";
+import { rebuildVectorStore } from "@/lib/embeddings";
+import { getErrorMessage } from "@/lib/errors";
+import { logger } from "@/lib/logger";
+
+/**
+ * POST /api/admin/rebuild-embeddings — re-embed every wiki page into the vector
+ * store (Cloudflare Vectorize in production).
+ *
+ * Service-token only, authenticated IN-ROUTE (no Clerk session), so it runs on
+ * the read-only Workers runtime where the settings-page rebuild
+ * (`/api/settings/rebuild-embeddings`) is hard-disabled by `isReadOnly()`. This
+ * is the way to backfill Vectorize after provisioning or recreating the index.
+ */
+export async function POST(req: Request) {
+  const principal = getServicePrincipal(req);
+  if (!principal) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    logger.warn("admin", `rebuild-embeddings requested by ${principal.handle}`);
+    const result = await rebuildVectorStore();
+    return NextResponse.json(result);
+  } catch (err: unknown) {
+    const message = getErrorMessage(err, "Failed to rebuild vector store");
+    // "No embedding provider configured" is a config problem → 400; else 500.
+    const status = message.includes("No embedding provider") ? 400 : 500;
+    logger.error("admin", "rebuild-embeddings failed:", err);
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/lib/__tests__/middleware-write-gate.test.ts
+++ b/src/lib/__tests__/middleware-write-gate.test.ts
@@ -24,6 +24,7 @@ describe("write-gate in-route auth exemptions", () => {
     expect(authenticatesInRoute("/api/agents/alice--yoyo/ingest")).toBe(true);
     expect(authenticatesInRoute("/api/admin/migrate")).toBe(true);
     expect(authenticatesInRoute("/api/admin/reset")).toBe(true);
+    expect(authenticatesInRoute("/api/admin/rebuild-embeddings")).toBe(true);
     expect(authenticatesInRoute("/api/admin/tenant/alice")).toBe(true);
     // Wiki routes: POST /api/wiki (create) and PUT/PATCH/DELETE /api/wiki/:slug
     expect(authenticatesInRoute("/api/wiki")).toBe(true);

--- a/src/lib/__tests__/rebuild-embeddings-route.test.ts
+++ b/src/lib/__tests__/rebuild-embeddings-route.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({ getServicePrincipal: vi.fn() }));
+vi.mock("@/lib/embeddings", () => ({ rebuildVectorStore: vi.fn() }));
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+import { getServicePrincipal } from "@/lib/auth";
+import { rebuildVectorStore } from "@/lib/embeddings";
+
+const mockedGetService = vi.mocked(getServicePrincipal);
+const mockedRebuild = vi.mocked(rebuildVectorStore);
+
+async function post() {
+  const { POST } = await import("@/app/api/admin/rebuild-embeddings/route");
+  return POST(
+    new Request("http://localhost/api/admin/rebuild-embeddings", { method: "POST" }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetService.mockReturnValue({ id: "service:yopedia", handle: "yopedia" });
+  mockedRebuild.mockResolvedValue({ total: 3, embedded: 3, skipped: 0, model: "@cf/baai/bge-m3" });
+});
+
+describe("POST /api/admin/rebuild-embeddings", () => {
+  it("401s without the service token (and does not rebuild)", async () => {
+    mockedGetService.mockReturnValue(null);
+    const res = await post();
+    expect(res.status).toBe(401);
+    expect(mockedRebuild).not.toHaveBeenCalled();
+  });
+
+  it("rebuilds and returns the result for a valid service token", async () => {
+    const res = await post();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ embedded: 3, model: "@cf/baai/bge-m3" });
+    expect(mockedRebuild).toHaveBeenCalledOnce();
+  });
+
+  it("maps a missing-provider error to 400", async () => {
+    mockedRebuild.mockRejectedValue(new Error("No embedding provider configured."));
+    const res = await post();
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/No embedding provider/) });
+  });
+
+  it("maps an unexpected error to 500", async () => {
+    mockedRebuild.mockRejectedValue(new Error("vectorize upsert failed"));
+    const res = await post();
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -48,6 +48,9 @@ const IN_ROUTE_AUTH_PATHS = new Set([
   // Admin content reset (destructive wipe): service-token only, in-route, with
   // an explicit confirm body. Called with no Clerk session.
   "/api/admin/reset",
+  // Admin embedding rebuild: service-token only, in-route. Backfills Vectorize
+  // (the settings-page rebuild is disabled on the read-only Workers runtime).
+  "/api/admin/rebuild-embeddings",
   // Wiki page creation: authenticated in-route via Clerk session OR the
   // service token (agents create pages via REST).
   "/api/wiki",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,81 +1,80 @@
 {
-  // yopedia — Cloudflare Pages deployment via @opennextjs/cloudflare
-  //
-  // Binding names match src/lib/storage/cloudflare-types.ts CloudflareEnv:
-  //   YOPEDIA_BUCKET   → R2Bucket
-  //   YOPEDIA_CONFIG   → KVNamespace
-  //   YOPEDIA_VECTORIZE → VectorizeIndex (optional)
-  //
-  // After provisioning resources, update bucket_name / id / index_name
-  // to match your Cloudflare account. Run:
-  //   npx wrangler r2 bucket list
-  //   npx wrangler kv namespace list
-  //   npx wrangler vectorize list
-
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "yopedia",
-  "main": ".open-next/worker.js",
-  "compatibility_date": "2025-01-01",
-  "compatibility_flags": ["nodejs_compat"],
-  "assets": {
-    "directory": ".open-next/assets",
-    "binding": "ASSETS"
-  },
-
-  // --- R2: Primary storage (wiki pages, raw sources, assets) ---
-  "r2_buckets": [
-    {
-      "binding": "YOPEDIA_BUCKET",
-      "bucket_name": "yopedia-raw"
-    }
-  ],
-
-  // --- KV: Config and derived indexes ---
-  "kv_namespaces": [
-    {
-      "binding": "YOPEDIA_CONFIG",
-      "id": "31e48c3fc033443788f1d3fe130e6266"
-    }
-  ],
-
-  // --- Vectorize: Semantic search embeddings (optional) ---
-  "vectorize": [
-    {
-      "binding": "YOPEDIA_VECTORIZE",
-      "index_name": "yopedia-embeddings"
-    }
-  ],
-
-  // --- Workers AI: serverless embeddings (e.g. @cf/baai/bge-m3 for CJK) ---
-  "ai": {
-    "binding": "AI"
-  },
-
-  // --- Queues: producer for the agent task queue (async maintenance + ingest).
-  // The consumer is a separate worker (workers/task-consumer/). enqueueTask()
-  // (src/lib/tasks.ts) sends here; it no-ops gracefully when this binding is
-  // absent (local dev / next start / tests). One-time provisioning:
-  //   npx wrangler queues create yopedia-tasks
-  //   npx wrangler queues create yopedia-tasks-dlq
-  "queues": {
-    "producers": [
-      {
-        "binding": "TASK_QUEUE",
-        "queue": "yopedia-tasks"
-      }
-    ]
-  },
-
-  // Public site-owner handle for runtime server gates (owner-only Lint). The
-  // authoritative copy for the client is the build-time inline (deploy
-  // workflow); this is runtime parity for server reads. Public, not a secret.
-  //
-  // AUTONOMOUS_MAINTENANCE="on" enables the daily maintenance cron to actually
-  // enqueue maintain tasks (reconcile disputes, refresh stale pages, and the
-  // deterministic janitorial fixes). Anything other than "on" = dry-run.
-  // See workers/task-consumer/README.md.
-  "vars": {
-    "NEXT_PUBLIC_OWNER_HANDLE": "yuanhao",
-    "AUTONOMOUS_MAINTENANCE": "on"
-  }
+	// yopedia — Cloudflare Pages deployment via @opennextjs/cloudflare
+	//
+	// Binding names match src/lib/storage/cloudflare-types.ts CloudflareEnv:
+	//   YOPEDIA_BUCKET   → R2Bucket
+	//   YOPEDIA_CONFIG   → KVNamespace
+	//   YOPEDIA_VECTORIZE → VectorizeIndex (optional)
+	//
+	// After provisioning resources, update bucket_name / id / index_name
+	// to match your Cloudflare account. Run:
+	//   npx wrangler r2 bucket list
+	//   npx wrangler kv namespace list
+	//   npx wrangler vectorize list
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "yopedia",
+	"main": ".open-next/worker.js",
+	"compatibility_date": "2025-01-01",
+	"compatibility_flags": [
+		"nodejs_compat"
+	],
+	"assets": {
+		"directory": ".open-next/assets",
+		"binding": "ASSETS"
+	},
+	// --- R2: Primary storage (wiki pages, raw sources, assets) ---
+	"r2_buckets": [
+		{
+			"binding": "YOPEDIA_BUCKET",
+			"bucket_name": "yopedia-raw"
+		}
+	],
+	// --- KV: Config and derived indexes ---
+	"kv_namespaces": [
+		{
+			"binding": "YOPEDIA_CONFIG",
+			"id": "31e48c3fc033443788f1d3fe130e6266"
+		}
+	],
+	// --- Vectorize: Semantic search embeddings (optional) ---
+	"vectorize": [
+		{
+			"binding": "YOPEDIA_VECTORIZE",
+			"index_name": "yopedia-embeddings"
+		},
+		{
+			"binding": "VECTORIZE",
+			"index_name": "yopedia-embeddings"
+		}
+	],
+	// --- Workers AI: serverless embeddings (e.g. @cf/baai/bge-m3 for CJK) ---
+	"ai": {
+		"binding": "AI"
+	},
+	// --- Queues: producer for the agent task queue (async maintenance + ingest).
+	// The consumer is a separate worker (workers/task-consumer/). enqueueTask()
+	// (src/lib/tasks.ts) sends here; it no-ops gracefully when this binding is
+	// absent (local dev / next start / tests). One-time provisioning:
+	//   npx wrangler queues create yopedia-tasks
+	//   npx wrangler queues create yopedia-tasks-dlq
+	"queues": {
+		"producers": [
+			{
+				"binding": "TASK_QUEUE",
+				"queue": "yopedia-tasks"
+			}
+		]
+	},
+	// Public site-owner handle for runtime server gates (owner-only Lint). The
+	// authoritative copy for the client is the build-time inline (deploy
+	// workflow); this is runtime parity for server reads. Public, not a secret.
+	//
+	// AUTONOMOUS_MAINTENANCE="on" enables the daily maintenance cron to actually
+	// enqueue maintain tasks (reconcile disputes, refresh stale pages, and the
+	// deterministic janitorial fixes). Anything other than "on" = dry-run.
+	// See workers/task-consumer/README.md.
+	"vars": {
+		"NEXT_PUBLIC_OWNER_HANDLE": "yuanhao",
+		"AUTONOMOUS_MAINTENANCE": "on"
+	}
 }


### PR DESCRIPTION
## Why
The Vectorize migration (#487) documented backfill via `POST /api/settings/rebuild-embeddings` — but that route **hard-403s on prod**: `isReadOnly()` is always true on the Workers runtime. So there was **no way to populate Vectorize in production**, and semantic search silently degrades to BM25 until vectors exist.

## What
New **`POST /api/admin/rebuild-embeddings`**: service-token gated, authenticated **in-route** (no Clerk session, same pattern as `/api/admin/reset`), **no `isReadOnly` block**. Runs `rebuildVectorStore()` to re-embed every page into the live store (Vectorize in prod, KV/fs fallback otherwise). Added to the middleware in-route-auth exemption so the service-token caller reaches the handler instead of a 401.

Returns `{ total, embedded, skipped, model }`.

## Tests
- `rebuild-embeddings-route.test.ts`: 401 without token (no rebuild); 200 + result for a valid token; missing-provider → 400; unexpected error → 500.
- `middleware-write-gate.test.ts`: asserts the new path is exempt.

`pnpm build` clean · **2798 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)