### PR TITLE
Tagline: a shared second brain for humans and agents

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,24 +26,24 @@ const fontMono = JetBrains_Mono({
 });
 
 const SITE_DESCRIPTION =
-  "A second brain for humans and agents. Not RAG — it accumulates: sources become cited pages, contradictions reconcile, and lineage stays visible.";
+  "A shared second brain for humans and agents. Not RAG — it accumulates: sources become cited pages, contradictions reconcile, and lineage stays visible.";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://yopedia.yuanhao-li.workers.dev"),
   title: {
-    default: "yopedia — a second brain for humans and agents",
+    default: "yopedia — a shared second brain for humans and agents",
     template: "%s · yopedia",
   },
   description: SITE_DESCRIPTION,
   openGraph: {
-    title: "yopedia — a second brain for humans and agents",
+    title: "yopedia — a shared second brain for humans and agents",
     description: SITE_DESCRIPTION,
     siteName: "yopedia",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "yopedia — a second brain for humans and agents",
+    title: "yopedia — a shared second brain for humans and agents",
     description: SITE_DESCRIPTION,
   },
 };

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -5,7 +5,7 @@ import { ImageResponse } from "next/og";
 export const dynamic = "force-static";
 
 export const alt =
-  "yopedia — a second brain for humans and agents. Not RAG — it accumulates.";
+  "yopedia — a shared second brain for humans and agents. Not RAG — it accumulates.";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -54,8 +54,8 @@ export default function OpengraphImage() {
               lineHeight: 1.1,
             }}
           >
-            <span>A second brain for</span>
-            <span>humans and agents.</span>
+            <span>A shared second brain</span>
+            <span>for humans and agents.</span>
           </div>
           <div style={{ fontSize: 30, color: "#a1a1aa", lineHeight: 1.3, maxWidth: 900 }}>
             Not RAG — it accumulates. Sources become cited pages; provenance and

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,7 +73,7 @@ export default async function Home() {
             animationDelay: ".05s",
           }}
         >
-          A second brain for humans{" "}
+          A shared second brain for humans{" "}
           <span style={{ fontStyle: "italic", color: "var(--accent)" }}>and</span>{" "}
           agents.
         </h1>

--- a/src/components/HomeGraph.tsx
+++ b/src/components/HomeGraph.tsx
@@ -6,8 +6,8 @@ import { useRouter } from "next/navigation";
 import { useGraphSimulation } from "@/hooks/useGraphSimulation";
 
 /**
- * Ambient knowledge-graph visual for the homepage — "a second brain you can
- * see." Reuses the full graph simulation (the content is small enough that the
+ * Ambient knowledge-graph visual for the homepage — "a shared second brain you
+ * can see." Reuses the full graph simulation (the content is small enough that the
  * whole graph is the preview); clicking a node opens its page. Silently absent
  * when there's nothing to show, so it never breaks the page.
  */


### PR DESCRIPTION
Swaps the homepage/metadata tagline from *"a second brain for humans and agents"* to *"a **shared** second brain for humans and agents"*.

**Why:** "second brain" is a personal-PKM term; yopedia's thesis is the **commons** — collective, owned by no one. "Shared" captures that, and aligns the app surfaces with the README / PRODUCT / concept docs, which already say "shared/collective second brain".

**Scope:** page title + OpenGraph/Twitter metadata (`layout.tsx`), the OG image (alt text + two-line headline, `opengraph-image.tsx`), and the homepage hero (`page.tsx`); plus a code-comment for consistency (`HomeGraph.tsx`). Copy-only — no logic.

`pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)