### PR TITLE
Match 'Share this page' button style to 'Ask about this page'

### DIFF
--- a/src/components/SharePageButton.tsx
+++ b/src/components/SharePageButton.tsx
@@ -29,18 +29,13 @@ export function SharePageButton({ path }: { path: string }) {
       type="button"
       onClick={onClick}
       title="Copy a shareable full-screen link to this page"
-      className="row"
+      // Match the sibling "Ask about this page" button exactly (.btn pill).
+      className="btn"
       style={{
         width: "100%",
         justifyContent: "center",
-        gap: 7,
         fontSize: 13,
-        padding: "9px 14px",
         marginTop: 10,
-        borderRadius: 10,
-        border: "1px solid var(--rule)",
-        background: "transparent",
-        color: "var(--ink-2)",
         cursor: "pointer",
       }}
     >


### PR DESCRIPTION
The new **Share this page** button used a flatter custom style (radius 10, lighter border) while **Ask about this page** uses the `.btn` pill — so they didn't read as a matched pair. Switch the share button to the same `.btn` class + sizing.

`pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)