### PR TITLE
Fix HTML /query output: strip stray code fence + persist/restore format

### DIFF
--- a/src/app/api/query/history/route.ts
+++ b/src/app/api/query/history/route.ts
@@ -3,6 +3,7 @@ import { appendQuery, listQueries, markSaved } from "@/lib/query-history";
 import { getPrincipal } from "@/lib/auth";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
+import { isQueryFormat } from "@/lib/query-format";
 
 /**
  * GET /api/query/history?limit=20
@@ -70,12 +71,11 @@ export async function POST(request: NextRequest) {
 
     // Default: append a new query entry
     const { question, answer, sources, format } = body;
-    // Only persist a recognized format; anything else falls back to "prose" on
-    // restore via the optional field being absent.
+    // Persist only a format that changes how a restored answer renders. "prose"
+    // is the default, so it (and anything unrecognized) is stored as absent and
+    // defaults back to "prose" on restore.
     const validFormat =
-      format === "table" || format === "slides" || format === "html"
-        ? format
-        : undefined;
+      isQueryFormat(format) && format !== "prose" ? format : undefined;
 
     if (!question || typeof question !== "string" || !question.trim()) {
       return NextResponse.json(

--- a/src/app/api/query/history/route.ts
+++ b/src/app/api/query/history/route.ts
@@ -40,7 +40,7 @@ export async function GET(request: NextRequest) {
  * Append a new query to history, or mark an existing entry as saved.
  *
  * Body for appending:
- *   { question: string, answer: string, sources: string[] }
+ *   { question: string, answer: string, sources: string[], format?: "prose" | "table" | "slides" | "html" }
  *
  * Body for marking saved:
  *   { action: "markSaved", id: string, slug: string }
@@ -69,7 +69,13 @@ export async function POST(request: NextRequest) {
     }
 
     // Default: append a new query entry
-    const { question, answer, sources } = body;
+    const { question, answer, sources, format } = body;
+    // Only persist a recognized format; anything else falls back to "prose" on
+    // restore via the optional field being absent.
+    const validFormat =
+      format === "table" || format === "slides" || format === "html"
+        ? format
+        : undefined;
 
     if (!question || typeof question !== "string" || !question.trim()) {
       return NextResponse.json(
@@ -90,6 +96,7 @@ export async function POST(request: NextRequest) {
       sources: Array.isArray(sources) ? sources : [],
       timestamp: new Date().toISOString(),
       owner: (await getPrincipal())?.handle,
+      format: validFormat,
     });
 
     return NextResponse.json({ entry, success: true });

--- a/src/app/query/page.tsx
+++ b/src/app/query/page.tsx
@@ -27,12 +27,17 @@ export default function QueryPage() {
 
   /** Save a completed query to history and refresh the list. */
   const saveToHistory = useCallback(
-    async (q: string, answer: string, sources: string[]) => {
+    async (
+      q: string,
+      answer: string,
+      sources: string[],
+      fmt: "prose" | "table" | "slides" | "html",
+    ) => {
       try {
         const res = await fetch("/api/query/history", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ question: q, answer, sources }),
+          body: JSON.stringify({ question: q, answer, sources, format: fmt }),
         });
         if (res.ok) {
           const data = await res.json();
@@ -186,6 +191,10 @@ export default function QueryPage() {
   function loadHistoryEntry(entry: HistoryEntry) {
     setQuestion(entry.question);
     setResult({ answer: entry.answer, sources: entry.sources });
+    // Restore the answer's format so an HTML answer re-renders in the sandboxed
+    // iframe (not as escaped markdown). Legacy entries lack it → default "prose";
+    // QueryResultPanel's content sniff still catches recognizable raw HTML.
+    setFormat(entry.format ?? "prose");
     setError(null);
     setLoading(false);
     setStreaming(false);

--- a/src/app/query/page.tsx
+++ b/src/app/query/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/QueryHistorySidebar";
 import { QueryResultPanel } from "@/components/QueryResultPanel";
 import { useStreamingQuery } from "@/hooks/useStreamingQuery";
+import type { QueryFormat } from "@/lib/query-format";
 import { Icon } from "@/components/folio/icons";
 import { logger } from "@/lib/logger";
 
@@ -31,7 +32,7 @@ export default function QueryPage() {
       q: string,
       answer: string,
       sources: string[],
-      fmt: "prose" | "table" | "slides" | "html",
+      fmt: QueryFormat,
     ) => {
       try {
         const res = await fetch("/api/query/history", {

--- a/src/components/QueryHistorySidebar.tsx
+++ b/src/components/QueryHistorySidebar.tsx
@@ -9,6 +9,8 @@ export interface HistoryEntry {
   sources: string[];
   timestamp: string;
   savedAs?: string;
+  /** Format the answer was generated in — drives HTML re-render on restore. */
+  format?: "prose" | "table" | "slides" | "html";
 }
 
 interface Props {

--- a/src/components/QueryHistorySidebar.tsx
+++ b/src/components/QueryHistorySidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { formatRelativeTime } from "@/lib/format";
+import type { QueryFormat } from "@/lib/query-format";
 
 export interface HistoryEntry {
   id: string;
@@ -10,7 +11,7 @@ export interface HistoryEntry {
   timestamp: string;
   savedAs?: string;
   /** Format the answer was generated in — drives HTML re-render on restore. */
-  format?: "prose" | "table" | "slides" | "html";
+  format?: QueryFormat;
 }
 
 interface Props {

--- a/src/components/QueryResultPanel.tsx
+++ b/src/components/QueryResultPanel.tsx
@@ -144,10 +144,12 @@ export function QueryResultPanel({
   // This is handled via the useEffect reset above + parent re-rendering with new props.
 
   // HTML answers render in a sandboxed iframe (HtmlPreview). Drive off the chosen
-  // format, with a content sniff as a fallback for answers reloaded without it.
+  // format, with a content sniff as a fallback for legacy history entries reloaded
+  // without one. Strip a wrapping ```html fence before sniffing so a fenced answer
+  // is still recognized as HTML.
   const isHtmlAnswer =
     format === "html" ||
-    /^\s*(<!doctype html|<html)/i.test(result.answer);
+    /^\s*(<!doctype html|<html)/i.test(stripHtmlFence(result.answer));
   const isMarp = result.answer.trimStart().startsWith("---\nmarp: true");
 
   return (

--- a/src/components/QueryResultPanel.tsx
+++ b/src/components/QueryResultPanel.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { SlidePreview } from "@/components/SlidePreview";
 import { HtmlPreview } from "@/components/HtmlPreview";
+import { stripHtmlFence } from "@/lib/html";
 import { Alert } from "@/components/Alert";
 import { useSlugTenants } from "@/hooks/useSlugTenants";
 import { logger } from "@/lib/logger";
@@ -64,7 +65,7 @@ export function QueryResultPanel({
     // formats copy a markdown wrapper with a heading + sources.
     let text: string;
     if (isHtml) {
-      text = result.answer;
+      text = stripHtmlFence(result.answer);
     } else {
       const lines = [`# ${question.trim()}`, "", result.answer];
       if (result.sources.length > 0) {
@@ -257,12 +258,12 @@ export function QueryResultPanel({
 
           {saveState.status === "saved" && saveState.slug && (
             <Alert variant="success">
-              Saved to the wiki and your vault.{" "}
+              {isHtml ? "Saved to your pages." : "Saved to the wiki."}{" "}
               <Link
                 href={hrefForSlug(saveState.slug)}
                 className="underline font-medium hover:opacity-80"
               >
-                View wiki page →
+                View →
               </Link>
             </Alert>
           )}

--- a/src/components/QueryResultPanel.tsx
+++ b/src/components/QueryResultPanel.tsx
@@ -9,9 +9,7 @@ import { stripHtmlFence } from "@/lib/html";
 import { Alert } from "@/components/Alert";
 import { useSlugTenants } from "@/hooks/useSlugTenants";
 import { logger } from "@/lib/logger";
-
-/** Answer format hint (mirrors QueryFormat in lib/query) — the panel renders accordingly. */
-type AnswerFormat = "prose" | "table" | "slides" | "html";
+import type { QueryFormat } from "@/lib/query-format";
 
 interface SaveState {
   status: "idle" | "editing" | "saving" | "saved" | "error";
@@ -28,7 +26,7 @@ export interface QueryResultPanelProps {
   /** Hide the "Save to Wiki" action (e.g. the signed-out homepage demo). */
   readOnly?: boolean;
   /** The format the answer was generated in — drives rendering + save. */
-  format?: AnswerFormat;
+  format?: QueryFormat;
 }
 
 export function QueryResultPanel({

--- a/src/hooks/useStreamingQuery.ts
+++ b/src/hooks/useStreamingQuery.ts
@@ -36,7 +36,12 @@ export interface UseStreamingQueryReturn {
 }
 
 interface UseStreamingQueryOptions {
-  onComplete?: (question: string, answer: string, sources: string[]) => void;
+  onComplete?: (
+    question: string,
+    answer: string,
+    sources: string[],
+    format: "prose" | "table" | "slides" | "html",
+  ) => void;
   onSubmitStart?: () => void;
   /** Initial query scope (e.g. "mine" when signed in, or a deep-linked owner:<h>). */
   initialScope?: string;
@@ -122,6 +127,7 @@ export function useStreamingQuery(
             trimmed,
             fallbackData.answer,
             fallbackData.sources,
+            format,
           );
           return;
         }
@@ -171,7 +177,7 @@ export function useStreamingQuery(
         setStreaming(false);
 
         // Notify caller that query completed
-        onCompleteRef.current?.(trimmed, answer, finalSources);
+        onCompleteRef.current?.(trimmed, answer, finalSources, format);
       } catch (err) {
         // Don't report abort errors as failures
         if (err instanceof DOMException && err.name === "AbortError") {

--- a/src/hooks/useStreamingQuery.ts
+++ b/src/hooks/useStreamingQuery.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect } from "react";
 import { extractCitedSlugs } from "@/lib/citations";
+import type { QueryFormat } from "@/lib/query-format";
 
 export interface QueryResponse {
   answer: string;
@@ -12,8 +13,8 @@ export interface QueryResponse {
 export interface UseStreamingQueryReturn {
   question: string;
   setQuestion: (q: string) => void;
-  format: "prose" | "table" | "slides" | "html";
-  setFormat: (f: "prose" | "table" | "slides" | "html") => void;
+  format: QueryFormat;
+  setFormat: (f: QueryFormat) => void;
   /** Active scope sent with each query ("mine", "owner:<h>", or undefined=All). */
   scope: string | undefined;
   setScope: (s: string | undefined) => void;
@@ -40,7 +41,7 @@ interface UseStreamingQueryOptions {
     question: string,
     answer: string,
     sources: string[],
-    format: "prose" | "table" | "slides" | "html",
+    format: QueryFormat,
   ) => void;
   onSubmitStart?: () => void;
   /** Initial query scope (e.g. "mine" when signed in, or a deep-linked owner:<h>). */
@@ -51,7 +52,7 @@ export function useStreamingQuery(
   options: UseStreamingQueryOptions = {},
 ): UseStreamingQueryReturn {
   const [question, setQuestion] = useState("");
-  const [format, setFormat] = useState<"prose" | "table" | "slides" | "html">("prose");
+  const [format, setFormat] = useState<QueryFormat>("prose");
   const [scope, setScope] = useState<string | undefined>(options.initialScope);
   const [result, setResult] = useState<QueryResponse | null>(null);
   const [loading, setLoading] = useState(false);

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -30,6 +30,21 @@ describe("stripHtmlFence", () => {
     );
   });
 
+  it("does NOT strip a trailing ``` when there is no leading fence", () => {
+    // Real HTML that happens to end in a fence-like line must survive intact —
+    // the trailing strip only fires when the answer is actually fence-wrapped.
+    expect(stripHtmlFence("<p>x</p>\n```")).toBe("<p>x</p>\n```");
+  });
+
+  it("strips a CRLF-delimited wrapping fence", () => {
+    expect(stripHtmlFence("```html\r\n<p>x</p>\r\n```")).toBe("<p>x</p>");
+  });
+
+  it("returns empty string for null/empty input", () => {
+    expect(stripHtmlFence("")).toBe("");
+    expect(stripHtmlFence(null as unknown as string)).toBe("");
+  });
+
   it("composeSrcDoc renders fenced HTML without the fence markers", () => {
     const out = composeSrcDoc("```html\n<html><head></head><body>hi</body></html>\n```");
     expect(out).not.toContain("```");

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -2,9 +2,41 @@ import { describe, it, expect } from "vitest";
 import {
   composeSrcDoc,
   htmlToPlainText,
+  stripHtmlFence,
   HTML_SANDBOX,
   HTML_MAX_HEIGHT,
 } from "../html";
+
+describe("stripHtmlFence", () => {
+  it("strips a wrapping ```html fence", () => {
+    expect(stripHtmlFence("```html\n<!doctype html><body>x</body>\n```")).toBe(
+      "<!doctype html><body>x</body>",
+    );
+  });
+
+  it("strips a bare ``` fence", () => {
+    expect(stripHtmlFence("```\n<p>x</p>\n```")).toBe("<p>x</p>");
+  });
+
+  it("strips an unterminated leading fence (mid-stream)", () => {
+    expect(stripHtmlFence("```html\n<!doctype html><body>partial")).toBe(
+      "<!doctype html><body>partial",
+    );
+  });
+
+  it("leaves un-fenced HTML untouched", () => {
+    expect(stripHtmlFence("<!doctype html><body>x</body>")).toBe(
+      "<!doctype html><body>x</body>",
+    );
+  });
+
+  it("composeSrcDoc renders fenced HTML without the fence markers", () => {
+    const out = composeSrcDoc("```html\n<html><head></head><body>hi</body></html>\n```");
+    expect(out).not.toContain("```");
+    expect(out).toContain("hi");
+    expect(out).toContain("default-src 'none'");
+  });
+});
 
 describe("composeSrcDoc", () => {
   it("injects a locked-down CSP (default-src 'none', no connect-src)", () => {

--- a/src/lib/__tests__/query-history-route.test.ts
+++ b/src/lib/__tests__/query-history-route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mock the query-history lib — we test the route's validation/wiring, not the
+// storage layer (covered by query-history.test.ts).
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/query-history", () => ({
+  appendQuery: vi.fn(async (entry) => ({ ...entry, id: "generated-id" })),
+  listQueries: vi.fn(async () => []),
+  markSaved: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getPrincipal: vi.fn(async () => ({ id: "asker", handle: "asker" })),
+}));
+
+import { appendQuery } from "@/lib/query-history";
+import { POST } from "@/app/api/query/history/route";
+
+const mockedAppend = vi.mocked(appendQuery);
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/query/history", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  mockedAppend.mockClear();
+});
+
+describe("POST /api/query/history — format validation", () => {
+  const base = { question: "q", answer: "a", sources: [] };
+
+  it("persists a render-changing format (html)", async () => {
+    const res = await POST(makeRequest({ ...base, format: "html" }));
+    expect(res.status).toBe(200);
+    expect(mockedAppend.mock.calls[0][0].format).toBe("html");
+  });
+
+  it("persists table and slides", async () => {
+    await POST(makeRequest({ ...base, format: "table" }));
+    expect(mockedAppend.mock.calls[0][0].format).toBe("table");
+    mockedAppend.mockClear();
+    await POST(makeRequest({ ...base, format: "slides" }));
+    expect(mockedAppend.mock.calls[0][0].format).toBe("slides");
+  });
+
+  it("stores 'prose' as absent (it's the restore default)", async () => {
+    const res = await POST(makeRequest({ ...base, format: "prose" }));
+    expect(res.status).toBe(200);
+    expect(mockedAppend.mock.calls[0][0].format).toBeUndefined();
+  });
+
+  it("drops an unrecognized/garbage format to absent", async () => {
+    await POST(makeRequest({ ...base, format: "evil" }));
+    expect(mockedAppend.mock.calls[0][0].format).toBeUndefined();
+    mockedAppend.mockClear();
+    await POST(makeRequest({ ...base, format: 42 }));
+    expect(mockedAppend.mock.calls[0][0].format).toBeUndefined();
+  });
+
+  it("omitting format leaves it absent", async () => {
+    await POST(makeRequest(base));
+    expect(mockedAppend.mock.calls[0][0].format).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/query-history.test.ts
+++ b/src/lib/__tests__/query-history.test.ts
@@ -71,6 +71,12 @@ describe("appendQuery", () => {
     expect(e.id).toBeTruthy();
     expect(await listQueries(undefined, null)).toEqual([]);
   });
+
+  it("round-trips the answer format so a restored HTML entry re-renders sandboxed", async () => {
+    await appendQuery(entry(OWNER, { question: "chart it", answer: "<!doctype html>…", format: "html" }));
+    const [restored] = await listQueries(undefined, OWNER);
+    expect(restored.format).toBe("html");
+  });
 });
 
 describe("listQueries", () => {

--- a/src/lib/__tests__/query.test.ts
+++ b/src/lib/__tests__/query.test.ts
@@ -855,6 +855,32 @@ describe("saveAnswerToWiki", () => {
     expect(entry!.type).toBe("html");
   });
 
+  it("strips a wrapping markdown fence from a saved HTML answer", async () => {
+    await ensureDirectories();
+    // The model sometimes wraps its HTML in a ```html fence despite the prompt;
+    // the save path must strip it so the page (and its summary) are clean.
+    const fenced =
+      "```html\n<!doctype html><html><body><p>Fenced body text</p></body></html>\n```";
+
+    const { slug } = await saveAnswerToWiki(
+      "Fenced Chart",
+      fenced,
+      undefined,
+      undefined,
+      "html",
+      "alice",
+    );
+
+    const page = await readWikiPageWithFrontmatter(slug);
+    expect(page).not.toBeNull();
+    // No fence markers leak into the stored document or its derived summary.
+    expect(page!.body).not.toContain("```");
+    expect(page!.body).toContain("<p>Fenced body text</p>");
+    const entry = (await listWikiPages()).find((e) => e.slug === slug);
+    expect(entry!.summary).not.toContain("`");
+    expect(entry!.summary).toContain("Fenced body text");
+  });
+
   it("wraps saved answer in YAML frontmatter with source and tags", async () => {
     await ensureDirectories();
 

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -53,11 +53,26 @@ const SANDBOX_HEAD =
   `window.addEventListener('load',r);setTimeout(r,60);})();</script>`;
 
 /**
+ * Strip a wrapping markdown code fence (```` ```html ... ``` ````) that the model
+ * sometimes adds despite being told to emit raw HTML — otherwise the fence
+ * markers leak into the rendered document as literal text. Handles a complete
+ * fence and an unterminated leading fence (mid-stream).
+ */
+export function stripHtmlFence(html: string): string {
+  let out = (html ?? "").trim();
+  const fenced = out.match(/^```[a-z0-9]*\s*\n([\s\S]*?)\n?```$/i);
+  if (fenced) return fenced[1].trim();
+  // Leading/trailing fence without a clean pair (e.g. still streaming).
+  out = out.replace(/^```[a-z0-9]*[ \t]*\n/i, "").replace(/\n```[ \t]*$/i, "");
+  return out.trim();
+}
+
+/**
  * Compose a srcdoc string from model HTML, injecting the sandbox `<head>` bits.
  * Robust to a full document, an `<html>` without a `<head>`, or a bare fragment.
  */
 export function composeSrcDoc(html: string): string {
-  const src = (html ?? "").trim();
+  const src = stripHtmlFence(html);
 
   const headOpen = src.match(/<head[^>]*>/i);
   if (headOpen?.index !== undefined) {

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -55,16 +55,20 @@ const SANDBOX_HEAD =
 /**
  * Strip a wrapping markdown code fence (```` ```html ... ``` ````) that the model
  * sometimes adds despite being told to emit raw HTML — otherwise the fence
- * markers leak into the rendered document as literal text. Handles a complete
- * fence and an unterminated leading fence (mid-stream).
+ * markers leak into the rendered document as literal text.
+ *
+ * Only acts when the content STARTS with a fence line (the model wrapping its
+ * whole answer): we then drop the opening fence and, if present, a matching
+ * closing fence — tolerating its absence so a still-streaming answer is handled.
+ * A trailing ```` ``` ```` is NEVER stripped on its own, so real HTML that happens
+ * to end with a fence-like line is left intact.
  */
 export function stripHtmlFence(html: string): string {
-  let out = (html ?? "").trim();
-  const fenced = out.match(/^```[a-z0-9]*\s*\n([\s\S]*?)\n?```$/i);
-  if (fenced) return fenced[1].trim();
-  // Leading/trailing fence without a clean pair (e.g. still streaming).
-  out = out.replace(/^```[a-z0-9]*[ \t]*\n/i, "").replace(/\n```[ \t]*$/i, "");
-  return out.trim();
+  const out = (html ?? "").trim();
+  const lead = out.match(/^```[a-z0-9]*[ \t]*\r?\n/i);
+  if (!lead) return out;
+  const body = out.slice(lead[0].length).replace(/\r?\n```[ \t]*$/i, "");
+  return body.trim();
 }
 
 /**

--- a/src/lib/query-format.ts
+++ b/src/lib/query-format.ts
@@ -1,0 +1,20 @@
+/**
+ * The canonical set of `/query` answer formats, in one dependency-free module so
+ * the type can be shared by both server code (`query.ts`, the history route) and
+ * client code (the query page, its hook, and result/history components) without
+ * dragging the Node storage layer into the client bundle.
+ *
+ * `QUERY_FORMATS` is the single runtime source of truth; derive validators from
+ * it so the type and the runtime check can't drift when a format is added.
+ */
+export const QUERY_FORMATS = ["prose", "table", "slides", "html"] as const;
+
+export type QueryFormat = (typeof QUERY_FORMATS)[number];
+
+/** Type guard: is `value` one of the known answer formats? */
+export function isQueryFormat(value: unknown): value is QueryFormat {
+  return (
+    typeof value === "string" &&
+    (QUERY_FORMATS as readonly string[]).includes(value)
+  );
+}

--- a/src/lib/query-history.ts
+++ b/src/lib/query-history.ts
@@ -54,6 +54,12 @@ export interface QueryHistoryEntry {
   savedAs?: string;
   /** Owner handle — the asker. Resolved to a tenant for storage placement. */
   owner?: string;
+  /**
+   * Answer format the entry was generated in. Persisted so a restored "html"
+   * answer re-renders in the sandboxed iframe rather than as escaped markdown.
+   * Absent on legacy entries — treat as "prose".
+   */
+  format?: "prose" | "table" | "slides" | "html";
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/query-history.ts
+++ b/src/lib/query-history.ts
@@ -8,6 +8,7 @@ import { getStorage } from "./storage";
 import { withFileLock } from "./lock";
 import { isEnoent } from "./errors";
 import { logger } from "./logger";
+import type { QueryFormat } from "./query-format";
 
 // ---------------------------------------------------------------------------
 // Query history — per-asker, persisted INSIDE the asker's tenant silo.
@@ -59,7 +60,7 @@ export interface QueryHistoryEntry {
    * answer re-renders in the sandboxed iframe rather than as escaped markdown.
    * Absent on legacy entries — treat as "prose".
    */
-  format?: "prose" | "table" | "slides" | "html";
+  format?: QueryFormat;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -20,6 +20,7 @@ import {
 } from "./bm25";
 import { extractCitedSlugs } from "./citations";
 import type { QueryResult } from "./types";
+import type { QueryFormat } from "./query-format";
 
 import {
   selectPagesForQuery,
@@ -96,7 +97,7 @@ export const HTML_FORMAT_INSTRUCTION = `Format your answer as a SINGLE, SELF-CON
 - Cite sources as plain links \`<a href="slug.md">Page Title</a>\` and also include them in a final "Sources" section, so citations are traceable.`;
 
 /** Answer format hint supported by `query()` / `buildQuerySystemPrompt()`. */
-export type QueryFormat = "prose" | "table" | "slides" | "html";
+export type { QueryFormat };
 
 // ---------------------------------------------------------------------------
 // BM25 sparse index search
@@ -302,8 +303,9 @@ export async function saveAnswerToWiki(
   const isHtml = contentType === "html";
 
   // Strip any markdown code fence the model wrapped the document in, so the saved
-  // page is clean HTML (it's stored verbatim, no H1 prepend — the title shows via
-  // ArticleView's <h1> outside the iframe). Markdown gets the usual H1 if missing.
+  // page is clean HTML (stored as-is apart from that, with no H1 prepend — the
+  // title shows via ArticleView's <h1> outside the iframe). Markdown gets the
+  // usual H1 if missing.
   const html = isHtml ? stripHtmlFence(content) : content;
   const pageContent = isHtml
     ? html

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -8,7 +8,7 @@ import {
   isArtifactType,
 } from "./wiki";
 import { slugify } from "./slugify";
-import { htmlToPlainText } from "./html";
+import { htmlToPlainText, stripHtmlFence } from "./html";
 import { extractSummary } from "./ingest";
 import { loadPageConventions } from "./schema";
 import { serializeFrontmatter } from "./frontmatter";
@@ -88,7 +88,7 @@ marp: true
  * answer — a single self-contained document rendered in a sandboxed iframe.
  */
 export const HTML_FORMAT_INSTRUCTION = `Format your answer as a SINGLE, SELF-CONTAINED HTML document — richer and more readable than markdown.
-- Output ONLY HTML: start with \`<!doctype html>\` and a full \`<html>\`/\`<head>\`/\`<body>\`. No markdown, no code fences around it.
+- Output ONLY HTML: start your reply with \`<!doctype html>\` and a full \`<html>\`/\`<head>\`/\`<body>\`. Do NOT wrap it in a markdown code fence (no \`\`\`html). No prose before or after.
 - Style with an inline \`<style>\` block. Use clean, readable typography and a light layout (headings, sections, callouts, tables where useful).
 - For charts/diagrams, draw them as INLINE \`<svg>\` (bar/line/pie/flow). Do NOT use any charting library.
 - It MUST be fully self-contained: NO external resources — no \`<link>\`, no \`<script src>\`, no CDN URLs, no web fonts, no network requests. Images only as inline \`data:\` URIs or inline SVG.
@@ -301,18 +301,19 @@ export async function saveAnswerToWiki(
 
   const isHtml = contentType === "html";
 
-  // HTML is stored VERBATIM — prepending a markdown `# title` would corrupt the
-  // document (the title still shows via ArticleView's <h1>, outside the iframe).
-  // Markdown gets the usual H1 if it lacks one.
+  // Strip any markdown code fence the model wrapped the document in, so the saved
+  // page is clean HTML (it's stored verbatim, no H1 prepend — the title shows via
+  // ArticleView's <h1> outside the iframe). Markdown gets the usual H1 if missing.
+  const html = isHtml ? stripHtmlFence(content) : content;
   const pageContent = isHtml
-    ? content
+    ? html
     : content.trimStart().startsWith("# ")
       ? content
       : `# ${title}\n\n${content}`;
 
   // Summary comes from plain text: tag-stripped for HTML, heading-stripped for md.
   const plainContent = isHtml
-    ? htmlToPlainText(content)
+    ? htmlToPlainText(html)
     : content.replace(/^#.*$/gm, "").trim();
   const summary = extractSummary(plainContent) || title;
 


### PR DESCRIPTION
Two related correctness fixes for the `html` answer format in `/query`.

## 1. Strip a stray markdown code fence
The model sometimes wraps its HTML output in a ` ```html ` fence despite being told not to. We render the answer verbatim in the sandbox, so the fence markers leaked into the page as literal text. `stripHtmlFence` now runs at render, save, and copy; the prompt is strengthened; and the post-save "your vault" copy was corrected (saved HTML is a personal artifact, not a vault page).

## 2. Persist + restore the answer format (cached HTML re-render)
A restored **recent-query** entry lost its `format`, so a saved **HTML** answer re-rendered as escaped markdown instead of the sandboxed `HtmlPreview` iframe when clicked again. Fix:

- `QueryHistoryEntry` gains an optional `format` (`prose|table|slides|html`); only non-prose formats are persisted (prose ≡ absent ≡ default).
- The history `POST` route validates `format` and threads it to `appendQuery`.
- `useStreamingQuery`'s `onComplete` carries the format (both streaming + non-streaming completion sites) → `saveToHistory` sends it.
- `loadHistoryEntry` restores it via `setFormat(entry.format ?? "prose")`.
- `QueryResultPanel`'s content-sniff strips the ` ```html ` fence before sniffing, so **legacy** entries (saved before `format` was persisted) are still recognized as HTML.

## Verification
- `pnpm build` clean; `pnpm test` green (2846 tests). Added a round-trip test asserting a restored `html` entry keeps its format.
- Reviewed by pr-review-toolkit/code-reviewer — no issues at threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)