### PR TITLE
Query history: store in the tenant silo (account-delete coverage)

### DIFF
--- a/src/lib/__tests__/query-history.test.ts
+++ b/src/lib/__tests__/query-history.test.ts
@@ -200,4 +200,60 @@ describe("legacy migration → tenant silo", () => {
     await fs.writeFile(legacyPerOwnerPath("alice"), legacy, "utf-8");
     expect(await listQueries(undefined, "alice")).toHaveLength(1); // no duplicate
   });
+
+  it("consolidates BOTH legacy sources for one owner, deduping a shared id (no dup)", async () => {
+    await fs.mkdir(path.join(tmpDir, "wiki", "query-history"), { recursive: true });
+    await fs.writeFile(legacySharedPath(), JSON.stringify([
+      { id: "s1", ...entry("alice", { question: "shared q" }) },
+      { id: "dup", ...entry("alice", { question: "from shared" }) },
+    ]), "utf-8");
+    await fs.writeFile(legacyPerOwnerPath("alice"), JSON.stringify([
+      { id: "p1", ...entry("alice", { question: "interim q" }) },
+      { id: "dup", ...entry("alice", { question: "from interim" }) }, // same id in both
+    ]), "utf-8");
+
+    const ids = (await listQueries(undefined, "alice")).map((e) => e.id).sort();
+    expect(ids).toEqual(["dup", "p1", "s1"]); // dup exactly once
+    await expect(fs.access(legacySharedPath())).rejects.toThrow();
+    await expect(fs.access(legacyPerOwnerPath("alice"))).rejects.toThrow();
+  });
+
+  it("prunes the shared file per-owner: keeps bob until bob migrates", async () => {
+    await fs.mkdir(path.join(tmpDir, "wiki"), { recursive: true });
+    await fs.writeFile(legacySharedPath(), JSON.stringify([
+      { id: "a", ...entry("alice", { question: "alice q" }) },
+      { id: "b", ...entry("bob", { question: "bob q" }) },
+    ]), "utf-8");
+
+    await listQueries(undefined, "alice");
+    // Shared file still exists and now holds ONLY bob's entry.
+    const afterAlice = JSON.parse(await fs.readFile(legacySharedPath(), "utf-8"));
+    expect(afterAlice.map((e: { owner: string }) => e.owner)).toEqual(["bob"]);
+
+    await listQueries(undefined, "bob");
+    await expect(fs.access(legacySharedPath())).rejects.toThrow(); // now empty → deleted
+    expect((await listQueries(undefined, "bob")).map((e) => e.question)).toEqual(["bob q"]);
+  });
+
+  it("quarantines an unparseable legacy file instead of probing it forever", async () => {
+    await fs.mkdir(path.join(tmpDir, "wiki"), { recursive: true });
+    await fs.writeFile(legacySharedPath(), "not json!", "utf-8");
+
+    expect(await listQueries(undefined, "alice")).toEqual([]);
+    // Original removed; quarantined copy kept for recovery.
+    await expect(fs.access(legacySharedPath())).rejects.toThrow();
+    expect(await fs.readFile(`${legacySharedPath()}.corrupt`, "utf-8")).toBe("not json!");
+  });
+});
+
+describe("tenant keying contract", () => {
+  it("owners that normalize to the same tenant share one silo file (consistent identity)", async () => {
+    // ownerToTenant maps "al.ice" and "al-ice" to the same tenant — the same
+    // identity the app uses for pages/raw/discuss, so they intentionally share.
+    expect(tenantForOwner("al.ice")).toBe(tenantForOwner("al-ice"));
+    await appendQuery(entry("al.ice", { question: "dotted" }));
+    await appendQuery(entry("al-ice", { question: "dashed", timestamp: "2025-01-02T00:00:00Z" }));
+    expect((await listQueries(undefined, "al.ice")).map((e) => e.question)).toEqual(["dashed", "dotted"]);
+    expect((await listQueries(undefined, "al-ice")).map((e) => e.question)).toEqual(["dashed", "dotted"]);
+  });
 });

--- a/src/lib/__tests__/query-history.test.ts
+++ b/src/lib/__tests__/query-history.test.ts
@@ -3,303 +3,201 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { appendQuery, listQueries, markSaved } from "../query-history";
+import { tenantForOwner } from "../wiki";
 import { _resetLocks } from "../lock";
+import { _resetStorage } from "../storage";
 
-// History is per-asker now; tests append/list under a fixed owner.
+// History is per-asker, stored in the asker's tenant silo.
 const OWNER = "tester";
 
 let tmpDir: string;
 let originalWikiDir: string | undefined;
+let originalDataDir: string | undefined;
 
 beforeEach(async () => {
   _resetLocks();
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "qhist-test-"));
   originalWikiDir = process.env.WIKI_DIR;
+  originalDataDir = process.env.DATA_DIR;
   process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.DATA_DIR = tmpDir; // silo paths (tenants/<t>/…) resolve against this
