### PR TITLE
HTML artifacts: full-screen share view + no inner scrollbar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, Source_Serif_4, JetBrains_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import { NavHeader } from "@/components/NavHeader";
 import { Footer } from "@/components/Footer";
+import { SiteChrome } from "@/components/SiteChrome";
 import { ClientProviders } from "@/components/ClientProviders";
 import { EnsureYoyo } from "@/components/EnsureYoyo";
 import "./globals.css";
@@ -81,14 +82,9 @@ export default function RootLayout({
         <ClerkProvider>
           <ClientProviders>
             <EnsureYoyo />
-            <a href="#main-content" className="skip-nav">
-              Skip to main content
-            </a>
-            <NavHeader />
-            <main id="main-content" className="flex-1">
+            <SiteChrome nav={<NavHeader />} footer={<Footer />}>
               {children}
-            </main>
-            <Footer />
+            </SiteChrome>
           </ClientProviders>
         </ClerkProvider>
       </body>

--- a/src/app/share/[handle]/[slug]/page.tsx
+++ b/src/app/share/[handle]/[slug]/page.tsx
@@ -2,35 +2,16 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { decodeSlug } from "@/lib/slugify";
-import {
-  readWikiPageWithFrontmatter,
-  tenantForOwner,
-  isArtifactType,
-} from "@/lib/wiki";
-import { pagePath, commonsPath } from "@/lib/links";
+import { readWikiPageWithFrontmatter, isArtifactType } from "@/lib/wiki";
 import { getPrincipal } from "@/lib/auth";
 import { canReadFrontmatter } from "@/lib/authz";
-import { belongsInCommons } from "@/lib/commons";
+import { wikiUrlFor, str } from "@/lib/share-url";
 import { Colophon } from "@/components/folio/primitives";
 import { HtmlPreview } from "@/components/HtmlPreview";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 
 interface ShareProps {
   params: Promise<{ handle: string; slug: string }>;
-}
-
-const str = (v: unknown): string | undefined =>
-  typeof v === "string" ? v : undefined;
-
-/** The page's canonical wiki URL — public commons at /wiki/<slug>, otherwise the
- *  owner-scoped /u/<tenant>/<slug>. */
-function wikiUrlFor(
-  slug: string,
-  fm: { owner?: unknown; visibility?: unknown; type?: unknown },
-): string {
-  return belongsInCommons({ visibility: str(fm.visibility), type: str(fm.type) })
-    ? commonsPath(slug)
-    : pagePath(tenantForOwner(str(fm.owner)), slug);
 }
 
 export async function generateMetadata({

--- a/src/app/share/[handle]/[slug]/page.tsx
+++ b/src/app/share/[handle]/[slug]/page.tsx
@@ -1,0 +1,124 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { decodeSlug } from "@/lib/slugify";
+import {
+  readWikiPageWithFrontmatter,
+  tenantForOwner,
+  isArtifactType,
+} from "@/lib/wiki";
+import { pagePath, commonsPath } from "@/lib/links";
+import { getPrincipal } from "@/lib/auth";
+import { canReadFrontmatter } from "@/lib/authz";
+import { belongsInCommons } from "@/lib/commons";
+import { Colophon } from "@/components/folio/primitives";
+import { HtmlPreview } from "@/components/HtmlPreview";
+import { MarkdownRenderer } from "@/components/MarkdownRenderer";
+
+interface ShareProps {
+  params: Promise<{ handle: string; slug: string }>;
+}
+
+const str = (v: unknown): string | undefined =>
+  typeof v === "string" ? v : undefined;
+
+/** The page's canonical wiki URL — public commons at /wiki/<slug>, otherwise the
+ *  owner-scoped /u/<tenant>/<slug>. */
+function wikiUrlFor(
+  slug: string,
+  fm: { owner?: unknown; visibility?: unknown; type?: unknown },
+): string {
+  return belongsInCommons({ visibility: str(fm.visibility), type: str(fm.type) })
+    ? commonsPath(slug)
+    : pagePath(tenantForOwner(str(fm.owner)), slug);
+}
+
+export async function generateMetadata({
+  params,
+}: ShareProps): Promise<Metadata> {
+  const { slug: encodedSlug } = await params;
+  const slug = decodeSlug(encodedSlug);
+  const page = await readWikiPageWithFrontmatter(slug);
+  if (!page || !canReadFrontmatter(page.frontmatter, await getPrincipal())) {
+    return { title: "Shared page" };
+  }
+  const title = page.title || slug;
+  const description = str(page.frontmatter.summary);
+  return {
+    title,
+    description,
+    openGraph: { title, description },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+/**
+ * Full-screen, chrome-less SHARE view of a page (the global nav/footer are
+ * hidden on `/share/*` via {@link SiteChrome}). Just a minimal header (yopedia +
+ * a link back to the wiki page) and the content filling the rest — an HTML
+ * artifact renders in its sandboxed frame full-bleed; other pages render as
+ * markdown. Read-gated identically to the owner-scoped page.
+ */
+export default async function SharePage({ params }: ShareProps) {
+  const { slug: encodedSlug } = await params;
+  const slug = decodeSlug(encodedSlug);
+  const page = await readWikiPageWithFrontmatter(slug);
+  const principal = await getPrincipal();
+
+  // Unreadable/missing → 404 (never reveal a private page exists).
+  if (!page || !canReadFrontmatter(page.frontmatter, principal)) notFound();
+
+  const isHtml = isArtifactType(str(page.frontmatter.type));
+  const wikiUrl = wikiUrlFor(slug, page.frontmatter);
+
+  return (
+    <div className="stack" style={{ minHeight: "100dvh" }}>
+      <header
+        className="spread"
+        style={{
+          alignItems: "center",
+          height: 56,
+          padding: "0 18px",
+          borderBottom: "1px solid var(--rule)",
+          background: "var(--paper)",
+          position: "sticky",
+          top: 0,
+          zIndex: 10,
+        }}
+      >
+        <Link
+          href="/"
+          className="row"
+          style={{ gap: 9, textDecoration: "none", color: "var(--ink)" }}
+        >
+          <Colophon size={18} />
+          <span style={{ fontWeight: 600, fontSize: 16 }}>yopedia</span>
+        </Link>
+        <Link
+          href={wikiUrl}
+          className="receipt"
+          style={{
+            fontSize: 12.5,
+            color: "var(--muted)",
+            textDecoration: "none",
+          }}
+        >
+          Open in wiki →
+        </Link>
+      </header>
+
+      {isHtml ? (
+        <HtmlPreview html={page.body} bare />
+      ) : (
+        <main
+          style={{ maxWidth: 760, margin: "0 auto", padding: "40px 24px 80px" }}
+        >
+          <h1 style={{ fontSize: 32, fontWeight: 700, marginBottom: 18 }}>
+            {page.title || slug}
+          </h1>
+          <MarkdownRenderer content={page.body} />
+        </main>
+      )}
+    </div>
+  );
+}

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -400,7 +400,25 @@ export async function ArticleView({
             {isArtifactType(typeof fm.type === "string" ? fm.type : undefined) ? (
               // A saved HTML output is rendered verbatim in a sandboxed iframe
               // (isolated; no app cookie/DOM/network access) — never markdown.
-              <HtmlPreview html={page.body} />
+              <>
+                <div
+                  className="row"
+                  style={{ justifyContent: "flex-end", marginBottom: 10 }}
+                >
+                  <Link
+                    href={`/share/${pageTenant}/${slug}`}
+                    className="receipt"
+                    style={{
+                      fontSize: 12,
+                      color: "var(--muted)",
+                      textDecoration: "none",
+                    }}
+                  >
+                    Open full screen ↗
+                  </Link>
+                </div>
+                <HtmlPreview html={page.body} />
+              </>
             ) : (
               <MarkdownRenderer
                 content={articleBody}

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -32,6 +32,11 @@ export function HtmlPreview({
 }) {
   const ref = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState(360);
+  // True once content exceeds the height cap: we then re-enable the iframe's own
+  // scrollbar as a fallback so the tail isn't silently clipped (normal-height
+  // content keeps `scrolling="no"` → no scrollbar).
+  const [overCap, setOverCap] = useState(false);
+  const warnedOverCap = useRef(false);
 
   // Lazy-load the (~200KB) Chart.js source ONLY for documents that actually use
   // it, so prose/table answers don't pay for it. The chartless render happens
@@ -72,7 +77,18 @@ export function HtmlPreview({
       if (typeof reported === "number" && reported > 0) {
         // Clamp: cap a runaway/hostile grow, and floor a degenerate (e.g. 1px)
         // report so the artifact can't collapse to an invisible sliver.
-        setHeight(Math.max(140, Math.min(Math.ceil(reported), HTML_MAX_HEIGHT)));
+        const ceil = Math.ceil(reported);
+        if (ceil > HTML_MAX_HEIGHT) {
+          setOverCap(true);
+          if (!warnedOverCap.current) {
+            warnedOverCap.current = true;
+            logger.warn(
+              "html",
+              `artifact height ${ceil}px exceeds cap ${HTML_MAX_HEIGHT}px — capping and re-enabling inner scroll so content isn't clipped`,
+            );
+          }
+        }
+        setHeight(Math.max(140, Math.min(ceil, HTML_MAX_HEIGHT)));
       }
     }
     window.addEventListener("message", onMessage);
@@ -87,8 +103,10 @@ export function HtmlPreview({
       title="HTML output"
       // The frame auto-sizes to its content, so it never needs its own
       // scrollbar — the page scrolls. `scrolling="no"` guarantees the inner
-      // scrollbar never appears (e.g. during a brief pre-resize layout).
-      scrolling="no"
+      // scrollbar never appears (e.g. during a brief pre-resize layout), EXCEPT
+      // for a rare artifact taller than the cap, where we re-enable it so the
+      // clipped tail stays reachable rather than silently lost.
+      scrolling={overCap ? "auto" : "no"}
       style={{
         width: "100%",
         height,

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -21,7 +21,15 @@ import { logger } from "@/lib/logger";
  * `dangerouslySetInnerHTML`. Frame height is reported by the document via
  * postMessage (clamped to a max to bound a runaway/hostile grow).
  */
-export function HtmlPreview({ html }: { html: string }) {
+export function HtmlPreview({
+  html,
+  bare = false,
+}: {
+  html: string;
+  /** Full-bleed share view: no border/radius, fills the viewport below the
+   *  share header. The auto-height still drives growth; this only restyles. */
+  bare?: boolean;
+}) {
   const ref = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState(360);
 
@@ -77,13 +85,18 @@ export function HtmlPreview({ html }: { html: string }) {
       srcDoc={composeSrcDoc(html, chartLib)}
       sandbox={HTML_SANDBOX}
       title="HTML output"
+      // The frame auto-sizes to its content, so it never needs its own
+      // scrollbar — the page scrolls. `scrolling="no"` guarantees the inner
+      // scrollbar never appears (e.g. during a brief pre-resize layout).
+      scrolling="no"
       style={{
         width: "100%",
         height,
-        border: "1px solid var(--rule)",
-        borderRadius: 10,
+        border: bare ? "none" : "1px solid var(--rule)",
+        borderRadius: bare ? 0 : 10,
         background: "var(--paper)",
         display: "block",
+        ...(bare ? { minHeight: "calc(100dvh - 56px)" } : {}),
       }}
     />
   );

--- a/src/components/SiteChrome.tsx
+++ b/src/components/SiteChrome.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+/**
+ * Wraps the app's global chrome (nav + footer) so it can be hidden on
+ * chrome-less routes. `/share/*` renders bare — just the page content — for a
+ * clean, embeddable, shareable view (the share page supplies its own minimal
+ * header). The nav/footer are passed in as nodes (rendered on the server) so a
+ * client component can conditionally render them without importing them.
+ */
+export function SiteChrome({
+  nav,
+  footer,
+  children,
+}: {
+  nav: ReactNode;
+  footer: ReactNode;
+  children: ReactNode;
+}) {
+  const pathname = usePathname();
+  const bare = pathname?.startsWith("/share") ?? false;
+
+  if (bare) {
+    return (
+      <main id="main-content" className="flex-1">
+        {children}
+      </main>
+    );
+  }
+
+  return (
+    <>
+      <a href="#main-content" className="skip-nav">
+        Skip to main content
+      </a>
+      {nav}
+      <main id="main-content" className="flex-1">
+        {children}
+      </main>
+      {footer}
+    </>
+  );
+}

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -70,6 +70,9 @@ describe("composeSrcDoc", () => {
     expect(out).toContain('<base target="_blank">');
     expect(out).toContain("__wikiHtmlHeight");
     expect(out).toContain("postMessage");
+    // The reporter must observe document.body (not just documentElement, whose
+    // box is pinned to the iframe height) so late reflow grows the frame.
+    expect(out).toContain("document.body");
   });
 
   it("inserts into an existing <head> (full document)", () => {

--- a/src/lib/__tests__/share-url.test.ts
+++ b/src/lib/__tests__/share-url.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { wikiUrlFor, str } from "../share-url";
+
+describe("wikiUrlFor", () => {
+  it("public commons page → global /wiki/<slug>", () => {
+    expect(wikiUrlFor("transformers", { type: "wiki" })).toBe(
+      "/wiki/transformers",
+    );
+    expect(wikiUrlFor("x", { owner: "yuanhao" })).toBe("/wiki/x");
+  });
+
+  it("html artifact → owner-scoped (excluded from the commons)", () => {
+    expect(wikiUrlFor("about-poke", { type: "html", owner: "yuanhao" })).toBe(
+      "/u/yuanhao/about-poke",
+    );
+  });
+
+  it("private page → owner-scoped (never a commons URL that 404s/leaks)", () => {
+    expect(
+      wikiUrlFor("secret", { visibility: "private", owner: "Alice" }),
+    ).toBe("/u/alice/secret");
+  });
+
+  it("agent-scoped page → owner-scoped", () => {
+    expect(
+      wikiUrlFor("notes", { type: "agent-knowledge", owner: "yuanhao--yoyo" }),
+    ).toBe("/u/yuanhao--yoyo/notes");
+  });
+
+  it("ownerless public page still resolves to commons", () => {
+    expect(wikiUrlFor("seed", {})).toBe("/wiki/seed");
+  });
+});
+
+describe("str", () => {
+  it("passes strings, drops non-strings", () => {
+    expect(str("hi")).toBe("hi");
+    expect(str(42)).toBeUndefined();
+    expect(str(undefined)).toBeUndefined();
+    expect(str(["a"])).toBeUndefined();
+  });
+});

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -30,8 +30,9 @@ export const HTML_SANDBOX = "allow-scripts";
 
 /**
  * Hard cap (px) on a sandboxed frame's reported height — bounds a runaway/hostile
- * grow while staying generous enough for a long, self-contained artifact (a full
- * blog-post-length document) to render without an inner scrollbar.
+ * grow while staying generous enough (~30 screen-heights at 800px) for a long,
+ * self-contained artifact to render without an inner scrollbar. Past the cap,
+ * HtmlPreview re-enables the iframe's own scrollbar so content isn't clipped.
  */
 export const HTML_MAX_HEIGHT = 24000;
 
@@ -109,10 +110,11 @@ button.btn{font:inherit;font-weight:600;background:var(--accent);color:#fff;bord
  * Tiny inline runtime injected into every HTML answer:
  *  - reports document height to the parent so the iframe auto-sizes (postMessage
  *    is permitted from a sandboxed frame even without same-origin access). Height
- *    is the max of documentElement/body scrollHeight, and we observe `body` (not
- *    just documentElement, whose box is pinned to the iframe height) so late
- *    reflow — wrapping grids, fonts/images loading — grows the frame instead of
- *    leaving a stale-short height with an inner scrollbar;
+ *    is the max of documentElement.scrollHeight and body's scrollHeight/
+ *    offsetHeight, and we observe `body` (not just documentElement, whose box is
+ *    pinned to the iframe height) so late reflow — wrapping grids, fonts/images
+ *    loading — grows the frame instead of leaving a stale-short height with an
+ *    inner scrollbar;
  *  - a delegated controller for the `.tabs` component so answers get working
  *    tabs without each one re-implementing the wiring.
  */
@@ -120,7 +122,7 @@ const BASE_SCRIPT =
   `<script>(function(){` +
   `function r(){try{var e=document.documentElement,b=document.body;` +
   `var h=Math.max(e?e.scrollHeight:0,b?b.scrollHeight:0,b?b.offsetHeight:0);` +
-  `parent.postMessage({${HTML_HEIGHT_MESSAGE_KEY}:Math.ceil(h)},'*')}catch(e){}}` +
+  `parent.postMessage({${HTML_HEIGHT_MESSAGE_KEY}:Math.ceil(h)},'*')}catch(_){}}` +
   `function s(){if(typeof ResizeObserver!=='undefined'){var o=new ResizeObserver(r);` +
   `o.observe(document.documentElement);if(document.body)o.observe(document.body);}r();}` +
   `if(document.readyState!=='loading')s();else document.addEventListener('DOMContentLoaded',s);` +

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -28,8 +28,12 @@
  */
 export const HTML_SANDBOX = "allow-scripts";
 
-/** Hard cap (px) on a sandboxed frame's reported height — bounds a runaway/hostile grow. */
-export const HTML_MAX_HEIGHT = 4000;
+/**
+ * Hard cap (px) on a sandboxed frame's reported height — bounds a runaway/hostile
+ * grow while staying generous enough for a long, self-contained artifact (a full
+ * blog-post-length document) to render without an inner scrollbar.
+ */
+export const HTML_MAX_HEIGHT = 24000;
 
 /** Message shape posted by the sandboxed frame to report its height. */
 export const HTML_HEIGHT_MESSAGE_KEY = "__wikiHtmlHeight";
@@ -104,16 +108,24 @@ button.btn{font:inherit;font-weight:600;background:var(--accent);color:#fff;bord
 /**
  * Tiny inline runtime injected into every HTML answer:
  *  - reports document height to the parent so the iframe auto-sizes (postMessage
- *    is permitted from a sandboxed frame even without same-origin access);
+ *    is permitted from a sandboxed frame even without same-origin access). Height
+ *    is the max of documentElement/body scrollHeight, and we observe `body` (not
+ *    just documentElement, whose box is pinned to the iframe height) so late
+ *    reflow — wrapping grids, fonts/images loading — grows the frame instead of
+ *    leaving a stale-short height with an inner scrollbar;
  *  - a delegated controller for the `.tabs` component so answers get working
  *    tabs without each one re-implementing the wiring.
  */
 const BASE_SCRIPT =
   `<script>(function(){` +
-  `function r(){try{parent.postMessage({${HTML_HEIGHT_MESSAGE_KEY}:` +
-  `Math.ceil(document.documentElement.scrollHeight)},'*')}catch(e){}}` +
-  `if(typeof ResizeObserver!=='undefined'){new ResizeObserver(r).observe(document.documentElement);}` +
-  `window.addEventListener('load',r);setTimeout(r,60);` +
+  `function r(){try{var e=document.documentElement,b=document.body;` +
+  `var h=Math.max(e?e.scrollHeight:0,b?b.scrollHeight:0,b?b.offsetHeight:0);` +
+  `parent.postMessage({${HTML_HEIGHT_MESSAGE_KEY}:Math.ceil(h)},'*')}catch(e){}}` +
+  `function s(){if(typeof ResizeObserver!=='undefined'){var o=new ResizeObserver(r);` +
+  `o.observe(document.documentElement);if(document.body)o.observe(document.body);}r();}` +
+  `if(document.readyState!=='loading')s();else document.addEventListener('DOMContentLoaded',s);` +
+  `window.addEventListener('load',r);window.addEventListener('resize',r);` +
+  `[60,200,500,1000].forEach(function(t){setTimeout(r,t)});` +
   `document.addEventListener('click',function(e){var b=e.target.closest&&e.target.closest('.tabs .tablist button[data-tab]');` +
   `if(!b)return;var root=b.closest('.tabs');var id=b.getAttribute('data-tab');` +
   `root.querySelectorAll('.tablist button').forEach(function(x){x.classList.toggle('active',x===b)});` +

--- a/src/lib/share-url.ts
+++ b/src/lib/share-url.ts
@@ -1,0 +1,24 @@
+import { belongsInCommons } from "./commons";
+import { commonsPath, pagePath } from "./links";
+import { tenantForOwner } from "./wiki";
+
+/** Narrow an unknown frontmatter value to a string (or undefined). */
+export function str(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+/**
+ * The canonical wiki URL for a page, from its frontmatter: a PUBLIC commons page
+ * resolves to the global `/wiki/<slug>`; everything else (private, agent-scoped,
+ * or an html artifact — all excluded from the commons) resolves to the
+ * owner-scoped `/u/<tenant>/<slug>`. Mirrors the owner route's commons-vs-owner
+ * branch so the share view's "Open in wiki" link points at the right home.
+ */
+export function wikiUrlFor(
+  slug: string,
+  fm: { owner?: unknown; visibility?: unknown; type?: unknown },
+): string {
+  return belongsInCommons({ visibility: str(fm.visibility), type: str(fm.type) })
+    ? commonsPath(slug)
+    : pagePath(tenantForOwner(str(fm.owner)), slug);
+}


### PR DESCRIPTION
Two related improvements to rendered HTML artifacts.

## No inner scrollbar
The sandboxed iframe auto-sizes from a `postMessage` height report, but it kept showing an inner scrollbar.
- **Reporter fix:** observe `document.body` (its box grows with content) in addition to `documentElement` (whose box is pinned to the iframe height, so late reflow never re-fired it); report the **max** scrollHeight; re-measure on load/resize + a few delayed ticks.
- **`scrolling="no"`** on the iframe as a hard guarantee — the frame auto-sizes to content so it never needs to scroll; the page scrolls.
- **Raised `HTML_MAX_HEIGHT` 4000 → 24000** so a long, blog-post-length artifact isn't capped (and thus scrolled).

Injected at render time → existing saved artifacts pick it up on next view.

## Full-screen share view
A chrome-less **`/share/<handle>/<slug>`** route for sharing an artifact: a minimal header (yopedia logo + "Open in wiki →") and the HTML filling all remaining space full-bleed (new `HtmlPreview` `bare` variant). 
- The global nav/footer are hidden on `/share/*` via a new `SiteChrome` client wrapper (nav/footer passed as nodes so it can conditionally render them — `NavHeader`/`Footer` are hardcoded in the root layout).
- **Read-gated identically** to the owner-scoped page (`canReadFrontmatter`; `notFound()` for unreadable, neutral metadata so private pages aren't leaked).
- Per-page OG/Twitter metadata (title + summary) for nicer link unfurls.
- Non-HTML pages render as markdown in a clean centered column.
- `ArticleView` gains an **"Open full screen ↗"** link on artifacts (the entry point).

## Verification
- `pnpm build` clean (`/share/[handle]/[slug]` route built); `pnpm test` green (2868). tsc clean for changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)