### PR TITLE
Review follow-up: fix stripLeadingH1 over-strip + extract/test helpers

### DIFF
--- a/src/app/share/[handle]/[slug]/page.tsx
+++ b/src/app/share/[handle]/[slug]/page.tsx
@@ -6,7 +6,8 @@ import { readWikiPageWithFrontmatter, isArtifactType } from "@/lib/wiki";
 import { getPrincipal } from "@/lib/auth";
 import { canReadFrontmatter } from "@/lib/authz";
 import { wikiUrlFor, str } from "@/lib/share-url";
-import { parseSources, dedupeSourcesForDisplay } from "@/lib/sources";
+import { parseSources, dedupeSourcesForDisplay, sourceLabel } from "@/lib/sources";
+import { stripLeadingH1 } from "@/lib/markdown";
 import type { SourceEntry } from "@/lib/types";
 import { Colophon } from "@/components/folio/primitives";
 import { HtmlPreview } from "@/components/HtmlPreview";
@@ -14,21 +15,6 @@ import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 
 interface ShareProps {
   params: Promise<{ handle: string; slug: string }>;
-}
-
-/** Drop a body's own leading `# Title` so it isn't shown twice (we render the
- *  title from frontmatter). Mirrors ArticleView. */
-function stripLeadingH1(body: string): string {
-  return body.replace(/^#\s+.+(?:\r?\n)?/m, "");
-}
-
-function sourceLabel(s: SourceEntry): string {
-  if (!s.url || s.url === "text-paste") return "pasted text";
-  try {
-    return new URL(s.url).hostname.replace(/^www\./, "");
-  } catch {
-    return s.url;
-  }
 }
 
 /** Citations at the bottom of a shared page. */

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -7,8 +7,8 @@ import { findBacklinks, findSimilarPages, buildSlugTenantMap, isArtifactType } f
 import { resolveSlugPath, profileHref } from "@/lib/links";
 import { getCommonsSlugSet, belongsInCommons } from "@/lib/commons";
 import type { Principal } from "@/lib/auth";
-import { parseSources, dedupeSourcesForDisplay } from "@/lib/sources";
-import type { SourceEntry } from "@/lib/types";
+import { parseSources, dedupeSourcesForDisplay, sourceLabel } from "@/lib/sources";
+import { stripLeadingH1 } from "@/lib/markdown";
 import { formatRelativeTime } from "@/lib/format";
 import { Icon } from "@/components/folio/icons";
 import { Avatar, Mark, Confidence, Freshness } from "@/components/folio/primitives";
@@ -104,10 +104,6 @@ function TableOfContents({
 }
 
 /** Remove the first H1 line so the promoted page title isn't duplicated. */
-function stripLeadingH1(body: string): string {
-  return body.replace(/^#\s+.+(?:\r?\n)?/m, "");
-}
-
 interface ArticleViewProps {
   page: WikiPage & { frontmatter: Frontmatter; body: string };
   slug: string;
@@ -260,15 +256,6 @@ export async function ArticleView({
   }
 
   // Sources rail label: a readable host, or the paste sentinel.
-  const sourceLabel = (s: SourceEntry): string => {
-    if (!s.url || s.url === "text-paste") return "pasted text";
-    try {
-      return new URL(s.url).hostname.replace(/^www\./, "");
-    } catch {
-      return s.url;
-    }
-  };
-
   const askHref = `/query?q=${encodeURIComponent(`About "${page.title}": `)}`;
 
   return (

--- a/src/lib/__tests__/contributors.test.ts
+++ b/src/lib/__tests__/contributors.test.ts
@@ -111,6 +111,27 @@ describe("contributors data layer", () => {
       expect(contributors.map((c) => c.handle)).toEqual(["alice"]);
     });
 
+    it("excludes the 'system' seed/placeholder author (scan + index paths)", async () => {
+      await createPage(
+        "page-a",
+        "Page A",
+        "---\nowner: alice\nvisibility: public\n---\n\n# Page A\n\nc.",
+      );
+      await saveRevision("page-a", "# Page A\n\nv1", "alice");
+      await saveRevision("page-a", "# Page A\n\nv2", "system");
+
+      // Live-scan path.
+      const scanned = await listContributors({ id: "alice", handle: "alice" });
+      expect(scanned.map((c) => c.handle)).toContain("alice");
+      expect(scanned.map((c) => c.handle)).not.toContain("system");
+
+      // Index fast path (anonymous) — the index stores system, listContributors filters it.
+      const { rebuildContributorIndex } = await import("../contributor-index");
+      await rebuildContributorIndex();
+      const anon = await listContributors(null);
+      expect(anon.map((c) => c.handle)).not.toContain("system");
+    });
+
     it("takes the contributor-index fast path ONLY for an anonymous viewer; a non-null principal uses the per-principal scan (sees their own private pages)", async () => {
       // A PUBLIC page edited by alice (visible to everyone, in the anon index).
       await createPage(

--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { stripLeadingH1 } from "../markdown";
+
+describe("stripLeadingH1", () => {
+  it("strips a genuine leading H1 title (and its line break)", () => {
+    // One trailing newline is consumed; a following blank line is harmless
+    // (the markdown renderer ignores leading whitespace).
+    expect(stripLeadingH1("# Title\n\nbody")).toBe("\nbody");
+    expect(stripLeadingH1("# Title\nbody")).toBe("body");
+    expect(stripLeadingH1("# Title")).toBe("");
+  });
+
+  it("does NOT strip an H1 that appears later in the body (the /m over-strip bug)", () => {
+    expect(stripLeadingH1("intro para\n\n# Real Heading\n\nmore")).toBe(
+      "intro para\n\n# Real Heading\n\nmore",
+    );
+    expect(stripLeadingH1("Some intro line.\n# Mid Heading\nrest")).toBe(
+      "Some intro line.\n# Mid Heading\nrest",
+    );
+  });
+
+  it("leaves ## / ### and #no-space alone", () => {
+    expect(stripLeadingH1("## Sub\nx")).toBe("## Sub\nx");
+    expect(stripLeadingH1("#NoSpace\nx")).toBe("#NoSpace\nx");
+  });
+
+  it("is a no-op when there's no leading H1", () => {
+    expect(stripLeadingH1("just prose")).toBe("just prose");
+    expect(stripLeadingH1("")).toBe("");
+  });
+});

--- a/src/lib/__tests__/sources.test.ts
+++ b/src/lib/__tests__/sources.test.ts
@@ -5,8 +5,34 @@ import {
   buildSourceEntry,
   newestSourceType,
   dedupeSourcesForDisplay,
+  sourceLabel,
 } from "../sources";
 import type { SourceEntry } from "../types";
+
+describe("sourceLabel", () => {
+  const mk = (url: string): SourceEntry => ({
+    type: "url",
+    url,
+    fetched: "2026-01-01",
+    triggered_by: "alice",
+  });
+
+  it("returns the bare hostname for a real URL, www stripped", () => {
+    expect(sourceLabel(mk("https://www.example.com/a/b?x=1"))).toBe("example.com");
+    expect(sourceLabel(mk("https://docs.anthropic.com/page"))).toBe("docs.anthropic.com");
+  });
+
+  it("returns 'pasted text' for a text paste / empty url", () => {
+    expect(sourceLabel(mk("text-paste"))).toBe("pasted text");
+    expect(sourceLabel({ ...mk(""), url: "" })).toBe("pasted text");
+  });
+
+  it("falls back to the raw value for a non-URL (e.g. a wiki-ref slug)", () => {
+    expect(sourceLabel({ ...mk("poke-ai-assistant"), type: "wiki-ref" })).toBe(
+      "poke-ai-assistant",
+    );
+  });
+});
 
 describe("dedupeSourcesForDisplay", () => {
   const mk = (

--- a/src/lib/contributors.ts
+++ b/src/lib/contributors.ts
@@ -17,6 +17,7 @@ import type { Principal } from "./auth";
 import { listRevisions, type Revision } from "./revisions";
 import { getDiscussRelPrefix } from "./talk";
 import { isEnoent } from "./errors";
+import { logger } from "./logger";
 import type { ContributorProfile, TalkThread } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -335,7 +336,17 @@ export async function listContributors(
 }
 
 /** Exclude the "system" seed/placeholder author — it isn't a real contributor
- *  (and has no `/u/<handle>` profile). */
+ *  (and has no `/u/<handle>` profile). An empty/whitespace handle is a real data
+ *  defect (an edit attributed to a blank author); drop it from the list but log
+ *  so the upstream attribution bug stays debuggable rather than silently hidden. */
 function isRealContributor(p: ContributorProfile): boolean {
-  return p.handle.trim() !== "" && p.handle !== "system";
+  if (p.handle === "system") return false;
+  if (p.handle.trim() === "") {
+    logger.warn(
+      "contributors",
+      `dropping a profile with an empty handle (editCount=${p.editCount}) — upstream attribution defect`,
+    );
+    return false;
+  }
+  return true;
 }

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,13 @@
+/**
+ * Small, pure markdown text helpers shared across render surfaces.
+ */
+
+/**
+ * Strip a body's own leading `# Title` (an ATX H1) so a caller that renders the
+ * title separately (from frontmatter) doesn't show it twice. Anchored to the
+ * START of the body — only a genuine leading title is removed, NOT a `# ` that
+ * appears later as a section heading. `##`/`###` and `#no-space` are left alone.
+ */
+export function stripLeadingH1(body: string): string {
+  return body.replace(/^\s*#[ \t]+.+(?:\r?\n)?/, "");
+}

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -91,6 +91,20 @@ export function dedupeSourcesForDisplay(sources: SourceEntry[]): SourceEntry[] {
 }
 
 /**
+ * A short human label for a source: the bare hostname for a real URL (`www.`
+ * stripped), "pasted text" for a text paste, and the raw value for a non-URL
+ * (e.g. a `wiki-ref` slug, which can't be parsed into a hostname).
+ */
+export function sourceLabel(s: SourceEntry): string {
+  if (!s.url || s.url === "text-paste") return "pasted text";
+  try {
+    return new URL(s.url).hostname.replace(/^www\./, "");
+  } catch {
+    return s.url;
+  }
+}
+
+/**
  * Build a fresh {@link SourceEntry} with sensible defaults.
  *
  * @param url        - Source URL or `"text-paste"` for pasted content.


### PR DESCRIPTION
Follow-up to the #512/#513 review.

## Bug: `stripLeadingH1` over-stripped
The helper used the `/m` flag, so `^#\s+` matched the start of **any** line — it removed the **first `# ` line anywhere** in a body (e.g. a mid-body section heading), not just a leading title. Confirmed: `"intro para\n\n# Real Heading\n…"` lost "# Real Heading".

Fixed by anchoring to the body start (no `/m`). Extracted to **`src/lib/markdown.ts`** (was byte-duplicated in `ArticleView` and the share route) and unit-tested the over-strip cases (`##`/`#no-space`/mid-body all left alone).

## Cleanups (also from review)
- Extracted **`sourceLabel`** into `src/lib/sources.ts` (was duplicated in `ArticleView` + the share route) and unit-tested it (hostname/`www.` strip, `text-paste`, non-URL fallback).
- `contributors`: `isRealContributor` now **logs** when it drops an empty-handle profile (a real upstream attribution defect) instead of silently hiding it; added a test that **"system" is excluded** via both the live-scan and the index fast-path.

## Verification
- `pnpm build` clean; lint clean; `pnpm test` green (2882, +new). New tests: `markdown.test.ts`, `sourceLabel` in `sources.test.ts`, "system" exclusion in `contributors.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)