### PR TITLE
Article view: fix breadcrumb + universal 'Share this page' (full-screen)

### DIFF
--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -278,9 +278,18 @@ export async function ArticleView({
           className="row receipt"
           style={{ gap: 8, fontSize: 12, color: "var(--muted)" }}
         >
-          <Link href="/wiki" style={{ color: "var(--muted)" }}>
-            commons
-          </Link>
+          {/* Commons pages live under the commons; owner-scoped pages (html
+              artifacts, private, agent) live under their owner's profile, so
+              don't mislabel those as "commons". */}
+          {isCommonsPage ? (
+            <Link href="/wiki" style={{ color: "var(--muted)" }}>
+              commons
+            </Link>
+          ) : (
+            <Link href={`/u/${pageTenant}`} style={{ color: "var(--muted)" }}>
+              @{pageTenant}
+            </Link>
+          )}
           <span style={{ color: "var(--faint)" }}>/</span>
           <span style={{ color: "var(--ink-2)" }}>{slug}</span>
         </div>

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -14,6 +14,7 @@ import { Icon } from "@/components/folio/icons";
 import { Avatar, Mark, Confidence, Freshness } from "@/components/folio/primitives";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { HtmlPreview } from "@/components/HtmlPreview";
+import { SharePageButton } from "@/components/SharePageButton";
 import { ArticleActions } from "@/components/ArticleActions";
 import { RevisionHistory } from "@/components/RevisionHistory";
 import { DiscussionPanel } from "@/components/DiscussionPanel";
@@ -409,25 +410,7 @@ export async function ArticleView({
             {isArtifactType(typeof fm.type === "string" ? fm.type : undefined) ? (
               // A saved HTML output is rendered verbatim in a sandboxed iframe
               // (isolated; no app cookie/DOM/network access) — never markdown.
-              <>
-                <div
-                  className="row"
-                  style={{ justifyContent: "flex-end", marginBottom: 10 }}
-                >
-                  <Link
-                    href={`/share/${pageTenant}/${slug}`}
-                    className="receipt"
-                    style={{
-                      fontSize: 12,
-                      color: "var(--muted)",
-                      textDecoration: "none",
-                    }}
-                  >
-                    Open full screen ↗
-                  </Link>
-                </div>
-                <HtmlPreview html={page.body} />
-              </>
+              <HtmlPreview html={page.body} />
             ) : (
               <MarkdownRenderer
                 content={articleBody}
@@ -597,6 +580,7 @@ export async function ArticleView({
           >
             <Icon.spark width="15" height="15" /> Ask about this page
           </Link>
+          <SharePageButton path={`/share/${pageTenant}/${slug}`} />
 
           <div className="rule" style={{ margin: "24px 0" }} />
           <TableOfContents items={toc} />

--- a/src/components/SharePageButton.tsx
+++ b/src/components/SharePageButton.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { Icon } from "@/components/folio/icons";
+import { logger } from "@/lib/logger";
+
+/**
+ * "Share this page" — copies the page's full-screen share URL (`/share/...`) to
+ * the clipboard. The full-screen view is the clean, chrome-less surface meant
+ * for sharing, so that's the link we hand out (not the in-app article URL).
+ */
+export function SharePageButton({ path }: { path: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function onClick() {
+    const url =
+      typeof window !== "undefined" ? window.location.origin + path : path;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      logger.error("share", "copy share link failed", err);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title="Copy a shareable full-screen link to this page"
+      className="row"
+      style={{
+        width: "100%",
+        justifyContent: "center",
+        gap: 7,
+        fontSize: 13,
+        padding: "9px 14px",
+        marginTop: 10,
+        borderRadius: 10,
+        border: "1px solid var(--rule)",
+        background: "transparent",
+        color: "var(--ink-2)",
+        cursor: "pointer",
+      }}
+    >
+      {copied ? (
+        <>
+          <Icon.check width="15" height="15" /> Link copied
+        </>
+      ) : (
+        <>
+          <Icon.link width="15" height="15" /> Share this page
+        </>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
Two article-view improvements.

## Breadcrumb fix
The breadcrumb hardcoded **commons → /wiki**, so an owner-scoped HTML artifact at `/u/<handle>/<slug>` wrongly read "commons / about-poke". It now branches on the existing `isCommonsPage`: commons pages keep **commons**, owner-scoped pages (HTML artifacts, private, agent) show **@\<owner\> → /u/\<owner\>**.

## Universal "Share this page"
A new `SharePageButton` sits under **"Ask about this page"** in the sidebar, on **every** page. It copies the page's chrome-less **full-screen `/share/<tenant>/<slug>` URL** — the surface meant for sharing — with a "Link copied" confirmation. The full-screen `/share` view already renders any page (HTML artifact full-bleed, markdown in a clean column), so this gives a shareable full-screen mode for all pages. Removed the earlier artifact-only inline "Open full screen ↗" link now that this is universal.

`pnpm build` clean; lint clean; `pnpm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)