### PR TITLE
Add HTML output format to /query (+ save as a sandboxed artifact page)

### DIFF
--- a/src/app/api/query/route.ts
+++ b/src/app/api/query/route.ts
@@ -7,6 +7,7 @@ import { logger } from "@/lib/logger";
 function parseFormat(value: unknown): QueryFormat {
   if (value === "table") return "table";
   if (value === "slides") return "slides";
+  if (value === "html") return "html";
   return "prose";
 }
 
@@ -32,10 +33,11 @@ export async function POST(request: NextRequest) {
       format !== undefined &&
       format !== "prose" &&
       format !== "table" &&
-      format !== "slides"
+      format !== "slides" &&
+      format !== "html"
     ) {
       return NextResponse.json(
-        { error: "format must be 'prose', 'table', or 'slides'" },
+        { error: "format must be 'prose', 'table', 'slides', or 'html'" },
         { status: 400 },
       );
     }

--- a/src/app/api/query/save/route.ts
+++ b/src/app/api/query/save/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { saveAnswerToWiki } from "@/lib/query";
+import { getPrincipal } from "@/lib/auth";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 
@@ -7,7 +8,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    const { title, content, sources } = body;
+    const { title, content, sources, format } = body;
 
     if (!title || typeof title !== "string" || title.trim().length === 0) {
       return NextResponse.json(
@@ -43,11 +44,19 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // An HTML answer is saved verbatim as a sandboxed, personal artifact owned by
+    // the asker. Writes are middleware-gated to a signed-in user, so a principal
+    // is present here. Any other format saves as markdown (unchanged behavior).
+    const isHtml = format === "html";
+    const owner = isHtml ? (await getPrincipal())?.handle : undefined;
+
     const result = await saveAnswerToWiki(
       title.trim(),
       content.trim(),
       undefined,
       validatedSources,
+      isHtml ? "html" : "markdown",
+      owner,
     );
 
     return NextResponse.json({ slug: result.slug, success: true });

--- a/src/app/api/query/save/route.ts
+++ b/src/app/api/query/save/route.ts
@@ -45,10 +45,23 @@ export async function POST(request: NextRequest) {
     }
 
     // An HTML answer is saved verbatim as a sandboxed, personal artifact owned by
-    // the asker. Writes are middleware-gated to a signed-in user, so a principal
-    // is present here. Any other format saves as markdown (unchanged behavior).
+    // the asker. Writes are middleware-gated to a signed-in user; if the principal
+    // can't be resolved here (a transient auth failure) we must NOT silently write
+    // a mis-attributed system-owned page — surface it. Other formats save as
+    // markdown (unchanged, system-owned behavior).
     const isHtml = format === "html";
-    const owner = isHtml ? (await getPrincipal())?.handle : undefined;
+    let owner: string | undefined;
+    if (isHtml) {
+      const principal = await getPrincipal();
+      if (!principal) {
+        logger.error("query", "HTML save: could not resolve principal despite write-gate");
+        return NextResponse.json(
+          { error: "Could not resolve your account — sign in again and retry." },
+          { status: 401 },
+        );
+      }
+      owner = principal.handle;
+    }
 
     const result = await saveAnswerToWiki(
       title.trim(),

--- a/src/app/api/query/stream/route.ts
+++ b/src/app/api/query/stream/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { hasLLMKey, callLLMStream } from "@/lib/llm";
 import { QUERY_MAX_OUTPUT_TOKENS } from "@/lib/constants";
-import { listReadableWikiPages, isAgentScopedType } from "@/lib/wiki";
+import { listReadableWikiPages, isAgentScopedType, isArtifactType } from "@/lib/wiki";
 import { getPrincipal } from "@/lib/auth";
 import {
   selectPagesForQuery,
@@ -34,14 +34,22 @@ export async function POST(request: NextRequest) {
       format !== undefined &&
       format !== "prose" &&
       format !== "table" &&
-      format !== "slides"
+      format !== "slides" &&
+      format !== "html"
     ) {
       return NextResponse.json(
-        { error: "format must be 'prose', 'table', or 'slides'" },
+        { error: "format must be 'prose', 'table', 'slides', or 'html'" },
         { status: 400 },
       );
     }
-    const queryFormat: QueryFormat = format === "table" ? "table" : format === "slides" ? "slides" : "prose";
+    const queryFormat: QueryFormat =
+      format === "table"
+        ? "table"
+        : format === "slides"
+          ? "slides"
+          : format === "html"
+            ? "html"
+            : "prose";
 
     // Validate `scope` if present — must be a string.
     if (scope !== undefined && typeof scope !== "string") {
@@ -70,7 +78,9 @@ export async function POST(request: NextRequest) {
     // pages (identity / knowledge / social), which surface solely via an explicit
     // `agent:` scope. Mirrors the non-streaming query() path (query.ts).
     if (!scopeSlugs) {
-      entries = entries.filter((e) => !isAgentScopedType(e.type));
+      entries = entries.filter(
+        (e) => !isAgentScopedType(e.type) && !isArtifactType(e.type),
+      );
     }
 
     // Empty wiki — nothing to query

--- a/src/app/query/page.tsx
+++ b/src/app/query/page.tsx
@@ -395,7 +395,7 @@ export default function QueryPage() {
               <span className="fmark" style={{ marginRight: 4 }}>
                 format
               </span>
-              {(["prose", "table", "slides"] as const).map((f) => {
+              {(["prose", "table", "slides", "html"] as const).map((f) => {
                 const active = format === f;
                 return (
                   <button
@@ -435,6 +435,7 @@ export default function QueryPage() {
               question={question}
               currentHistoryId={currentHistoryId}
               onHistorySaved={handleHistorySaved}
+              format={format}
             />
           )}
         </div>

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { slugify } from "@/lib/slugify";
 import type { Frontmatter } from "@/lib/frontmatter";
 import type { WikiPage } from "@/lib/types";
-import { findBacklinks, findSimilarPages, buildSlugTenantMap } from "@/lib/wiki";
+import { findBacklinks, findSimilarPages, buildSlugTenantMap, isArtifactType } from "@/lib/wiki";
 import { resolveSlugPath } from "@/lib/links";
 import { getCommonsSlugSet, belongsInCommons } from "@/lib/commons";
 import type { Principal } from "@/lib/auth";
@@ -13,6 +13,7 @@ import { formatRelativeTime } from "@/lib/format";
 import { Icon } from "@/components/folio/icons";
 import { Avatar, Mark, Confidence, Freshness } from "@/components/folio/primitives";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
+import { HtmlPreview } from "@/components/HtmlPreview";
 import { ArticleActions } from "@/components/ArticleActions";
 import { RevisionHistory } from "@/components/RevisionHistory";
 import { DiscussionPanel } from "@/components/DiscussionPanel";
@@ -392,14 +393,20 @@ export async function ArticleView({
       >
         <div className="min-w-0">
           <article>
-            <MarkdownRenderer
-              content={articleBody}
-              className="prose-article"
-              headingIds={toc.map((t) => t.id)}
-              tenant={pageTenant}
-              slugTenants={slugTenants}
-              commonsSlugs={commonsSlugs}
-            />
+            {isArtifactType(typeof fm.type === "string" ? fm.type : undefined) ? (
+              // A saved HTML output is rendered verbatim in a sandboxed iframe
+              // (isolated; no app cookie/DOM/network access) — never markdown.
+              <HtmlPreview html={page.body} />
+            ) : (
+              <MarkdownRenderer
+                content={articleBody}
+                className="prose-article"
+                headingIds={toc.map((t) => t.id)}
+                tenant={pageTenant}
+                slugTenants={slugTenants}
+                commonsSlugs={commonsSlugs}
+              />
+            )}
           </article>
 
           {backlinks.length > 0 && (

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -31,7 +31,9 @@ export function HtmlPreview({ html }: { html: string }) {
         HTML_HEIGHT_MESSAGE_KEY
       ];
       if (typeof reported === "number" && reported > 0) {
-        setHeight(Math.min(Math.ceil(reported), HTML_MAX_HEIGHT));
+        // Clamp: cap a runaway/hostile grow, and floor a degenerate (e.g. 1px)
+        // report so the artifact can't collapse to an invisible sliver.
+        setHeight(Math.max(140, Math.min(Math.ceil(reported), HTML_MAX_HEIGHT)));
       }
     }
     window.addEventListener("message", onMessage);

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  composeSrcDoc,
+  HTML_SANDBOX,
+  HTML_MAX_HEIGHT,
+  HTML_HEIGHT_MESSAGE_KEY,
+} from "@/lib/html";
+
+/**
+ * Render model-authored HTML SAFELY in a sandboxed iframe.
+ *
+ * Security = isolation, not sanitization: `sandbox="allow-scripts"` WITHOUT
+ * `allow-same-origin` gives the frame a unique opaque origin, so scripts run but
+ * cannot read the app's cookies/DOM/storage/session or make credentialed
+ * requests; an injected CSP (see {@link composeSrcDoc}) additionally blocks all
+ * network egress and external resources. Rendered via `srcDoc` — NEVER
+ * `dangerouslySetInnerHTML`. Frame height is reported by the document via
+ * postMessage (clamped to a max to bound a runaway/hostile grow).
+ */
+export function HtmlPreview({ html }: { html: string }) {
+  const ref = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(360);
+
+  useEffect(() => {
+    function onMessage(e: MessageEvent) {
+      // Trust only messages from THIS frame's window, with the expected shape.
+      if (!ref.current || e.source !== ref.current.contentWindow) return;
+      const reported = (e.data as Record<string, unknown> | null)?.[
+        HTML_HEIGHT_MESSAGE_KEY
+      ];
+      if (typeof reported === "number" && reported > 0) {
+        setHeight(Math.min(Math.ceil(reported), HTML_MAX_HEIGHT));
+      }
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, []);
+
+  return (
+    <iframe
+      ref={ref}
+      srcDoc={composeSrcDoc(html)}
+      sandbox={HTML_SANDBOX}
+      title="HTML output"
+      style={{
+        width: "100%",
+        height,
+        border: "1px solid var(--rule)",
+        borderRadius: 10,
+        background: "var(--paper)",
+        display: "block",
+      }}
+    />
+  );
+}

--- a/src/components/QueryResultPanel.tsx
+++ b/src/components/QueryResultPanel.tsx
@@ -4,9 +4,13 @@ import { useState, useCallback, useEffect } from "react";
 import Link from "next/link";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { SlidePreview } from "@/components/SlidePreview";
+import { HtmlPreview } from "@/components/HtmlPreview";
 import { Alert } from "@/components/Alert";
 import { useSlugTenants } from "@/hooks/useSlugTenants";
 import { logger } from "@/lib/logger";
+
+/** Answer format hint (mirrors QueryFormat in lib/query) — the panel renders accordingly. */
+type AnswerFormat = "prose" | "table" | "slides" | "html";
 
 interface SaveState {
   status: "idle" | "editing" | "saving" | "saved" | "error";
@@ -22,6 +26,8 @@ export interface QueryResultPanelProps {
   onHistorySaved?: (id: string, slug: string) => void;
   /** Hide the "Save to Wiki" action (e.g. the signed-out homepage demo). */
   readOnly?: boolean;
+  /** The format the answer was generated in — drives rendering + save. */
+  format?: AnswerFormat;
 }
 
 export function QueryResultPanel({
@@ -31,6 +37,7 @@ export function QueryResultPanel({
   currentHistoryId,
   onHistorySaved,
   readOnly = false,
+  format = "prose",
 }: QueryResultPanelProps) {
   const { hrefForSlug } = useSlugTenants();
   const [saveState, setSaveState] = useState<SaveState>({ status: "idle" });
@@ -51,20 +58,29 @@ export function QueryResultPanel({
     return () => clearTimeout(timer);
   }, [copyState]);
 
-  const handleCopyMarkdown = useCallback(async () => {
-    const lines = [`# ${question.trim()}`, "", result.answer];
-    if (result.sources.length > 0) {
-      lines.push("", "## Sources", "");
-      for (const slug of result.sources) lines.push(`- [[${slug}]]`);
+  const isHtml = format === "html";
+  const handleCopy = useCallback(async () => {
+    // HTML copies the document verbatim (it's the shareable artifact); other
+    // formats copy a markdown wrapper with a heading + sources.
+    let text: string;
+    if (isHtml) {
+      text = result.answer;
+    } else {
+      const lines = [`# ${question.trim()}`, "", result.answer];
+      if (result.sources.length > 0) {
+        lines.push("", "## Sources", "");
+        for (const slug of result.sources) lines.push(`- [[${slug}]]`);
+      }
+      text = lines.join("\n");
     }
     try {
-      await navigator.clipboard.writeText(lines.join("\n"));
+      await navigator.clipboard.writeText(text);
       setCopyState("copied");
     } catch (err) {
       logger.error("query", "copy failed", err);
       setCopyState("error");
     }
-  }, [result, question]);
+  }, [result, question, isHtml]);
 
   function handleSaveClick() {
     setSaveTitle(question.trim());
@@ -85,6 +101,7 @@ export function QueryResultPanel({
           title: saveTitle.trim(),
           content: result.answer,
           sources: result.sources,
+          format,
         }),
       });
 
@@ -125,16 +142,30 @@ export function QueryResultPanel({
   /** Allow external callers to set save state (e.g. loading from history). */
   // This is handled via the useEffect reset above + parent re-rendering with new props.
 
+  // HTML answers render in a sandboxed iframe (HtmlPreview). Drive off the chosen
+  // format, with a content sniff as a fallback for answers reloaded without it.
+  const isHtmlAnswer =
+    format === "html" ||
+    /^\s*(<!doctype html|<html)/i.test(result.answer);
+  const isMarp = result.answer.trimStart().startsWith("---\nmarp: true");
+
   return (
     <div className="mt-8 space-y-6">
       <div className="rounded-lg border border-foreground/10 p-6">
-        {!streaming &&
-        result.answer.trimStart().startsWith("---\nmarp: true") ? (
+        {isHtmlAnswer && streaming ? (
+          // Mid-stream HTML is malformed — show the raw source (escaped) as it
+          // builds; the sandboxed render mounts once streaming completes.
+          <pre className="overflow-auto whitespace-pre-wrap break-words text-xs text-foreground/60 max-h-72">
+            {result.answer || "Rendering HTML…"}
+          </pre>
+        ) : isHtmlAnswer ? (
+          <HtmlPreview html={result.answer} />
+        ) : !streaming && isMarp ? (
           <SlidePreview content={result.answer} />
         ) : (
           <MarkdownRenderer content={result.answer} />
         )}
-        {streaming && (
+        {streaming && !isHtmlAnswer && (
           <span className="inline-block w-2 h-4 bg-foreground/60 animate-pulse ml-0.5 align-text-bottom" />
         )}
       </div>
@@ -164,14 +195,16 @@ export function QueryResultPanel({
         <div className="border-t border-foreground/10 pt-4 space-y-3">
           <div className="flex flex-wrap gap-2">
             <button
-              onClick={handleCopyMarkdown}
+              onClick={handleCopy}
               className="rounded-lg border border-foreground/20 px-4 py-2 text-sm font-medium hover:bg-foreground/5 transition-colors"
             >
               {copyState === "copied"
                 ? "Copied!"
                 : copyState === "error"
                   ? "Copy failed"
-                  : "Copy as Markdown"}
+                  : isHtml
+                    ? "Copy HTML"
+                    : "Copy as Markdown"}
             </button>
             {!readOnly && saveState.status === "idle" && (
               <button

--- a/src/hooks/useStreamingQuery.ts
+++ b/src/hooks/useStreamingQuery.ts
@@ -12,8 +12,8 @@ export interface QueryResponse {
 export interface UseStreamingQueryReturn {
   question: string;
   setQuestion: (q: string) => void;
-  format: "prose" | "table" | "slides";
-  setFormat: (f: "prose" | "table" | "slides") => void;
+  format: "prose" | "table" | "slides" | "html";
+  setFormat: (f: "prose" | "table" | "slides" | "html") => void;
   /** Active scope sent with each query ("mine", "owner:<h>", or undefined=All). */
   scope: string | undefined;
   setScope: (s: string | undefined) => void;
@@ -46,7 +46,7 @@ export function useStreamingQuery(
   options: UseStreamingQueryOptions = {},
 ): UseStreamingQueryReturn {
   const [question, setQuestion] = useState("");
-  const [format, setFormat] = useState<"prose" | "table" | "slides">("prose");
+  const [format, setFormat] = useState<"prose" | "table" | "slides" | "html">("prose");
   const [scope, setScope] = useState<string | undefined>(options.initialScope);
   const [result, setResult] = useState<QueryResponse | null>(null);
   const [loading, setLoading] = useState(false);

--- a/src/lib/__tests__/commons.test.ts
+++ b/src/lib/__tests__/commons.test.ts
@@ -44,6 +44,10 @@ describe("belongsInCommons", () => {
     expect(belongsInCommons({ type: "agent-identity" })).toBe(false);
     expect(belongsInCommons({ type: "wiki" })).toBe(true);
   });
+
+  it("excludes saved HTML artifacts (personal rendered outputs)", () => {
+    expect(belongsInCommons({ type: "html" })).toBe(false);
+  });
 });
 
 describe("syncCommonsForPage", () => {

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  composeSrcDoc,
+  htmlToPlainText,
+  HTML_SANDBOX,
+  HTML_MAX_HEIGHT,
+} from "../html";
+
+describe("composeSrcDoc", () => {
+  it("injects a locked-down CSP (default-src 'none', no connect-src)", () => {
+    const out = composeSrcDoc("<!doctype html><html><head></head><body>hi</body></html>");
+    expect(out).toContain('http-equiv="Content-Security-Policy"');
+    expect(out).toContain("default-src 'none'");
+    expect(out).toContain("img-src data:");
+    // No network egress is permitted.
+    expect(out).not.toContain("connect-src");
+  });
+
+  it("adds <base target=\"_blank\"> and a resize reporter", () => {
+    const out = composeSrcDoc("<html><head></head><body>x</body></html>");
+    expect(out).toContain('<base target="_blank">');
+    expect(out).toContain("__wikiHtmlHeight");
+    expect(out).toContain("postMessage");
+  });
+
+  it("inserts into an existing <head> (full document)", () => {
+    const out = composeSrcDoc("<!doctype html><html><head><title>T</title></head><body>b</body></html>");
+    // The CSP comes right after <head>, before the existing <title>.
+    expect(out.indexOf("Content-Security-Policy")).toBeLessThan(out.indexOf("<title>"));
+    expect(out).toContain("<title>T</title>");
+  });
+
+  it("adds a <head> when <html> has none", () => {
+    const out = composeSrcDoc("<html><body>only body</body></html>");
+    expect(out).toContain("<head>");
+    expect(out).toContain("Content-Security-Policy");
+    expect(out).toContain("only body");
+  });
+
+  it("wraps a bare fragment in a full document", () => {
+    const out = composeSrcDoc("<p>just a fragment</p>");
+    expect(out.toLowerCase()).toContain("<!doctype html>");
+    expect(out).toContain("Content-Security-Policy");
+    expect(out).toContain("<p>just a fragment</p>");
+  });
+
+  it("the sandbox never grants same-origin (isolation invariant)", () => {
+    // The escape footgun is allow-scripts + allow-same-origin together.
+    expect(HTML_SANDBOX).toContain("allow-scripts");
+    expect(HTML_SANDBOX).not.toContain("allow-same-origin");
+    expect(HTML_MAX_HEIGHT).toBeGreaterThan(0);
+  });
+});
+
+describe("htmlToPlainText", () => {
+  it("drops script/style bodies and tags, decoding entities", () => {
+    const html =
+      "<style>.x{color:red}</style><h1>Title</h1><script>steal()</script><p>Body &amp; more &lt;tag&gt;</p>";
+    const text = htmlToPlainText(html);
+    expect(text).toContain("Title");
+    expect(text).toContain("Body & more <tag>");
+    expect(text).not.toContain("steal()");
+    expect(text).not.toContain("color:red");
+    expect(text).not.toMatch(/<\/?(h1|p|style|script)/i);
+  });
+
+  it("collapses whitespace and trims", () => {
+    expect(htmlToPlainText("<div>  a\n\n  b  </div>")).toBe("a b");
+  });
+});

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -44,6 +44,34 @@ describe("composeSrcDoc", () => {
     expect(out).toContain("<p>just a fragment</p>");
   });
 
+  it("injects our restrictive CSP BEFORE a model-supplied relaxing one", () => {
+    // A model that emits its own relaxing <meta CSP> can't replace ours: ours is
+    // injected first, and per the CSP spec multiple policies combine to the most
+    // restrictive (intersection), so `default-src 'none'` still wins.
+    const out = composeSrcDoc(
+      '<html><head><meta http-equiv="Content-Security-Policy" content="default-src *"></head><body>x</body></html>',
+    );
+    expect(out.indexOf("default-src 'none'")).toBeLessThan(
+      out.indexOf("default-src *"),
+    );
+    // Our <base target="_blank"> is also injected ahead of any model <base>.
+    expect(out).toContain('<base target="_blank">');
+  });
+
+  it("handles empty / whitespace input (wraps into a valid CSP'd document)", () => {
+    for (const input of ["", "   ", "\n"]) {
+      const out = composeSrcDoc(input);
+      expect(out.toLowerCase()).toContain("<!doctype html>");
+      expect(out).toContain("default-src 'none'");
+    }
+  });
+
+  it("inserts after a <head> with attributes", () => {
+    const out = composeSrcDoc("<html><head lang=\"en\"><title>T</title></head><body>b</body></html>");
+    expect(out).toContain('<head lang="en">');
+    expect(out.indexOf("Content-Security-Policy")).toBeLessThan(out.indexOf("<title>"));
+  });
+
   it("the sandbox never grants same-origin (isolation invariant)", () => {
     // The escape footgun is allow-scripts + allow-same-origin together.
     expect(HTML_SANDBOX).toContain("allow-scripts");

--- a/src/lib/__tests__/lifecycle.test.ts
+++ b/src/lib/__tests__/lifecycle.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as embeddings from "../embeddings";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
@@ -126,6 +127,28 @@ describe("writeWikiPageWithSideEffects", () => {
     // Should have the updated summary
     expect(index).toContain("Updated summary");
     expect(index).not.toContain("A test page");
+  });
+
+  // Embedding: skipped for saved html artifacts, run for normal pages.
+  it("embeds a normal page but SKIPS embedding for an html artifact", async () => {
+    const spy = vi.spyOn(embeddings, "upsertEmbedding").mockResolvedValue();
+
+    await writeWikiPageWithSideEffects(makeOpts({ slug: "normal-page" }));
+    expect(spy).toHaveBeenCalledWith("normal-page", expect.any(String));
+
+    spy.mockClear();
+    await writeWikiPageWithSideEffects(
+      makeOpts({
+        slug: "html-artifact",
+        content: serializeFrontmatter(
+          { type: "html" },
+          "<!doctype html><html><body>chart</body></html>",
+        ),
+      }),
+    );
+    expect(spy).not.toHaveBeenCalled();
+
+    spy.mockRestore();
   });
 
   // 4. Appends to log

--- a/src/lib/__tests__/query-route.test.ts
+++ b/src/lib/__tests__/query-route.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/query", () => ({
+  query: vi.fn(async () => ({ answer: "ok", sources: [] })),
+}));
+vi.mock("@/lib/auth", () => ({ getPrincipal: vi.fn(async () => null) }));
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+import { query } from "@/lib/query";
+import { POST } from "@/app/api/query/route";
+
+const mockedQuery = vi.mocked(query);
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/query", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST /api/query — format validation", () => {
+  it("accepts format:'html' and threads it to query()", async () => {
+    const res = await POST(makeRequest({ question: "what is A?", format: "html" }));
+    expect(res.status).toBe(200);
+    expect(mockedQuery).toHaveBeenCalledTimes(1);
+    expect(mockedQuery.mock.calls[0][1]).toBe("html"); // 2nd arg = format
+  });
+
+  it("accepts the existing formats", async () => {
+    for (const f of ["prose", "table", "slides"]) {
+      await POST(makeRequest({ question: "q", format: f }));
+    }
+    expect(mockedQuery).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects an invalid format with 400 and does not run the query", async () => {
+    const res = await POST(makeRequest({ question: "q", format: "bogus" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/format must be/);
+    expect(mockedQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/query-save-route.test.ts
+++ b/src/lib/__tests__/query-save-route.test.ts
@@ -17,9 +17,11 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 import { saveAnswerToWiki } from "@/lib/query";
+import { getPrincipal } from "@/lib/auth";
 import { POST } from "@/app/api/query/save/route";
 
 const mockedSaveAnswer = vi.mocked(saveAnswerToWiki);
+const mockedGetPrincipal = vi.mocked(getPrincipal);
 
 function makeRequest(body: unknown): NextRequest {
   return new NextRequest("http://localhost/api/query/save", {
@@ -32,6 +34,7 @@ function makeRequest(body: unknown): NextRequest {
 beforeEach(() => {
   mockedSaveAnswer.mockReset();
   mockedSaveAnswer.mockResolvedValue({ slug: "test-page" } as ReturnType<typeof saveAnswerToWiki> extends Promise<infer T> ? T : never);
+  mockedGetPrincipal.mockResolvedValue({ id: "test-user", handle: "test-user" });
 });
 
 describe("POST /api/query/save", () => {
@@ -93,6 +96,20 @@ describe("POST /api/query/save", () => {
       "html",
       "test-user", // owner from the session principal
     );
+  });
+
+  it("rejects an HTML save with 401 when the principal can't be resolved", async () => {
+    mockedGetPrincipal.mockResolvedValueOnce(null);
+    const req = makeRequest({
+      title: "Chart",
+      content: "<!doctype html><html><body>x</body></html>",
+      format: "html",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    // No mis-attributed system-owned artifact is written.
+    expect(mockedSaveAnswer).not.toHaveBeenCalled();
   });
 
   it("rejects non-array sources with 400", async () => {

--- a/src/lib/__tests__/query-save-route.test.ts
+++ b/src/lib/__tests__/query-save-route.test.ts
@@ -51,6 +51,8 @@ describe("POST /api/query/save", () => {
       "Some answer content",
       undefined,
       sources,
+      "markdown",
+      undefined,
     );
   });
 
@@ -68,6 +70,28 @@ describe("POST /api/query/save", () => {
       "Answer without sources",
       undefined,
       undefined,
+      "markdown",
+      undefined,
+    );
+  });
+
+  it("saves an HTML answer as an artifact owned by the asker", async () => {
+    const req = makeRequest({
+      title: "Chart",
+      content: "<!doctype html><html><body>x</body></html>",
+      format: "html",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    expect(mockedSaveAnswer).toHaveBeenCalledWith(
+      "Chart",
+      "<!doctype html><html><body>x</body></html>",
+      undefined,
+      undefined,
+      "html",
+      "test-user", // owner from the session principal
     );
   });
 

--- a/src/lib/__tests__/query-stream-route.test.ts
+++ b/src/lib/__tests__/query-stream-route.test.ts
@@ -94,4 +94,27 @@ describe("POST /api/query/stream — agent-scope filtering (#413)", () => {
     expect(passedEntries.map((e) => e.type)).toContain("agent-identity");
     expect(passedEntries.map((e) => e.type)).toContain("agent-knowledge");
   });
+
+  it("excludes saved html artifacts from an unscoped query (and accepts format:html)", async () => {
+    mockedList.mockResolvedValue([
+      { slug: "concept-a", title: "A", summary: "", type: undefined },
+      { slug: "saved-chart", title: "Chart", summary: "", type: "html" },
+    ] as unknown as Awaited<ReturnType<typeof listReadableWikiPages>>);
+
+    await POST(makeRequest({ question: "?", format: "html" }));
+
+    expect(mockedSelect).toHaveBeenCalledTimes(1);
+    const passedEntries = mockedSelect.mock.calls[0][1] as Array<{ type?: string }>;
+    // The artifact's markup must never enter the LLM context.
+    expect(passedEntries.map((e) => e.type)).not.toContain("html");
+    expect(passedEntries.map((e) => (e as { slug: string }).slug)).toEqual([
+      "concept-a",
+    ]);
+  });
+
+  it("rejects an invalid format with 400", async () => {
+    const res = await POST(makeRequest({ question: "?", format: "bogus" }));
+    expect(res.status).toBe(400);
+    expect(mockedSelect).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/__tests__/query-stream-route.test.ts
+++ b/src/lib/__tests__/query-stream-route.test.ts
@@ -22,9 +22,11 @@ vi.mock("@/lib/search", () => ({
 
 vi.mock("@/lib/wiki", () => ({
   listReadableWikiPages: vi.fn(),
-  // Real-ish predicate: agent-scoped types are the `agent-*` family.
+  // Real-ish predicates: agent-scoped types are the `agent-*` family; saved
+  // artifacts are `html`.
   isAgentScopedType: (t: unknown) =>
     typeof t === "string" && t.startsWith("agent-"),
+  isArtifactType: (t: unknown) => t === "html",
 }));
 
 vi.mock("@/lib/llm", () => ({

--- a/src/lib/__tests__/query.test.ts
+++ b/src/lib/__tests__/query.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
-import { searchIndex, buildContext, query, saveAnswerToWiki, buildCorpusStats, bm25Score, extractCitedSlugs, reciprocalRankFusion, buildQuerySystemPrompt, TABLE_FORMAT_INSTRUCTION, extractBestSnippet, selectPagesForQuery } from "../query";
+import { searchIndex, buildContext, query, saveAnswerToWiki, buildCorpusStats, bm25Score, extractCitedSlugs, reciprocalRankFusion, buildQuerySystemPrompt, TABLE_FORMAT_INSTRUCTION, HTML_FORMAT_INSTRUCTION, extractBestSnippet, selectPagesForQuery } from "../query";
 import { writeWikiPage, updateIndex, ensureDirectories, readWikiPage, readWikiPageWithFrontmatter, listWikiPages } from "../wiki";
 import { registerAgent } from "../agents";
 import { _resetStorage } from "../storage";
@@ -825,6 +825,36 @@ describe("saveAnswerToWiki", () => {
     expect(entry!.summary).toContain("Neural networks are computational models");
   });
 
+  it("saves an HTML answer verbatim as a typed, owner-attributed artifact", async () => {
+    await ensureDirectories();
+    const html =
+      "<!doctype html><html><head><style>b{font-weight:700}</style></head><body><h1>Chart</h1><svg></svg><script>1+1</script></body></html>";
+
+    const { slug } = await saveAnswerToWiki(
+      "My Chart",
+      html,
+      undefined,
+      undefined,
+      "html",
+      "alice",
+    );
+
+    const page = await readWikiPageWithFrontmatter(slug);
+    expect(page).not.toBeNull();
+    // Body stored verbatim — no injected markdown `# ` heading.
+    expect(page!.body).toContain("<svg></svg>");
+    expect(page!.body).toContain("<script>1+1</script>");
+    expect(page!.body.trimStart()).not.toMatch(/^# /);
+    // Typed as an artifact and attributed to the asker.
+    expect(page!.frontmatter.type).toBe("html");
+    expect(page!.frontmatter.owner).toBe("alice");
+
+    // The index summary is tag-stripped plain text (no markup leaks into ranking).
+    const entry = (await listWikiPages()).find((e) => e.slug === slug);
+    expect(entry!.summary).not.toMatch(/[<>]/);
+    expect(entry!.type).toBe("html");
+  });
+
   it("wraps saved answer in YAML frontmatter with source and tags", async () => {
     await ensureDirectories();
 
@@ -1335,6 +1365,17 @@ describe("buildQuerySystemPrompt — format option", () => {
     // Default behavior must match explicit "prose" — guards against the
     // default ever drifting away from existing callers' expectations.
     expect(proseDefault).toBe(proseExplicit);
+  });
+
+  it("appends the HTML instruction only when format is 'html'", async () => {
+    const html = await buildQuerySystemPrompt("ctx", entries, ["alpha"], "html");
+    expect(html).toContain(HTML_FORMAT_INSTRUCTION);
+    expect(html).toMatch(/self-contained html/i);
+    // Other formats never include it.
+    const prose = await buildQuerySystemPrompt("ctx", entries, ["alpha"], "prose");
+    const table = await buildQuerySystemPrompt("ctx", entries, ["alpha"], "table");
+    expect(prose).not.toContain(HTML_FORMAT_INSTRUCTION);
+    expect(table).not.toContain(HTML_FORMAT_INSTRUCTION);
   });
 });
 

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -46,7 +46,7 @@ import type { IndexEntry } from "../types";
 import { registerAgent, ensureAgentsDir } from "../agents";
 import { createVault, addToVault, vaultIdFor } from "../vault";
 import { serializeFrontmatter } from "../frontmatter";
-import { isAgentScopedType } from "../wiki";
+import { isAgentScopedType, isArtifactType } from "../wiki";
 import type { AgentProfile } from "../types";
 import { _resetStorage } from "../storage";
 import { relatedByVector, searchByVector } from "../embeddings";
@@ -106,6 +106,16 @@ describe("isAgentScopedType", () => {
     expect(isAgentScopedType("prose")).toBe(false);
     // "agent" must be a prefix, not just contained.
     expect(isAgentScopedType("my-agent-notes")).toBe(false);
+  });
+});
+
+describe("isArtifactType", () => {
+  it("is true only for saved-artifact types (html)", () => {
+    expect(isArtifactType("html")).toBe(true);
+    expect(isArtifactType("wiki")).toBe(false);
+    expect(isArtifactType("agent-knowledge")).toBe(false);
+    expect(isArtifactType(undefined)).toBe(false);
+    expect(isArtifactType("")).toBe(false);
   });
 });
 

--- a/src/lib/commons.ts
+++ b/src/lib/commons.ts
@@ -11,7 +11,7 @@
 
 import { getStorage } from "./storage";
 import { withFileLock } from "./lock";
-import { listWikiPages, isAgentScopedType, tenantForOwner } from "./wiki";
+import { listWikiPages, isAgentScopedType, isArtifactType, tenantForOwner } from "./wiki";
 import { logger } from "./logger";
 import type { IndexEntry } from "./types";
 
@@ -36,12 +36,20 @@ export interface CommonsEntry {
   type?: string;
 }
 
-/** A page belongs in the commons iff it's public and not agent-scoped. */
+/**
+ * A page belongs in the commons iff it's public, not agent-scoped, and not a
+ * rendered artifact (e.g. a saved `html` query output — a personal artifact, not
+ * collective knowledge; see {@link isArtifactType}).
+ */
 export function belongsInCommons(meta: {
   visibility?: string;
   type?: string;
 }): boolean {
-  return meta.visibility !== "private" && !isAgentScopedType(meta.type);
+  return (
+    meta.visibility !== "private" &&
+    !isAgentScopedType(meta.type) &&
+    !isArtifactType(meta.type)
+  );
 }
 
 /**

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -1,0 +1,94 @@
+/**
+ * Helpers for the sandboxed "html" answer format.
+ *
+ * Pure and runtime-agnostic (no DOM) so they work on the Cloudflare Workers
+ * runtime and in tests. The security model is ISOLATION, not sanitization:
+ * model-authored HTML is rendered in an `<iframe srcDoc>` with
+ * `sandbox="allow-scripts"` and NO `allow-same-origin`, so scripts run in a
+ * unique opaque origin that can't read the app's cookies/DOM/storage or make
+ * credentialed/same-origin requests. The injected CSP additionally blocks all
+ * network egress and external resources.
+ */
+
+/**
+ * The iframe `sandbox` attribute. Scripts run, but the absence of
+ * `allow-same-origin` gives the frame a unique opaque origin — it CANNOT touch
+ * the parent app's cookies, DOM, storage, or session.
+ *
+ * SECURITY: never add `allow-same-origin` here. `allow-scripts` +
+ * `allow-same-origin` together let the framed document remove its own sandbox
+ * (`frameElement.sandbox`) and escape isolation. Frame height is solved by
+ * postMessage (below), so same-origin access is never needed.
+ */
+export const HTML_SANDBOX = "allow-scripts";
+
+/** Hard cap (px) on a sandboxed frame's reported height — bounds a runaway/hostile grow. */
+export const HTML_MAX_HEIGHT = 4000;
+
+/** Message shape posted by the sandboxed frame to report its height. */
+export const HTML_HEIGHT_MESSAGE_KEY = "__wikiHtmlHeight";
+
+/**
+ * Content-Security-Policy injected into every sandboxed document. `default-src
+ * 'none'` + no `connect-src` blocks fetch/XHR/WebSocket/beacon (no exfiltration,
+ * no phone-home); `img-src`/`font-src data:` enforce "no external resources"
+ * even if the model emits a CDN URL. Inline styles + scripts are the only thing
+ * a self-contained document needs.
+ */
+const SANDBOX_CSP =
+  "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; font-src data:";
+
+/**
+ * Injected into the document `<head>`: the CSP, `<base target="_blank">` (any
+ * link opens in a new tab rather than navigating the frame to an app route), and
+ * a tiny resize reporter (postMessage is permitted from a sandboxed frame even
+ * without same-origin access).
+ */
+const SANDBOX_HEAD =
+  `<meta http-equiv="Content-Security-Policy" content="${SANDBOX_CSP}">` +
+  `<base target="_blank">` +
+  `<script>(function(){function r(){try{parent.postMessage({${HTML_HEIGHT_MESSAGE_KEY}:` +
+  `Math.ceil(document.documentElement.scrollHeight)},'*')}catch(e){}}` +
+  `if(typeof ResizeObserver!=='undefined'){new ResizeObserver(r).observe(document.documentElement);}` +
+  `window.addEventListener('load',r);setTimeout(r,60);})();</script>`;
+
+/**
+ * Compose a srcdoc string from model HTML, injecting the sandbox `<head>` bits.
+ * Robust to a full document, an `<html>` without a `<head>`, or a bare fragment.
+ */
+export function composeSrcDoc(html: string): string {
+  const src = (html ?? "").trim();
+
+  const headOpen = src.match(/<head[^>]*>/i);
+  if (headOpen?.index !== undefined) {
+    const at = headOpen.index + headOpen[0].length;
+    return src.slice(0, at) + SANDBOX_HEAD + src.slice(at);
+  }
+
+  const htmlOpen = src.match(/<html[^>]*>/i);
+  if (htmlOpen?.index !== undefined) {
+    const at = htmlOpen.index + htmlOpen[0].length;
+    return `${src.slice(0, at)}<head>${SANDBOX_HEAD}</head>${src.slice(at)}`;
+  }
+
+  return `<!doctype html><html><head>${SANDBOX_HEAD}</head><body>${src}</body></html>`;
+}
+
+/**
+ * Strip HTML to plain text for DERIVED text only (summary, search/embedding) —
+ * never for rendering. Drops `<script>`/`<style>` bodies, removes tags, decodes
+ * a few common entities, and collapses whitespace.
+ */
+export function htmlToPlainText(html: string): string {
+  return (html ?? "")
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0?39;|&apos;/gi, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -264,11 +264,20 @@ async function runPageLifecycleOp(
   if (op.kind === "write") {
     // Skip embedding rendered artifacts (e.g. saved `html` outputs): they're
     // excluded from the search/query corpus, and their raw markup would pollute
-    // the vector store.
-    const fmType = parseFrontmatter(op.content).data.type;
-    const isArtifact = isArtifactType(
-      typeof fmType === "string" ? fmType : undefined,
-    );
+    // the vector store. Fail-open: a frontmatter parse error must NOT break the
+    // (already-committed) write — fall back to attempting the embedding, which
+    // is itself guarded below.
+    let isArtifact = false;
+    try {
+      const fmType = parseFrontmatter(op.content).data.type;
+      isArtifact = isArtifactType(typeof fmType === "string" ? fmType : undefined);
+    } catch (err) {
+      logger.warn(
+        "wiki",
+        `embedding-skip frontmatter parse failed for "${slug}":`,
+        getErrorMessage(err, String(err)),
+      );
+    }
     if (!isArtifact) {
       try {
         await upsertEmbedding(slug, op.content);

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -14,6 +14,7 @@ import {
   appendToLog,
   wikiRelPath,
   tenantForOwner,
+  isArtifactType,
   enrichEntry,
 } from "./wiki";
 import { syncPageIndexForPage, removePageIndexForSlug } from "./page-index";
@@ -261,14 +262,23 @@ async function runPageLifecycleOp(
   //        independent ops (embedding, revisions, discussions) run CONCURRENTLY
   //        instead of one-after-another to cut latency.
   if (op.kind === "write") {
-    try {
-      await upsertEmbedding(slug, op.content);
-    } catch (err) {
-      logger.warn(
-        "wiki",
-        `embedding upsert failed for "${slug}":`,
-        getErrorMessage(err, String(err)),
-      );
+    // Skip embedding rendered artifacts (e.g. saved `html` outputs): they're
+    // excluded from the search/query corpus, and their raw markup would pollute
+    // the vector store.
+    const fmType = parseFrontmatter(op.content).data.type;
+    const isArtifact = isArtifactType(
+      typeof fmType === "string" ? fmType : undefined,
+    );
+    if (!isArtifact) {
+      try {
+        await upsertEmbedding(slug, op.content);
+      } catch (err) {
+        logger.warn(
+          "wiki",
+          `embedding upsert failed for "${slug}":`,
+          getErrorMessage(err, String(err)),
+        );
+      }
     }
   } else {
     const cleanups: { label: string; run: Promise<unknown> }[] = [

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -5,8 +5,10 @@ import {
   writeWikiPageWithSideEffects,
   withPageCache,
   isAgentScopedType,
+  isArtifactType,
 } from "./wiki";
 import { slugify } from "./slugify";
+import { htmlToPlainText } from "./html";
 import { extractSummary } from "./ingest";
 import { loadPageConventions } from "./schema";
 import { serializeFrontmatter } from "./frontmatter";
@@ -81,8 +83,20 @@ Start the response with the Marp front matter:
 marp: true
 ---`;
 
+/**
+ * Extra system-prompt instruction appended when the caller requests an HTML
+ * answer — a single self-contained document rendered in a sandboxed iframe.
+ */
+export const HTML_FORMAT_INSTRUCTION = `Format your answer as a SINGLE, SELF-CONTAINED HTML document — richer and more readable than markdown.
+- Output ONLY HTML: start with \`<!doctype html>\` and a full \`<html>\`/\`<head>\`/\`<body>\`. No markdown, no code fences around it.
+- Style with an inline \`<style>\` block. Use clean, readable typography and a light layout (headings, sections, callouts, tables where useful).
+- For charts/diagrams, draw them as INLINE \`<svg>\` (bar/line/pie/flow). Do NOT use any charting library.
+- It MUST be fully self-contained: NO external resources — no \`<link>\`, no \`<script src>\`, no CDN URLs, no web fonts, no network requests. Images only as inline \`data:\` URIs or inline SVG.
+- You MAY include a small inline \`<script>\` for light interactivity (toggles, tabs, hover detail), but it runs in a locked-down sandbox with no network and no access to anything outside the document.
+- Cite sources as plain links \`<a href="slug.md">Page Title</a>\` and also include them in a final "Sources" section, so citations are traceable.`;
+
 /** Answer format hint supported by `query()` / `buildQuerySystemPrompt()`. */
-export type QueryFormat = "prose" | "table" | "slides";
+export type QueryFormat = "prose" | "table" | "slides" | "html";
 
 // ---------------------------------------------------------------------------
 // BM25 sparse index search
@@ -153,6 +167,8 @@ export async function buildQuerySystemPrompt(
     systemPrompt += `\n\n${TABLE_FORMAT_INSTRUCTION}`;
   } else if (format === "slides") {
     systemPrompt += `\n\n${SLIDES_FORMAT_INSTRUCTION}`;
+  } else if (format === "html") {
+    systemPrompt += `\n\n${HTML_FORMAT_INSTRUCTION}`;
   }
 
   return systemPrompt;
@@ -198,10 +214,13 @@ export async function query(
       return { answer: scopeError, sources: [] };
     }
 
-    // General (unscoped) query excludes agent-scoped pages — agent knowledge
-    // surfaces only via an `agent:` scope.
+    // General (unscoped) query excludes agent-scoped pages (agent knowledge
+    // surfaces only via an `agent:` scope) and saved HTML artifacts (rendered
+    // outputs, not knowledge — their markup must never enter the LLM context).
     if (!scopeSlugs) {
-      entries = entries.filter((e) => !isAgentScopedType(e.type));
+      entries = entries.filter(
+        (e) => !isAgentScopedType(e.type) && !isArtifactType(e.type),
+      );
     }
 
     // Empty wiki — nothing to query
@@ -271,6 +290,8 @@ export async function saveAnswerToWiki(
   content: string,
   explicitSlug?: string,
   sources?: string[],
+  contentType: "markdown" | "html" = "markdown",
+  owner?: string,
 ): Promise<{ slug: string }> {
   const slug = explicitSlug || slugify(title);
 
@@ -278,13 +299,21 @@ export async function saveAnswerToWiki(
     throw new Error("Title must produce a valid slug");
   }
 
-  // Prepend a heading if the content doesn't already start with one
-  const pageContent = content.trimStart().startsWith("# ")
-    ? content
-    : `# ${title}\n\n${content}`;
+  const isHtml = contentType === "html";
 
-  // Extract a short summary from the content (first sentence or first 200 chars)
-  const plainContent = content.replace(/^#.*$/gm, "").trim();
+  // HTML is stored VERBATIM — prepending a markdown `# title` would corrupt the
+  // document (the title still shows via ArticleView's <h1>, outside the iframe).
+  // Markdown gets the usual H1 if it lacks one.
+  const pageContent = isHtml
+    ? content
+    : content.trimStart().startsWith("# ")
+      ? content
+      : `# ${title}\n\n${content}`;
+
+  // Summary comes from plain text: tag-stripped for HTML, heading-stripped for md.
+  const plainContent = isHtml
+    ? htmlToPlainText(content)
+    : content.replace(/^#.*$/gm, "").trim();
   const summary = extractSummary(plainContent) || title;
 
   // Wrap in YAML frontmatter so saved answers have the same metadata as
@@ -308,6 +337,19 @@ export async function saveAnswerToWiki(
     authors: ["system"],
   };
 
+  // An HTML output is a personal artifact: mark its type (so the page renders in
+  // the sandboxed iframe and is excluded from the commons/search/query corpus)
+  // and attribute it to the asker so it lives in THEIR silo + Mine/vault lens and
+  // is reachable at /u/<handle>/<slug>. Markdown saves keep the legacy
+  // system-owned commons behavior.
+  if (isHtml) {
+    frontmatterData.type = "html";
+    if (owner) {
+      frontmatterData.owner = owner;
+      frontmatterData.authors = [owner];
+    }
+  }
+
   if (sources && sources.length > 0) {
     const sourceEntries = sources.map((slug) =>
       buildSourceEntry(slug, "wiki-ref", "system"),
@@ -320,16 +362,17 @@ export async function saveAnswerToWiki(
     pageContent,
   );
 
-  // Hand off to the unified write pipeline. We pass the original answer
-  // `content` (rather than `pageContent`) as the cross-ref source so the
-  // related-pages prompt sees the same text the user actually saw.
+  // Hand off to the unified write pipeline. For markdown we pass the original
+  // answer `content` as the cross-ref source so the related-pages prompt sees
+  // what the user saw. HTML artifacts are personal outputs — skip cross-ref
+  // (no `null` source) so commons pages don't backlink to them.
   const { slug: writtenSlug } = await writeWikiPageWithSideEffects({
     slug,
     title,
     content: contentWithFm,
     summary,
     logOp: "save",
-    crossRefSource: content,
+    crossRefSource: isHtml ? null : content,
     author: "system",
     logDetails: ({ updatedSlugs }) =>
       `query answer saved as ${slug} · linked ${updatedSlugs.length} related page(s)`,

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -13,6 +13,7 @@ import {
   withPageCache,
   wikiRelPath,
   isAgentScopedType,
+  isArtifactType,
   tenantForOwner,
 } from "./wiki";
 import { canReadFrontmatter } from "./authz";
@@ -442,13 +443,16 @@ export function fuzzyMatch(
  * are searched.
  */
 /**
- * Slugs whose page is agent-scoped (`agent-*` type) — excluded from general
- * (unscoped) search so agent knowledge surfaces only via an `agent:` scope.
+ * Slugs excluded from general (unscoped) search: agent-scoped pages (`agent-*`,
+ * surface only via an `agent:` scope) and saved artifacts (e.g. `html` query
+ * outputs — personal rendered outputs whose markup shouldn't surface as hits).
  */
-async function agentScopedSlugSet(): Promise<Set<string>> {
+async function searchExcludedSlugSet(): Promise<Set<string>> {
   const pages = await listWikiPages();
   return new Set(
-    pages.filter((p) => isAgentScopedType(p.type)).map((p) => p.slug),
+    pages
+      .filter((p) => isAgentScopedType(p.type) || isArtifactType(p.type))
+      .map((p) => p.slug),
   );
 }
 
@@ -478,7 +482,7 @@ export async function searchWikiContent(
   const scopeSlugs = scope ? new Set(scope.slugs) : null;
   // Without a scope, exclude agent-scoped pages from general search — they
   // surface only via an `agent:` scope.
-  const excludedSlugs = scope ? null : await agentScopedSlugSet();
+  const excludedSlugs = scope ? null : await searchExcludedSlugSet();
 
   const scored: Array<{
     slug: string;
@@ -612,7 +616,7 @@ export async function fuzzySearchWikiContent(
   const SKIP = new Set(["index.md", "log.md"]);
   const exactSlugs = new Set(exactResults.map((r) => r.slug));
   const scopeSlugs = scope ? new Set(scope.slugs) : null;
-  const excludedSlugs = scope ? null : await agentScopedSlugSet();
+  const excludedSlugs = scope ? null : await searchExcludedSlugSet();
 
   const fuzzyResults: ContentSearchResult[] = [];
 

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -52,6 +52,16 @@ export function isAgentScopedType(type: string | undefined): boolean {
 }
 
 /**
+ * True when a page `type` marks it as a saved RENDERED ARTIFACT (e.g. an `html`
+ * query output), not synthesized knowledge. Artifacts are reachable by URL and
+ * the owner's lens, but excluded from the commons, general search, and the query
+ * corpus — their raw markup isn't canonical content and would pollute ranking.
+ */
+export function isArtifactType(type: string | undefined): boolean {
+  return type === "html";
+}
+
+/**
  * Compute a storage-relative path for a raw source file.
  *
  * Same logic as {@link wikiRelPath} but for the `raw/` directory. Used by


### PR DESCRIPTION
Inspired by Anthropic's "unreasonable effectiveness of HTML" — a 4th `/query` answer format, **HTML**: a single self-contained document (rich layout, inline-SVG charts, light interactivity), rendered safely and **saveable verbatim** as a reusable, shareable wiki page.

## Security — isolation, not sanitization
Today raw HTML in a page is *escaped* (react-markdown `skipHtml`; no sanitizer/CSP). Rendering model HTML naively = stored XSS. Instead we **isolate**:
- `<iframe srcDoc>` with `sandbox="allow-scripts"` and **NO `allow-same-origin`** → the frame gets a unique opaque origin: scripts run but **cannot** read the app's cookies/DOM/storage/session or make credentialed/same-origin requests. (The escape footgun — `allow-scripts` + `allow-same-origin` — is explicitly avoided; a test asserts its absence.)
- Injected **CSP** (`default-src 'none'`, no `connect-src`, `img/font-src data:`) blocks all network egress + external resources, even if the model emits a CDN URL.
- Height via `postMessage` (clamped). Rendered via `srcDoc` — never `dangerouslySetInnerHTML`. New `src/lib/html.ts` + `HtmlPreview.tsx`.

## Format + save
- Threading mirrors `slides`: `QueryFormat` + `HTML_FORMAT_INSTRUCTION` + `buildQuerySystemPrompt`; UI toggle; hook union; both route validators. `QueryResultPanel` → `HtmlPreview` (streaming gated to completion; "Copy HTML").
- **Save verbatim** (no LLM re-process): the save route threads `format`; `saveAnswerToWiki` stores HTML with no markdown H1, `type: "html"`, a tag-stripped summary, and **owned by the asker** → lives in their silo + Mine/vault lens, reachable/shareable at `/u/<handle>/<slug>`. `ArticleView` renders `type:"html"` via the sandbox.

## Personal artifact (your choice)
New `isArtifactType("html")` excludes saved HTML from the commons (`belongsInCommons`), unscoped query (both paths), general search, and embeddings (skip in `lifecycle`) — so its markup never pollutes the knowledge graph. Reachable by URL + your lens.

## Tests
New `html.test.ts` (composeSrcDoc CSP/base/resize + the no-same-origin invariant; `htmlToPlainText`) + extended query/commons/search/save-route/stream-route: format-instruction threading, verbatim+typed+owned save with tag-stripped summary, commons/artifact exclusion.

`pnpm build` clean · **2830 tests pass**.

Deferred (future): interactive "HTML video", a global app-level CSP as defense-in-depth backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)