+  _resetStorage();
 });
 
 afterEach(async () => {
-  if (originalWikiDir === undefined) {
-    delete process.env.WIKI_DIR;
-  } else {
-    process.env.WIKI_DIR = originalWikiDir;
-  }
+  if (originalWikiDir === undefined) delete process.env.WIKI_DIR;
+  else process.env.WIKI_DIR = originalWikiDir;
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+  _resetStorage();
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
+/** The silo history file for an owner. */
+const siloFile = (owner: string) =>
+  path.join(tmpDir, "tenants", tenantForOwner(owner), "query-history.json");
+/** The legacy shared single-file store. */
+const legacySharedPath = () => path.join(tmpDir, "wiki", "query-history.json");
+/** A legacy interim per-owner file (PR #493). */
+const legacyPerOwnerPath = (key: string) =>
+  path.join(tmpDir, "wiki", "query-history", `${key}.json`);
+
+const entry = (owner: string, over: Partial<Record<string, unknown>> = {}) => ({
+  question: "q", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z", owner, ...over,
+});
+
 describe("appendQuery", () => {
-  it("creates history file and appends entry", async () => {
-    const entry = await appendQuery({
-      question: "What is machine learning?",
-      answer: "Machine learning is...",
-      sources: ["machine-learning"],
-      timestamp: new Date().toISOString(),
-      owner: OWNER,
-    });
+  it("creates the silo history file and appends an entry", async () => {
+    const e = await appendQuery(entry(OWNER, { question: "What is machine learning?", answer: "ML is..." }));
+    expect(e.id).toBeTruthy();
+    expect(e.question).toBe("What is machine learning?");
 
-    expect(entry.id).toBeTruthy();
-    expect(entry.question).toBe("What is machine learning?");
-    expect(entry.answer).toBe("Machine learning is...");
-    expect(entry.sources).toEqual(["machine-learning"]);
-
-    // The per-owner file should exist (physical isolation, not a shared file).
-    const filePath = path.join(tmpDir, "wiki", "query-history", "tester.json");
-    const raw = await fs.readFile(filePath, "utf-8");
-    const data = JSON.parse(raw);
+    const data = JSON.parse(await fs.readFile(siloFile(OWNER), "utf-8"));
     expect(data).toHaveLength(1);
-    expect(data[0].id).toBe(entry.id);
+    expect(data[0].id).toBe(e.id);
   });
 
   it("appends multiple entries in order", async () => {
-    await appendQuery({ question: "Q1", answer: "A1", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: OWNER });
-    await appendQuery({ question: "Q2", answer: "A2", sources: ["page-a"], timestamp: "2025-01-02T00:00:00Z", owner: OWNER });
-    await appendQuery({ question: "Q3", answer: "A3", sources: [], timestamp: "2025-01-03T00:00:00Z", owner: OWNER });
+    await appendQuery(entry(OWNER, { question: "Q1", timestamp: "2025-01-01T00:00:00Z" }));
+    await appendQuery(entry(OWNER, { question: "Q2", timestamp: "2025-01-02T00:00:00Z" }));
+    await appendQuery(entry(OWNER, { question: "Q3", timestamp: "2025-01-03T00:00:00Z" }));
 
-    const filePath = path.join(tmpDir, "wiki", "query-history", "tester.json");
-    const raw = await fs.readFile(filePath, "utf-8");
-    const data = JSON.parse(raw);
-    expect(data).toHaveLength(3);
-    expect(data[0].question).toBe("Q1");
-    expect(data[1].question).toBe("Q2");
-    expect(data[2].question).toBe("Q3");
-  });
-});
-
-describe("per-owner physical isolation + legacy migration", () => {
-  const legacyPath = () => path.join(tmpDir, "wiki", "query-history.json");
-  const ownerFile = (owner: string) =>
-    path.join(tmpDir, "wiki", "query-history", `${owner}.json`);
-
-  it("writes each asker to a separate file and never a shared one", async () => {
-    await appendQuery({ question: "alice q", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: "alice" });
-    await appendQuery({ question: "bob q", answer: "b", sources: [], timestamp: "2025-01-02T00:00:00Z", owner: "bob" });
-
-    expect(JSON.parse(await fs.readFile(ownerFile("alice"), "utf-8"))).toHaveLength(1);
-    expect(JSON.parse(await fs.readFile(ownerFile("bob"), "utf-8"))).toHaveLength(1);
-    // No shared query-history.json — there's no cross-user file to over-read.
-    await expect(fs.access(legacyPath())).rejects.toThrow();
+    const data = JSON.parse(await fs.readFile(siloFile(OWNER), "utf-8"));
+    expect(data.map((d: { question: string }) => d.question)).toEqual(["Q1", "Q2", "Q3"]);
   });
 
-  it("migrates a legacy shared file into per-owner files, then deletes it", async () => {
-    await fs.mkdir(path.join(tmpDir, "wiki"), { recursive: true });
-    await fs.writeFile(
-      legacyPath(),
-      JSON.stringify([
-        { id: "1", question: "alice q", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: "alice" },
-        { id: "2", question: "bob q", answer: "b", sources: [], timestamp: "2025-01-02T00:00:00Z", owner: "bob" },
-        { id: "3", question: "orphan q", answer: "o", sources: [], timestamp: "2025-01-03T00:00:00Z" }, // no owner → dropped
-      ]),
-      "utf-8",
-    );
-
-    // First read for alice triggers the migration.
-    expect((await listQueries(undefined, "alice")).map((e) => e.question)).toEqual(["alice q"]);
-    // Bob's entry was preserved (lossless), the orphan dropped, legacy removed.
-    expect((await listQueries(undefined, "bob")).map((e) => e.question)).toEqual(["bob q"]);
-    await expect(fs.access(legacyPath())).rejects.toThrow();
-    expect(JSON.parse(await fs.readFile(ownerFile("alice"), "utf-8"))).toHaveLength(1);
-  });
-
-  it("a new entry survives the migration (appended after legacy entries)", async () => {
-    await fs.mkdir(path.join(tmpDir, "wiki"), { recursive: true });
-    await fs.writeFile(
-      legacyPath(),
-      JSON.stringify([
-        { id: "old", question: "old q", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: "alice" },
-      ]),
-      "utf-8",
-    );
-
-    await appendQuery({ question: "new q", answer: "b", sources: [], timestamp: "2025-01-02T00:00:00Z", owner: "alice" });
-
-    // Most-recent-first: the new entry, then the migrated legacy one.
-    expect((await listQueries(undefined, "alice")).map((e) => e.question)).toEqual(["new q", "old q"]);
-    await expect(fs.access(legacyPath())).rejects.toThrow();
+  it("does not persist an owner-less entry (returns it for optimistic UI)", async () => {
+    const e = await appendQuery({ question: "anon", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z" });
+    expect(e.id).toBeTruthy();
+    expect(await listQueries(undefined, null)).toEqual([]);
   });
 });
 
 describe("listQueries", () => {
   it("returns entries most recent first", async () => {
-    await appendQuery({ question: "First", answer: "A1", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: OWNER });
-    await appendQuery({ question: "Second", answer: "A2", sources: [], timestamp: "2025-01-02T00:00:00Z", owner: OWNER });
-
-    const entries = await listQueries(undefined, OWNER);
-    expect(entries).toHaveLength(2);
-    expect(entries[0].question).toBe("Second");
-    expect(entries[1].question).toBe("First");
+    await appendQuery(entry(OWNER, { question: "First", timestamp: "2025-01-01T00:00:00Z" }));
+    await appendQuery(entry(OWNER, { question: "Second", timestamp: "2025-01-02T00:00:00Z" }));
+    expect((await listQueries(undefined, OWNER)).map((e) => e.question)).toEqual(["Second", "First"]);
   });
 
-  it("respects limit parameter", async () => {
+  it("respects the limit", async () => {
     for (let i = 0; i < 10; i++) {
-      await appendQuery({ question: `Q${i}`, answer: `A${i}`, sources: [], timestamp: new Date(2025, 0, i + 1).toISOString(), owner: OWNER });
+      await appendQuery(entry(OWNER, { question: `Q${i}`, timestamp: new Date(2025, 0, i + 1).toISOString() }));
     }
-
-    const entries = await listQueries(3, OWNER);
-    expect(entries).toHaveLength(3);
-    expect(entries[0].question).toBe("Q9");
-    expect(entries[1].question).toBe("Q8");
-    expect(entries[2].question).toBe("Q7");
+    expect((await listQueries(3, OWNER)).map((e) => e.question)).toEqual(["Q9", "Q8", "Q7"]);
   });
 
-  it("is per-asker: returns only the owner's entries, none for anonymous", async () => {
-    await appendQuery({ question: "alice q", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: "alice" });
-    await appendQuery({ question: "bob q", answer: "b", sources: [], timestamp: "2025-01-02T00:00:00Z", owner: "bob" });
-
+  it("is per-asker: only the owner's entries, none for anonymous", async () => {
+    await appendQuery(entry("alice", { question: "alice q" }));
+    await appendQuery(entry("bob", { question: "bob q", timestamp: "2025-01-02T00:00:00Z" }));
     expect((await listQueries(undefined, "alice")).map((e) => e.question)).toEqual(["alice q"]);
     expect((await listQueries(undefined, "bob")).map((e) => e.question)).toEqual(["bob q"]);
-    // Anonymous (no owner) sees nothing.
     expect(await listQueries()).toEqual([]);
     expect(await listQueries(undefined, null)).toEqual([]);
   });
 
-  it("returns empty array when no history file exists", async () => {
-    await fs.mkdir(path.join(tmpDir, "wiki"), { recursive: true });
-    const entries = await listQueries(undefined, OWNER);
-    expect(entries).toEqual([]);
-  });
-
-  it("returns empty array when wiki dir does not exist", async () => {
-    process.env.WIKI_DIR = path.join(tmpDir, "nonexistent");
-    const entries = await listQueries(undefined, OWNER);
-    expect(entries).toEqual([]);
-  });
-
-  it("handles malformed JSON file gracefully", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const wikiDir = path.join(tmpDir, "wiki");
-    await fs.mkdir(wikiDir, { recursive: true });
-    await fs.writeFile(path.join(wikiDir, "query-history.json"), "not json!", "utf-8");
-
-    const entries = await listQueries(undefined, OWNER);
-    expect(entries).toEqual([]);
-    warnSpy.mockRestore();
+  it("returns [] when no history exists", async () => {
+    expect(await listQueries(undefined, OWNER)).toEqual([]);
   });
 });
 
 describe("markSaved", () => {
-  it("updates savedAs field on the matching entry", async () => {
-    const e1 = await appendQuery({ question: "Q1", answer: "A1", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: OWNER });
-    const e2 = await appendQuery({ question: "Q2", answer: "A2", sources: [], timestamp: "2025-01-02T00:00:00Z", owner: OWNER });
-
+  it("updates savedAs on the matching entry only", async () => {
+    const e1 = await appendQuery(entry(OWNER, { question: "Q1" }));
+    const e2 = await appendQuery(entry(OWNER, { question: "Q2", timestamp: "2025-01-02T00:00:00Z" }));
     await markSaved(e1.id, "answer-q1", OWNER);
 
     const entries = await listQueries(undefined, OWNER);
-    const updated1 = entries.find((e) => e.id === e1.id);
-    const updated2 = entries.find((e) => e.id === e2.id);
-
-    expect(updated1?.savedAs).toBe("answer-q1");
-    expect(updated2?.savedAs).toBeUndefined();
+    expect(entries.find((e) => e.id === e1.id)?.savedAs).toBe("answer-q1");
+    expect(entries.find((e) => e.id === e2.id)?.savedAs).toBeUndefined();
   });
 
-  it("does nothing for non-existent id", async () => {
-    await appendQuery({ question: "Q1", answer: "A1", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: OWNER });
-
-    await markSaved("nonexistent-id", "some-slug", OWNER);
-
-    const entries = await listQueries(undefined, OWNER);
-    expect(entries).toHaveLength(1);
-    expect(entries[0].savedAs).toBeUndefined();
-  });
-
-  it("does not let a non-owner mark someone else's entry", async () => {
-    const e = await appendQuery({ question: "Q", answer: "A", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: "alice" });
+  it("cannot mark another owner's entry (different silo file)", async () => {
+    const e = await appendQuery(entry("alice", { question: "Q" }));
     await markSaved(e.id, "sneaky", "bob");
-    const entries = await listQueries(undefined, "alice");
-    expect(entries[0].savedAs).toBeUndefined();
+    expect((await listQueries(undefined, "alice"))[0].savedAs).toBeUndefined();
   });
 });
 
-describe("max history cap", () => {
-  it("trims oldest entries when exceeding 200", async () => {
-    const wikiDir = path.join(tmpDir, "wiki");
-    await fs.mkdir(wikiDir, { recursive: true });
+describe("storage placement + isolation", () => {
+  it("stores history inside the tenant silo, not the shared wiki root", async () => {
+    await appendQuery(entry("alice", { question: "alice q" }));
+    await appendQuery(entry("bob", { question: "bob q", timestamp: "2025-01-02T00:00:00Z" }));
 
-    const seed: Array<{ id: string; question: string; answer: string; sources: string[]; timestamp: string; owner: string }> = [];
-    for (let i = 0; i < 200; i++) {
-      seed.push({ id: `seed-${i}`, question: `Q${i}`, answer: `A${i}`, sources: [], timestamp: new Date(2025, 0, 1, 0, 0, i).toISOString(), owner: OWNER });
-    }
-    await fs.writeFile(path.join(wikiDir, "query-history.json"), JSON.stringify(seed, null, 2), "utf-8");
-
-    for (let i = 200; i < 205; i++) {
-      await appendQuery({ question: `Q${i}`, answer: `A${i}`, sources: [], timestamp: new Date(2025, 0, 1, 0, 0, i).toISOString(), owner: OWNER });
-    }
-
-    const entries = await listQueries(undefined, OWNER);
-    expect(entries).toHaveLength(200);
-    expect(entries[0].question).toBe("Q204");
-    expect(entries[entries.length - 1].question).toBe("Q5");
-  });
-});
-
-describe("hardening — isolation, idempotency, no-clobber", () => {
-  const wikiDir = () => path.join(tmpDir, "wiki");
-  const legacyPath = () => path.join(wikiDir(), "query-history.json");
-  const ownerFile = (key: string) =>
-    path.join(wikiDir(), "query-history", `${key}.json`);
-
-  it("never clobbers history when a read fails (corrupt file → throws, file untouched)", async () => {
-    await fs.mkdir(path.join(wikiDir(), "query-history"), { recursive: true });
-    await fs.writeFile(ownerFile("tester"), "not json!", "utf-8");
-
-    await expect(
-      appendQuery({ question: "q", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: "tester" }),
-    ).rejects.toThrow();
-
-    // The unreadable file is left intact — NOT overwritten with [newEntry].
-    expect(await fs.readFile(ownerFile("tester"), "utf-8")).toBe("not json!");
-  });
-
-  it("ownerKey is injective: handles differing only by stripped chars don't collide", async () => {
-    await appendQuery({ question: "dotted", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: "al.ice" });
-    await appendQuery({ question: "plain", answer: "b", sources: [], timestamp: "2025-01-02T00:00:00Z", owner: "alice" });
-
-    expect((await listQueries(undefined, "al.ice")).map((e) => e.question)).toEqual(["dotted"]);
-    expect((await listQueries(undefined, "alice")).map((e) => e.question)).toEqual(["plain"]);
-  });
-
-  it("all-symbol handles don't collapse into a shared/empty file", async () => {
-    await appendQuery({ question: "bang", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: "!!!" });
-    await appendQuery({ question: "hash", answer: "b", sources: [], timestamp: "2025-01-02T00:00:00Z", owner: "###" });
-
-    expect((await listQueries(undefined, "!!!")).map((e) => e.question)).toEqual(["bang"]);
-    expect((await listQueries(undefined, "###")).map((e) => e.question)).toEqual(["hash"]);
-    // No shared `.json` catch-all (the old empty-key bug).
-    await expect(fs.access(ownerFile(""))).rejects.toThrow();
+    expect(JSON.parse(await fs.readFile(siloFile("alice"), "utf-8"))).toHaveLength(1);
+    expect(JSON.parse(await fs.readFile(siloFile("bob"), "utf-8"))).toHaveLength(1);
+    // No shared file at the wiki root.
+    await expect(fs.access(legacySharedPath())).rejects.toThrow();
+    // The path is under tenants/<tenant>/.
+    expect(siloFile("alice")).toContain(path.join("tenants", "alice"));
   });
 
   it("the cap is per-owner: one owner at 200 doesn't trim another", async () => {
     for (let i = 0; i < 205; i++) {
-      await appendQuery({ question: `a${i}`, answer: "x", sources: [], timestamp: new Date(2025, 0, 1, 0, 0, i).toISOString(), owner: "alice" });
+      await appendQuery(entry("alice", { question: `a${i}`, timestamp: new Date(2025, 0, 1, 0, 0, i).toISOString() }));
     }
     for (let i = 0; i < 3; i++) {
-      await appendQuery({ question: `b${i}`, answer: "x", sources: [], timestamp: new Date(2025, 0, 1, 0, 0, i).toISOString(), owner: "bob" });
+      await appendQuery(entry("bob", { question: `b${i}`, timestamp: new Date(2025, 0, 1, 0, 0, i).toISOString() }));
     }
     expect(await listQueries(undefined, "alice")).toHaveLength(200);
     expect(await listQueries(undefined, "bob")).toHaveLength(3);
   });
 
-  it("migration is idempotent if the legacy file reappears (dedupe by id)", async () => {
-    await fs.mkdir(wikiDir(), { recursive: true });
-    const legacy = [{ id: "x1", question: "q", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: "alice" }];
-    await fs.writeFile(legacyPath(), JSON.stringify(legacy), "utf-8");
+  it("never clobbers history when a read fails (corrupt file → throws, untouched)", async () => {
+    await fs.mkdir(path.dirname(siloFile(OWNER)), { recursive: true });
+    await fs.writeFile(siloFile(OWNER), "not json!", "utf-8");
+    await expect(appendQuery(entry(OWNER))).rejects.toThrow();
+    expect(await fs.readFile(siloFile(OWNER), "utf-8")).toBe("not json!");
+  });
+});
 
-    expect(await listQueries(undefined, "alice")).toHaveLength(1);
-    await expect(fs.access(legacyPath())).rejects.toThrow();
+describe("legacy migration → tenant silo", () => {
+  it("migrates the shared file into per-tenant silo files, dropping owner-less + deleting it", async () => {
+    await fs.mkdir(path.join(tmpDir, "wiki"), { recursive: true });
+    await fs.writeFile(legacySharedPath(), JSON.stringify([
+      { id: "1", ...entry("alice", { question: "alice q" }) },
+      { id: "2", ...entry("bob", { question: "bob q", timestamp: "2025-01-02T00:00:00Z" }) },
+      { id: "3", question: "orphan", answer: "o", sources: [], timestamp: "2025-01-03T00:00:00Z" }, // no owner
+    ]), "utf-8");
 
-    // Legacy reappears with the SAME id (e.g. a failed delete that later resolves).
-    await fs.writeFile(legacyPath(), JSON.stringify(legacy), "utf-8");
-    expect(await listQueries(undefined, "alice")).toHaveLength(1); // no duplicate
+    expect((await listQueries(undefined, "alice")).map((e) => e.question)).toEqual(["alice q"]);
+    expect((await listQueries(undefined, "bob")).map((e) => e.question)).toEqual(["bob q"]);
+    // Lossless for owned entries; orphan dropped; shared file removed once empty.
+    await expect(fs.access(legacySharedPath())).rejects.toThrow();
+    expect(JSON.parse(await fs.readFile(siloFile("alice"), "utf-8"))).toHaveLength(1);
   });
 
-  it("merges legacy entries BELOW pre-existing per-owner entries (most-recent-first)", async () => {
-    await fs.mkdir(path.join(wikiDir(), "query-history"), { recursive: true });
-    await fs.writeFile(ownerFile("alice"), JSON.stringify([
-      { id: "new", question: "newer q", answer: "a", sources: [], timestamp: "2025-01-05T00:00:00Z", owner: "alice" },
-    ]), "utf-8");
-    await fs.writeFile(legacyPath(), JSON.stringify([
-      { id: "old", question: "older q", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: "alice" },
+  it("migrates an interim per-owner file (PR #493) into the silo, then removes it", async () => {
+    const key = "alice"; // legacyOwnerKey("alice") === "alice"
+    await fs.mkdir(path.join(tmpDir, "wiki", "query-history"), { recursive: true });
+    await fs.writeFile(legacyPerOwnerPath(key), JSON.stringify([
+      { id: "p1", ...entry("alice", { question: "interim q" }) },
     ]), "utf-8");
 
-    expect((await listQueries(undefined, "alice")).map((e) => e.question)).toEqual(["newer q", "older q"]);
+    expect((await listQueries(undefined, "alice")).map((e) => e.question)).toEqual(["interim q"]);
+    await expect(fs.access(legacyPerOwnerPath(key))).rejects.toThrow();
+    expect(JSON.parse(await fs.readFile(siloFile("alice"), "utf-8"))).toHaveLength(1);
+  });
+
+  it("a new entry survives migration (appended above the migrated legacy ones)", async () => {
+    await fs.mkdir(path.join(tmpDir, "wiki"), { recursive: true });
+    await fs.writeFile(legacySharedPath(), JSON.stringify([
+      { id: "old", ...entry("alice", { question: "old q" }) },
+    ]), "utf-8");
+
+    await appendQuery(entry("alice", { question: "new q", timestamp: "2025-01-02T00:00:00Z" }));
+    expect((await listQueries(undefined, "alice")).map((e) => e.question)).toEqual(["new q", "old q"]);
+  });
+
+  it("is idempotent if a legacy file reappears (dedupe by id, no duplication)", async () => {
+    await fs.mkdir(path.join(tmpDir, "wiki", "query-history"), { recursive: true });
+    const legacy = JSON.stringify([{ id: "x1", ...entry("alice", { question: "q" }) }]);
+    await fs.writeFile(legacyPerOwnerPath("alice"), legacy, "utf-8");
+
+    expect(await listQueries(undefined, "alice")).toHaveLength(1);
+    // Reappears with the same id (e.g. a failed delete that later resolves).
+    await fs.mkdir(path.join(tmpDir, "wiki", "query-history"), { recursive: true });
+    await fs.writeFile(legacyPerOwnerPath("alice"), legacy, "utf-8");
+    expect(await listQueries(undefined, "alice")).toHaveLength(1); // no duplicate
   });
 });

--- a/src/lib/__tests__/tenant-admin.test.ts
+++ b/src/lib/__tests__/tenant-admin.test.ts
@@ -84,6 +84,19 @@ describe("deleteTenant", () => {
     );
   });
 
+  it("removes the tenant's query history (it lives in the silo)", async () => {
+    const { appendQuery } = await import("../query-history");
+    await appendQuery({ question: "q", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: "alice" });
+    await appendQuery({ question: "q", answer: "a", sources: [], timestamp: "2025-01-01T00:00:00Z", owner: "bob" });
+    expect(await getStorage().fileExists("tenants/alice/query-history.json")).toBe(true);
+
+    await deleteTenant("alice");
+
+    // alice's private query log is gone with her silo; bob's is untouched.
+    expect(await getStorage().fileExists("tenants/alice/query-history.json")).toBe(false);
+    expect(await getStorage().fileExists("tenants/bob/query-history.json")).toBe(true);
+  });
+
   it("never deletes a page the handle only CONTRIBUTED to (owned by another)", async () => {
     // Owned by bob, but alice is a contributor — deleting tenant alice must
     // leave it intact (it belongs to bob's silo).

--- a/src/lib/query-history.ts
+++ b/src/lib/query-history.ts
@@ -86,15 +86,35 @@ function generateId(): string {
   return `${ts}-${rand}`;
 }
 
-/** Read a history file, returning [] on absence OR any error (for legacy reads). */
-async function readHistoryLenient(relPath: string): Promise<QueryHistoryEntry[]> {
+/**
+ * Read a LEGACY history file for migration. Absent → []. A transient read error
+ * → [] + warn (defer migration to the next access). An UNPARSEABLE file is
+ * quarantined to `<path>.corrupt` and removed (so the per-request migration probe
+ * stops re-firing forever) and surfaced at `error` — a human may want to recover
+ * it. Returns [] in every non-happy case so a corrupt/missing legacy file never
+ * blocks the silo write.
+ */
+async function readLegacyHistory(relPath: string): Promise<QueryHistoryEntry[]> {
+  const storage = getStorage();
+  let raw: string;
   try {
-    const raw = await getStorage().readFile(relPath);
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as QueryHistoryEntry[]) : [];
+    raw = await storage.readFile(relPath);
   } catch (err: unknown) {
     if (!isEnoent(err)) {
-      logger.warn("query-history", `lenient read ${relPath} failed:`, err);
+      logger.warn("query-history", `legacy read ${relPath} failed:`, err);
+    }
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as QueryHistoryEntry[]) : [];
+  } catch (err) {
+    logger.error("query-history", `legacy ${relPath} unparseable; quarantining:`, err);
+    try {
+      await storage.writeFile(`${relPath}.corrupt`, raw);
+      await storage.deleteFile(relPath);
+    } catch (qerr) {
+      logger.error("query-history", `quarantine ${relPath} failed:`, qerr);
     }
     return [];
   }
@@ -150,9 +170,10 @@ function trimToCap(entries: QueryHistoryEntry[]): QueryHistoryEntry[] {
 /**
  * Consolidate an owner's history from the legacy locations into their tenant
  * silo, then remove the legacy copies. Idempotent (dedupe by id) and loss-safe
- * (silo is written BEFORE legacy is cleared). Cheap once done — both legacy
- * probes miss. Never throws for the listQueries path beyond what readOwnerHistory
- * would; a transient failure just defers migration to the next access.
+ * (silo is written BEFORE legacy is cleared, so a cleanup failure just re-merges
+ * next time). Cheap once done — both legacy probes miss. A silo/legacy WRITE
+ * failure propagates (it gates the cleanup, keeping migration loss-safe); a
+ * transient legacy READ just defers migration to the next access.
  */
 async function migrateLegacyHistory(owner: string): Promise<void> {
   const storage = getStorage();
@@ -167,15 +188,22 @@ async function migrateLegacyHistory(owner: string): Promise<void> {
 
   // Gather legacy entries for THIS owner (shared older than the interim files).
   const sharedOwner = sharedExists
-    ? (await readHistoryLenient(sharedPath)).filter((e) => e.owner === owner)
+    ? (await readLegacyHistory(sharedPath)).filter((e) => e.owner === owner)
     : [];
-  const perOwner = perOwnerExists ? await readHistoryLenient(perOwnerPath) : [];
+  const perOwner = perOwnerExists ? await readLegacyHistory(perOwnerPath) : [];
 
   // 1. Merge into the silo first (so nothing is lost if cleanup later fails).
   await withFileLock(lockFor(owner), async () => {
     const silo = await readOwnerHistory(owner);
+    // Dedupe by id against the silo AND across the two sources (the same id can
+    // appear in both if a #493 split left the shared file in place).
     const seen = new Set(silo.map((e) => e.id));
-    const incoming = [...sharedOwner, ...perOwner].filter((e) => !seen.has(e.id));
+    const incoming: QueryHistoryEntry[] = [];
+    for (const e of [...sharedOwner, ...perOwner]) {
+      if (seen.has(e.id)) continue;
+      seen.add(e.id);
+      incoming.push(e);
+    }
     if (incoming.length > 0) {
       await writeOwnerHistory(owner, trimToCap([...incoming, ...silo]));
     }
@@ -188,7 +216,7 @@ async function migrateLegacyHistory(owner: string): Promise<void> {
   //    ordering. The `rest.length === all.length` guard skips a needless rewrite.
   if (sharedExists) {
     await withFileLock(LEGACY_SHARED_LOCK, async () => {
-      const all = await readHistoryLenient(sharedPath);
+      const all = await readLegacyHistory(sharedPath);
       const rest = all.filter((e) => e.owner && e.owner !== owner);
       if (rest.length === all.length) return;
       if (rest.length === 0) await deleteSafe(sharedPath);

--- a/src/lib/query-history.ts
+++ b/src/lib/query-history.ts
@@ -1,31 +1,43 @@
-import { wikiRelPath, ensureDirectories } from "./wiki";
+import {
+  wikiRelPath,
+  ensureDirectories,
+  tenantForOwner,
+  validateTenant,
+} from "./wiki";
 import { getStorage } from "./storage";
 import { withFileLock } from "./lock";
 import { isEnoent } from "./errors";
 import { logger } from "./logger";
 
 // ---------------------------------------------------------------------------
-// Query history — per-asker, persisted as one JSON file PER OWNER.
+// Query history — per-asker, persisted INSIDE the asker's tenant silo.
 // ---------------------------------------------------------------------------
 //
-// Privacy is **physical**: each asker's history lives in its own file
-// (`query-history/<ownerKey>.json`), so there is no shared store to accidentally
-// over-read — a reader can only ever touch the file for the owner it was given,
-// and `ownerKey` is an INJECTIVE, path-safe encoding (distinct owners never
-// collide and never produce an empty/shared key). (A query answer may quote the
-// asker's own private pages, so history must never be served cross-user.) The
-// legacy single `query-history.json` is migrated into per-owner files on first
-// access, then deleted; entries with no owner are dropped (already unreadable).
+// Each asker's history lives at `tenants/<tenant>/query-history.json`, keyed by
+// the same canonical identity (`tenantForOwner`) as their pages/raw/discuss.
+// Two consequences:
+//   * Privacy is **physical** — a reader only ever touches one tenant's file;
+//     there is no shared store to over-read, and the route only ever passes the
+//     session-derived handle (no client-supplied owner).
+//   * It lives in the user's folder, so **account deletion removes it for free**
+//     (`deleteTenant` wipes the whole `tenants/<tenant>/` prefix) — a query
+//     answer can quote the asker's private pages, so it must not orphan.
+//
+// It is NOT a vault (no page references, not browseable) and NOT part of the
+// page-based export.
+//
+// Migration: legacy locations (the original shared `wiki/query-history.json` and
+// the interim per-owner `wiki/query-history/<key>.json` files) are consolidated
+// into the silo on first access, then removed. Owner-less entries are dropped
+// (they were already unreadable).
 
 /** Maximum number of history entries to keep PER OWNER. Oldest trimmed on append. */
 const MAX_HISTORY_ENTRIES = 200;
 
-/** Legacy single-file store, migrated to per-owner files then removed. */
-const LEGACY_FILENAME = "query-history.json";
-/** Where an unparseable legacy file is quarantined (so migration stops retrying). */
-const LEGACY_CORRUPT_FILENAME = "query-history.json.corrupt";
-/** Lock serializing the one-time legacy → per-owner migration. */
-const LEGACY_LOCK = "query-history-legacy";
+/** Legacy shared single-file store (pre per-owner). Migrated then removed. */
+const LEGACY_SHARED_FILENAME = "query-history.json";
+/** Lock serializing edits to the legacy shared file during migration. */
+const LEGACY_SHARED_LOCK = "query-history-legacy";
 
 export interface QueryHistoryEntry {
   /** Unique id (timestamp-based). */
@@ -40,7 +52,7 @@ export interface QueryHistoryEntry {
   timestamp: string;
   /** Slug of the wiki page if the answer was saved. */
   savedAs?: string;
-  /** Owner handle — the asker. Determines which per-owner file the entry lives in. */
+  /** Owner handle — the asker. Resolved to a tenant for storage placement. */
   owner?: string;
 }
 
@@ -48,29 +60,23 @@ export interface QueryHistoryEntry {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Encode an owner handle into a path-safe file segment.
- *
- * Lowercased to match the app's canonical identity (same normalization as
- * `tenantForOwner`), then any character outside `[a-z0-9_-]` — and the `~`
- * marker itself — is escaped as `~<hex>`. This is **injective**: distinct
- * owners map to distinct keys (no `al.ice`/`alice` collision), it can never be
- * empty for a non-empty owner, and path-traversal bytes (`/`, `.`) are escaped.
- */
-function ownerKey(owner: string): string {
+/** Storage-relative path to an owner's history file inside their tenant silo. */
+function historyRelPathFor(owner: string): string {
+  const tenant = tenantForOwner(owner);
+  validateTenant(tenant);
+  return `tenants/${tenant}/query-history.json`;
+}
+
+/** Per-owner (per-tenant) lock key. */
+function lockFor(owner: string): string {
+  return `query-history:${tenantForOwner(owner)}`;
+}
+
+/** Interim per-owner file key (PR #493) — only used to locate files for migration. */
+function legacyOwnerKey(owner: string): string {
   return owner
     .toLowerCase()
     .replace(/[^a-z0-9_-]|~/g, (c) => `~${c.charCodeAt(0).toString(16)}`);
-}
-
-/** Per-owner history file path. */
-function historyRelPathFor(owner: string): string {
-  return wikiRelPath(`query-history/${ownerKey(owner)}.json`);
-}
-
-/** Per-owner lock key. */
-function lockFor(owner: string): string {
-  return `query-history:${ownerKey(owner)}`;
 }
 
 function generateId(): string {
@@ -80,12 +86,26 @@ function generateId(): string {
   return `${ts}-${rand}`;
 }
 
+/** Read a history file, returning [] on absence OR any error (for legacy reads). */
+async function readHistoryLenient(relPath: string): Promise<QueryHistoryEntry[]> {
+  try {
+    const raw = await getStorage().readFile(relPath);
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as QueryHistoryEntry[]) : [];
+  } catch (err: unknown) {
+    if (!isEnoent(err)) {
+      logger.warn("query-history", `lenient read ${relPath} failed:`, err);
+    }
+    return [];
+  }
+}
+
 /**
- * Read an owner's history file. A genuinely absent file (ENOENT) → `[]`. A REAL
- * failure (transient storage error, or a corrupt/unparseable file) is RETHROWN —
- * a read-modify-write caller must never overwrite real history with an empty list
- * because a read transiently failed. {@link listQueries} (a pure read) downgrades
- * a throw to `[]` for that one request.
+ * Read an owner's silo history file. A genuinely absent file (ENOENT) → `[]`. A
+ * REAL failure (transient storage error, or a corrupt/unparseable file) is
+ * RETHROWN — a read-modify-write caller must never overwrite real history with an
+ * empty list because a read transiently failed. {@link listQueries} (a pure read)
+ * downgrades a throw to `[]` for that one request.
  */
 async function readOwnerHistory(owner: string): Promise<QueryHistoryEntry[]> {
   const relPath = historyRelPathFor(owner);
@@ -111,6 +131,16 @@ async function writeOwnerHistory(
   );
 }
 
+async function deleteSafe(relPath: string): Promise<void> {
+  try {
+    await getStorage().deleteFile(relPath);
+  } catch (err) {
+    if (!isEnoent(err)) {
+      logger.warn("query-history", `delete ${relPath} failed:`, err);
+    }
+  }
+}
+
 function trimToCap(entries: QueryHistoryEntry[]): QueryHistoryEntry[] {
   return entries.length > MAX_HISTORY_ENTRIES
     ? entries.slice(entries.length - MAX_HISTORY_ENTRIES)
@@ -118,94 +148,53 @@ function trimToCap(entries: QueryHistoryEntry[]): QueryHistoryEntry[] {
 }
 
 /**
- * One-time, lossless migration from the shared `query-history.json` to per-owner
- * files. Idempotent and cheap once done — the legacy file is deleted, so the
- * existence probe short-circuits without taking the lock. Owner-less entries are
- * dropped (they were never returned to anyone). Resilient by design: it never
- * throws (callers shouldn't break on a migration hiccup), it only deletes the
- * legacy file once EVERY owner migrated (a per-owner failure → retry next time,
- * the dedupe-by-id keeps that idempotent), and an unparseable legacy file is
- * quarantined so the probe stops firing forever.
+ * Consolidate an owner's history from the legacy locations into their tenant
+ * silo, then remove the legacy copies. Idempotent (dedupe by id) and loss-safe
+ * (silo is written BEFORE legacy is cleared). Cheap once done — both legacy
+ * probes miss. Never throws for the listQueries path beyond what readOwnerHistory
+ * would; a transient failure just defers migration to the next access.
  */
-async function migrateLegacyHistory(): Promise<void> {
+async function migrateLegacyHistory(owner: string): Promise<void> {
   const storage = getStorage();
-  const legacyPath = wikiRelPath(LEGACY_FILENAME);
+  const sharedPath = wikiRelPath(LEGACY_SHARED_FILENAME);
+  const perOwnerPath = wikiRelPath(`query-history/${legacyOwnerKey(owner)}.json`);
 
-  // Cheap probe: once migrated the file is gone → ENOENT → return un-locked. A
-  // transient probe failure just skips this round (the next request retries).
-  try {
-    await storage.readFile(legacyPath);
-  } catch (err) {
-    if (!isEnoent(err)) logger.warn("query-history", "legacy probe failed:", err);
-    return;
-  }
+  const [sharedExists, perOwnerExists] = await Promise.all([
+    storage.fileExists(sharedPath),
+    storage.fileExists(perOwnerPath),
+  ]);
+  if (!sharedExists && !perOwnerExists) return;
 
-  await withFileLock(LEGACY_LOCK, async () => {
-    // Re-read under the lock — another request may have just migrated + deleted.
-    let raw: string;
-    try {
-      raw = await storage.readFile(legacyPath);
-    } catch (err) {
-      if (!isEnoent(err)) logger.warn("query-history", "legacy reread failed:", err);
-      return; // gone (already migrated) or transient → retry next request
+  // Gather legacy entries for THIS owner (shared older than the interim files).
+  const sharedOwner = sharedExists
+    ? (await readHistoryLenient(sharedPath)).filter((e) => e.owner === owner)
+    : [];
+  const perOwner = perOwnerExists ? await readHistoryLenient(perOwnerPath) : [];
+
+  // 1. Merge into the silo first (so nothing is lost if cleanup later fails).
+  await withFileLock(lockFor(owner), async () => {
+    const silo = await readOwnerHistory(owner);
+    const seen = new Set(silo.map((e) => e.id));
+    const incoming = [...sharedOwner, ...perOwner].filter((e) => !seen.has(e.id));
+    if (incoming.length > 0) {
+      await writeOwnerHistory(owner, trimToCap([...incoming, ...silo]));
     }
-
-    let entries: QueryHistoryEntry[];
-    try {
-      const parsed = JSON.parse(raw);
-      entries = Array.isArray(parsed) ? (parsed as QueryHistoryEntry[]) : [];
-    } catch (err) {
-      // Unparseable legacy file: quarantine it (so the probe stops re-firing
-      // every request) and surface loudly — a human may want to recover it.
-      logger.error("query-history", "legacy file unparseable; quarantining:", err);
-      try {
-        await storage.writeFile(wikiRelPath(LEGACY_CORRUPT_FILENAME), raw);
-        await storage.deleteFile(legacyPath);
-      } catch (qerr) {
-        logger.error("query-history", "legacy quarantine failed:", qerr);
-      }
-      return;
-    }
-
-    // Group by owner; owner-less entries are intentionally dropped.
-    const byOwner = new Map<string, QueryHistoryEntry[]>();
-    for (const e of entries) {
-      if (!e.owner) continue;
-      const arr = byOwner.get(e.owner) ?? [];
-      arr.push(e);
-      byOwner.set(e.owner, arr);
-    }
-
-    // Merge each owner's legacy entries into their file (legacy first = older).
-    // The dedupe-by-id keeps this idempotent if migration re-runs (e.g. after a
-    // failed delete) — preserved legacy ids are already present and skipped.
-    let allMigrated = true;
-    for (const [owner, legacyEntries] of byOwner) {
-      try {
-        await withFileLock(lockFor(owner), async () => {
-          const existing = await readOwnerHistory(owner); // strict: throws on real failure
-          const seen = new Set(existing.map((e) => e.id));
-          const merged = [
-            ...legacyEntries.filter((e) => !seen.has(e.id)),
-            ...existing,
-          ];
-          await writeOwnerHistory(owner, trimToCap(merged));
-        });
-      } catch (err) {
-        allMigrated = false;
-        logger.error("query-history", `migrate owner "${owner}" failed; will retry:`, err);
-      }
-    }
-
-    // Only drop the shared file once every owner migrated — otherwise leave it
-    // for a retry (re-merge is idempotent via the id dedupe above).
-    if (!allMigrated) return;
-    try {
-      await storage.deleteFile(legacyPath);
-    } catch (err) {
-      if (!isEnoent(err)) logger.error("query-history", "legacy delete failed:", err);
-    }
+    if (perOwnerExists) await deleteSafe(perOwnerPath);
   });
+
+  // 2. Prune the shared file (after the silo write): drop this owner's entries
+  //    AND any owner-less ones (already unreadable), so it eventually empties and
+  //    is deleted. Done in a SEPARATE lock (not nested) to avoid cross-lock
+  //    ordering. The `rest.length === all.length` guard skips a needless rewrite.
+  if (sharedExists) {
+    await withFileLock(LEGACY_SHARED_LOCK, async () => {
+      const all = await readHistoryLenient(sharedPath);
+      const rest = all.filter((e) => e.owner && e.owner !== owner);
+      if (rest.length === all.length) return;
+      if (rest.length === 0) await deleteSafe(sharedPath);
+      else await storage.writeFile(sharedPath, JSON.stringify(rest, null, 2));
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -216,10 +205,8 @@ async function migrateLegacyHistory(): Promise<void> {
  * Append a query to the asker's history file. Uses a per-owner lock to prevent
  * TOCTOU races and trims to {@link MAX_HISTORY_ENTRIES}. An owner-less entry is
  * returned (for the client's optimistic UI) but NOT persisted — anonymous
- * history is unreadable anyway, and there is no shared file to write it to.
- *
- * A real read failure propagates rather than overwriting existing history with a
- * single-entry file (see {@link readOwnerHistory}).
+ * history is unreadable anyway. A real read failure propagates rather than
+ * overwriting existing history (see {@link readOwnerHistory}).
  */
 export async function appendQuery(
   entry: Omit<QueryHistoryEntry, "id">,
@@ -228,7 +215,7 @@ export async function appendQuery(
   if (!entry.owner) return newEntry;
   const owner = entry.owner;
 
-  await migrateLegacyHistory();
+  await migrateLegacyHistory(owner);
   await withFileLock(lockFor(owner), async () => {
     const entries = await readOwnerHistory(owner);
     entries.push(newEntry);
@@ -238,17 +225,17 @@ export async function appendQuery(
 }
 
 /**
- * List the asker's past queries, most recent first. Reads ONLY the owner's file;
- * an anonymous caller (no owner) gets nothing — privacy is enforced by which file
- * is read, not by a post-read filter. A read failure degrades to `[]` for this
- * one request (a pure read can't lose data).
+ * List the asker's past queries, most recent first. Reads ONLY the owner's silo
+ * file; an anonymous caller (no owner) gets nothing — privacy is enforced by
+ * which file is read, not by a post-read filter. A read failure degrades to `[]`
+ * for this one request (a pure read can't lose data).
  */
 export async function listQueries(
   limit?: number,
   owner?: string | null,
 ): Promise<QueryHistoryEntry[]> {
   if (!owner) return [];
-  await migrateLegacyHistory();
+  await migrateLegacyHistory(owner);
   let entries: QueryHistoryEntry[];
   try {
     entries = await readOwnerHistory(owner);
@@ -271,7 +258,7 @@ export async function markSaved(
   owner?: string | null,
 ): Promise<void> {
   if (!owner) return;
-  await migrateLegacyHistory();
+  await migrateLegacyHistory(owner);
   await withFileLock(lockFor(owner), async () => {
     const entries = await readOwnerHistory(owner);
     const entry = entries.find((e) => e.id === id);


### PR DESCRIPTION
## Why
Per-owner query history (from #493) lived at `wiki/query-history/<key>.json` — **outside** the `tenants/<handle>/` prefix that `deleteTenant` wipes. So a **deleted account's query history orphans** and is never removed, even though an answer can quote the asker's **private** pages. (Export is page-based and never bundled it — and shouldn't: it's a private log, not a vault/page references.)

## What
Move it into the asker's **tenant silo** — `tenants/<tenant>/query-history.json`, keyed by the same canonical identity (`tenantForOwner`) as their pages/raw/discuss:
- **`deleteTenant` now removes it for free** via `deleteDirectory(tenants/<tenant>)` — no separate cleanup hook to forget.
- Identity matches the rest of the app (`validateTenant` guards path safety; never empty) → no new collision risk, consistent isolation.
- **Not a vault** (no page refs, not browseable); **not in export** (page-based).

**Lossless lazy migration** consolidates both legacy locations into the silo on first access, then removes them: the original shared `wiki/query-history.json` (this owner's entries; owner-less dropped; deleted once empty) and the interim `wiki/query-history/<key>.json` files (#493). Silo is written before legacy is cleared (loss-safe); dedupe-by-id keeps re-runs idempotent; read failures still rethrow on write paths (no clobber).

## Access control (unchanged, confirmed)
Reads are enforced by the route passing the **session-derived** `getPrincipal().handle` only — no `?owner=` / body field, spoof-proof. A user can't name another owner.

## Tests
- `query-history.test.ts` reworked for the silo: placement under `tenants/<tenant>/`, per-owner cap, no-clobber-on-corrupt-read, shared + interim migration, idempotent re-run.
- `tenant-admin.test.ts`: `deleteTenant("alice")` removes her `query-history.json`; bob's remains.

`pnpm build` clean · **2803 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)