### PR TITLE
Fix artifact rendering, share view title/sources, @system contributor

### DIFF
--- a/src/app/share/[handle]/[slug]/page.tsx
+++ b/src/app/share/[handle]/[slug]/page.tsx
@@ -6,12 +6,62 @@ import { readWikiPageWithFrontmatter, isArtifactType } from "@/lib/wiki";
 import { getPrincipal } from "@/lib/auth";
 import { canReadFrontmatter } from "@/lib/authz";
 import { wikiUrlFor, str } from "@/lib/share-url";
+import { parseSources, dedupeSourcesForDisplay } from "@/lib/sources";
+import type { SourceEntry } from "@/lib/types";
 import { Colophon } from "@/components/folio/primitives";
 import { HtmlPreview } from "@/components/HtmlPreview";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 
 interface ShareProps {
   params: Promise<{ handle: string; slug: string }>;
+}
+
+/** Drop a body's own leading `# Title` so it isn't shown twice (we render the
+ *  title from frontmatter). Mirrors ArticleView. */
+function stripLeadingH1(body: string): string {
+  return body.replace(/^#\s+.+(?:\r?\n)?/m, "");
+}
+
+function sourceLabel(s: SourceEntry): string {
+  if (!s.url || s.url === "text-paste") return "pasted text";
+  try {
+    return new URL(s.url).hostname.replace(/^www\./, "");
+  } catch {
+    return s.url;
+  }
+}
+
+/** Citations at the bottom of a shared page. */
+function SourcesFooter({ sources }: { sources: SourceEntry[] }) {
+  if (sources.length === 0) return null;
+  return (
+    <section style={{ marginTop: 40 }}>
+      <p className="fmark" style={{ marginBottom: 14 }}>
+        Sources · {sources.length}
+      </p>
+      <ol className="stack" style={{ gap: 12, margin: 0, paddingLeft: 0, listStyle: "none" }}>
+        {sources.map((s, i) => (
+          <li key={`${s.url}-${i}`} style={{ fontSize: 13.5, lineHeight: 1.5 }}>
+            <span className="receipt" style={{ color: "var(--accent)", marginRight: 6 }}>
+              [{i + 1}]
+            </span>
+            <span style={{ color: "var(--ink-2)" }}>{sourceLabel(s)}</span>
+            {s.url && s.url !== "text-paste" && (
+              <div
+                className="receipt"
+                style={{ fontSize: 11, color: "var(--faint)", marginTop: 3, wordBreak: "break-all" }}
+              >
+                <a href={s.url} target="_blank" rel="noreferrer" style={{ color: "var(--faint)" }}>
+                  {s.url}
+                </a>
+                {s.fetched ? ` · fetched ${s.fetched}` : ""}
+              </div>
+            )}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
 }
 
 export async function generateMetadata({
@@ -51,6 +101,9 @@ export default async function SharePage({ params }: ShareProps) {
 
   const isHtml = isArtifactType(str(page.frontmatter.type));
   const wikiUrl = wikiUrlFor(slug, page.frontmatter);
+  const sources = dedupeSourcesForDisplay(
+    parseSources(page.frontmatter.sources as string | string[] | undefined),
+  );
 
   return (
     <div className="stack" style={{ minHeight: "100dvh" }}>
@@ -89,7 +142,14 @@ export default async function SharePage({ params }: ShareProps) {
       </header>
 
       {isHtml ? (
-        <HtmlPreview html={page.body} bare />
+        <>
+          <HtmlPreview html={page.body} bare />
+          {sources.length > 0 && (
+            <div style={{ maxWidth: 760, margin: "0 auto", padding: "0 24px 60px", width: "100%" }}>
+              <SourcesFooter sources={sources} />
+            </div>
+          )}
+        </>
       ) : (
         <main
           style={{ maxWidth: 760, margin: "0 auto", padding: "40px 24px 80px" }}
@@ -97,7 +157,9 @@ export default async function SharePage({ params }: ShareProps) {
           <h1 style={{ fontSize: 32, fontWeight: 700, marginBottom: 18 }}>
             {page.title || slug}
           </h1>
-          <MarkdownRenderer content={page.body} />
+          {/* Strip the body's own leading H1 — the title above already shows it. */}
+          <MarkdownRenderer content={stripLeadingH1(page.body)} />
+          <SourcesFooter sources={sources} />
         </main>
       )}
     </div>

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -32,11 +32,6 @@ export function HtmlPreview({
 }) {
   const ref = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState(360);
-  // True once content exceeds the height cap: we then re-enable the iframe's own
-  // scrollbar as a fallback so the tail isn't silently clipped (normal-height
-  // content keeps `scrolling="no"` → no scrollbar).
-  const [overCap, setOverCap] = useState(false);
-  const warnedOverCap = useRef(false);
 
   // Lazy-load the (~200KB) Chart.js source ONLY for documents that actually use
   // it, so prose/table answers don't pay for it. The chartless render happens
@@ -77,18 +72,7 @@ export function HtmlPreview({
       if (typeof reported === "number" && reported > 0) {
         // Clamp: cap a runaway/hostile grow, and floor a degenerate (e.g. 1px)
         // report so the artifact can't collapse to an invisible sliver.
-        const ceil = Math.ceil(reported);
-        if (ceil > HTML_MAX_HEIGHT) {
-          setOverCap(true);
-          if (!warnedOverCap.current) {
-            warnedOverCap.current = true;
-            logger.warn(
-              "html",
-              `artifact height ${ceil}px exceeds cap ${HTML_MAX_HEIGHT}px — capping and re-enabling inner scroll so content isn't clipped`,
-            );
-          }
-        }
-        setHeight(Math.max(140, Math.min(ceil, HTML_MAX_HEIGHT)));
+        setHeight(Math.max(140, Math.min(Math.ceil(reported), HTML_MAX_HEIGHT)));
       }
     }
     window.addEventListener("message", onMessage);
@@ -101,12 +85,11 @@ export function HtmlPreview({
       srcDoc={composeSrcDoc(html, chartLib)}
       sandbox={HTML_SANDBOX}
       title="HTML output"
-      // The frame auto-sizes to its content, so it never needs its own
-      // scrollbar — the page scrolls. `scrolling="no"` guarantees the inner
-      // scrollbar never appears (e.g. during a brief pre-resize layout), EXCEPT
-      // for a rare artifact taller than the cap, where we re-enable it so the
-      // clipped tail stays reachable rather than silently lost.
-      scrolling={overCap ? "auto" : "no"}
+      // The frame auto-sizes to its content (the page scrolls), so normal
+      // artifacts show no inner scrollbar. We do NOT force `scrolling="no"`: a
+      // self-contained artifact with its own full-viewport (100vh) layout
+      // reports a short height, and suppressing the scrollbar would clip it to
+      // nothing — letting it scroll keeps the content reachable.
       style={{
         width: "100%",
         height,

--- a/src/lib/contributors.ts
+++ b/src/lib/contributors.ts
@@ -315,7 +315,7 @@ export async function listContributors(
         "./contributor-index"
       );
       const idx = await getContributorIndex();
-      if (idx) return profilesFromIndex(idx);
+      if (idx) return profilesFromIndex(idx).filter(isRealContributor);
     } catch {
       // Fall through to the live scan — the index is purely an accelerator.
     }
@@ -331,5 +331,11 @@ export async function listContributors(
 
   // Sort by editCount descending, then handle ascending for stability.
   profiles.sort((a, b) => b.editCount - a.editCount || a.handle.localeCompare(b.handle));
-  return profiles;
+  return profiles.filter(isRealContributor);
+}
+
+/** Exclude the "system" seed/placeholder author — it isn't a real contributor
+ *  (and has no `/u/<handle>` profile). */
+function isRealContributor(p: ContributorProfile): boolean {
+  return p.handle.trim() !== "" && p.handle !== "system";
 }


### PR DESCRIPTION
Four fixes surfaced while testing the artifact/share work.

## 1. HTML artifact rendered blank
`scrolling="no"` (added in #510) clipped a **self-contained artifact that uses a full-viewport `100vh` layout** — such a doc defines its own scroll viewport and reports a short height, so suppressing the scrollbar hid everything. Dropped `scrolling="no"` (and the over-cap machinery) so the content stays reachable; it scrolls, as it did before #510. (Normal blog-post artifacts still auto-size with no scrollbar via the reporter.)

## 2. Share view doubled the title
The markdown branch rendered an `<h1>` from frontmatter **and** the body's own leading `# Title`. Now strips the body's leading H1 (mirrors ArticleView).

## 3. Share view: Sources at the bottom
The full-screen `/share` view now lists the page's **Sources** (frontmatter citations) at the bottom of the content, for both HTML artifacts and markdown pages.

## 4. "@system" listed as a contributor
The seed/placeholder author `system` showed up in the Contributors list (homepage + `/wiki/contributors`). Filtered at the source in `listContributors` (both the index fast-path and the live-scan path), so it's excluded everywhere.

`pnpm build` clean; `pnpm test` green (2874).

🤖 Generated with [Claude Code](https://claude.com/claude-code)