### PR TITLE
Full-screen share: render artifacts edge-to-edge, no scrollbar

### DIFF
--- a/src/app/share/[handle]/[slug]/page.tsx
+++ b/src/app/share/[handle]/[slug]/page.tsx
@@ -137,14 +137,10 @@ export default async function SharePage({ params }: ShareProps) {
       </header>
 
       {isHtml ? (
-        <>
-          <HtmlPreview html={page.body} bare />
-          {sources.length > 0 && (
-            <div style={{ maxWidth: 760, margin: "0 auto", padding: "0 24px 60px", width: "100%" }}>
-              <SourcesFooter sources={sources} />
-            </div>
-          )}
-        </>
+        // A self-contained artifact fills the viewport exactly (header + frame =
+        // 100dvh) so there's no page scrollbar; its sources stay one click away
+        // via "Open in wiki" rather than forcing a scroll past the full frame.
+        <HtmlPreview html={page.body} bare />
       ) : (
         <main
           style={{ maxWidth: 760, margin: "0 auto", padding: "40px 24px 80px" }}

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -82,22 +82,21 @@ export function HtmlPreview({
   return (
     <iframe
       ref={ref}
-      srcDoc={composeSrcDoc(html, chartLib)}
+      // Inline (article) view: auto-size to content so the page scrolls and a
+      // normal artifact shows no inner scrollbar. Full-screen share (`bare`):
+      // fix the frame to the viewport so a self-contained artifact's `100vh`
+      // layout resolves correctly (no auto-grow feedback loop) and it scrolls
+      // INSIDE the frame, with that inner scrollbar hidden — a clean full page.
+      srcDoc={composeSrcDoc(html, chartLib, bare)}
       sandbox={HTML_SANDBOX}
       title="HTML output"
-      // The frame auto-sizes to its content (the page scrolls), so normal
-      // artifacts show no inner scrollbar. We do NOT force `scrolling="no"`: a
-      // self-contained artifact with its own full-viewport (100vh) layout
-      // reports a short height, and suppressing the scrollbar would clip it to
-      // nothing — letting it scroll keeps the content reachable.
       style={{
         width: "100%",
-        height,
+        height: bare ? "calc(100dvh - 56px)" : height,
         border: bare ? "none" : "1px solid var(--rule)",
         borderRadius: bare ? 0 : 10,
         background: "var(--paper)",
         display: "block",
-        ...(bare ? { minHeight: "calc(100dvh - 56px)" } : {}),
       }}
     />
   );

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -131,6 +131,14 @@ describe("composeSrcDoc", () => {
     expect(HTML_MAX_HEIGHT).toBeGreaterThan(0);
   });
 
+  it("hides the document scrollbar only when hideScrollbar is set (full-screen share)", () => {
+    const bare = composeSrcDoc("<p>x</p>", undefined, true);
+    const normal = composeSrcDoc("<p>x</p>");
+    expect(bare).toContain("scrollbar-width:none");
+    expect(bare).toContain("::-webkit-scrollbar");
+    expect(normal).not.toContain("scrollbar-width:none");
+  });
+
   it("injects the editorial baseline style + tab controller", () => {
     const out = composeSrcDoc("<p>plain answer</p>");
     // A predefined component class and the brand accent token are present.

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -152,15 +152,26 @@ export function usesChartLib(html: string): boolean {
  * runtime. The model's own markup is injected after this string, so its
  * `<style>` overrides the baseline.
  */
-function sandboxHead(html: string, chartLibSource?: string): string {
+function sandboxHead(
+  html: string,
+  chartLibSource?: string,
+  hideScrollbar?: boolean,
+): string {
   const chartLib =
     chartLibSource && usesChartLib(html)
       ? `<script>${chartLibSource}</script>`
       : "";
+  // Full-screen share view: the frame is fixed to the viewport and the artifact
+  // scrolls inside it — hide that inner scrollbar so the page reads clean.
+  const hideBar = hideScrollbar
+    ? `<style>html{scrollbar-width:none;-ms-overflow-style:none}` +
+      `html::-webkit-scrollbar,body::-webkit-scrollbar{width:0;height:0;display:none}</style>`
+    : "";
   return (
     `<meta http-equiv="Content-Security-Policy" content="${SANDBOX_CSP}">` +
     `<base target="_blank">` +
     BASE_STYLE +
+    hideBar +
     chartLib +
     BASE_SCRIPT
   );
@@ -191,11 +202,17 @@ export function stripHtmlFence(html: string): string {
  *
  * `chartLibSource` (the Chart.js UMD source) is injected only when the document
  * actually uses charts; pass it from a lazy `import()` of `vendor/chartjs.generated`
- * so the heavy library stays out of the default client bundle.
+ * so the heavy library stays out of the default client bundle. `hideScrollbar`
+ * suppresses the document's own scrollbar (the full-screen share view, where the
+ * frame is fixed to the viewport and scrolls internally).
  */
-export function composeSrcDoc(html: string, chartLibSource?: string): string {
+export function composeSrcDoc(
+  html: string,
+  chartLibSource?: string,
+  hideScrollbar?: boolean,
+): string {
   const src = stripHtmlFence(html);
-  const head = sandboxHead(src, chartLibSource);
+  const head = sandboxHead(src, chartLibSource, hideScrollbar);
 
   const headOpen = src.match(/<head[^>]*>/i);
   if (headOpen?.index !== undefined) {


### PR DESCRIPTION
The `/share` full-screen view still showed a scrollbar for a self-contained artifact (e.g. `about-poke`). Cause: the artifact uses a full-viewport `100vh` layout, and the auto-sizing iframe grew without bound (a feedback loop: iframe grows → `100vh` grows → …), producing a very tall page with a scrollbar.

Fix — render the bare/full-screen view as a **true full screen**:
- **Fix the iframe to the viewport** (`height: calc(100dvh - 56px)`), so the artifact's `100vh` resolves correctly (no auto-grow loop) and it scrolls **inside** the frame.
- **Hide that inner scrollbar** via an injected style (new `composeSrcDoc(html, chartLib, hideScrollbar)` arg, passed only in bare mode) → a clean, scrollbar-free full page.
- **Drop the sources footer from the HTML share branch** — appending it below a viewport-filling frame would reintroduce a page scrollbar; sources remain one click away via "Open in wiki". The **markdown** share view keeps its sources (a normal reading column).

The inline article view (non-bare) is unchanged: it still auto-sizes to content.

`pnpm build` clean; lint clean; `pnpm test` green (2886, +1 for the hideScrollbar injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)