### PR TITLE
Artifact cleanup: no leaked markdown, no inline scrollbar, fold automation to yoyo

### DIFF
--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import {
   composeSrcDoc,
   usesChartLib,
+  usesViewportUnits,
   HTML_SANDBOX,
   HTML_MAX_HEIGHT,
   HTML_HEIGHT_MESSAGE_KEY,
@@ -32,6 +33,9 @@ export function HtmlPreview({
 }) {
   const ref = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState(360);
+  // App-style artifacts (full-viewport 100vh layouts) get a fixed, scroll-hidden
+  // frame instead of auto-height; see the iframe below.
+  const appStyle = usesViewportUnits(html);
 
   // Lazy-load the (~200KB) Chart.js source ONLY for documents that actually use
   // it, so prose/table answers don't pay for it. The chartless render happens
@@ -82,17 +86,22 @@ export function HtmlPreview({
   return (
     <iframe
       ref={ref}
-      // Inline (article) view: auto-size to content so the page scrolls and a
-      // normal artifact shows no inner scrollbar. Full-screen share (`bare`):
-      // fix the frame to the viewport so a self-contained artifact's `100vh`
-      // layout resolves correctly (no auto-grow feedback loop) and it scrolls
-      // INSIDE the frame, with that inner scrollbar hidden — a clean full page.
-      srcDoc={composeSrcDoc(html, chartLib, bare)}
+      // Document-style artifacts auto-size to content (the page scrolls, no
+      // inner scrollbar). "App-style" artifacts that lay out against the
+      // viewport (100vh) define their own scroll viewport — auto-sizing
+      // feedback-loops them to absurd heights — so we fix the frame and let
+      // them scroll INSIDE it, with that inner scrollbar hidden. Full-screen
+      // share (`bare`) fills the viewport; inline gets a tall contained frame.
+      srcDoc={composeSrcDoc(html, chartLib, bare || appStyle)}
       sandbox={HTML_SANDBOX}
       title="HTML output"
       style={{
         width: "100%",
-        height: bare ? "calc(100dvh - 56px)" : height,
+        height: bare
+          ? "calc(100dvh - 56px)"
+          : appStyle
+            ? "80vh"
+            : height,
         border: bare ? "none" : "1px solid var(--rule)",
         borderRadius: bare ? 0 : 10,
         background: "var(--paper)",

--- a/src/lib/__tests__/agent-handle.test.ts
+++ b/src/lib/__tests__/agent-handle.test.ts
@@ -1,5 +1,30 @@
 import { describe, it, expect } from "vitest";
-import { isAgentHandle, DEFAULT_AGENT_NAME } from "../agent-handle";
+import {
+  isAgentHandle,
+  DEFAULT_AGENT_NAME,
+  normalizeActor,
+  isAutomationActor,
+} from "../agent-handle";
+
+describe("automation actors", () => {
+  it("recognizes system/lint-fix/yopedia as automation (case-insensitive)", () => {
+    expect(isAutomationActor("system")).toBe(true);
+    expect(isAutomationActor("lint-fix")).toBe(true);
+    expect(isAutomationActor("yopedia")).toBe(true);
+    expect(isAutomationActor("Lint-Fix")).toBe(true);
+    expect(isAutomationActor("yuanhao")).toBe(false);
+    expect(isAutomationActor("yoyo")).toBe(false);
+    expect(isAutomationActor("")).toBe(false);
+  });
+
+  it("normalizeActor folds automation into the agent, passes people through", () => {
+    expect(normalizeActor("system")).toBe(DEFAULT_AGENT_NAME);
+    expect(normalizeActor("lint-fix")).toBe(DEFAULT_AGENT_NAME);
+    expect(normalizeActor("yopedia")).toBe(DEFAULT_AGENT_NAME);
+    expect(normalizeActor("yuanhao")).toBe("yuanhao");
+    expect(normalizeActor("yuanhao--yoyo")).toBe("yuanhao--yoyo");
+  });
+});
 
 describe("isAgentHandle", () => {
   it("recognizes composite agent ids", () => {

--- a/src/lib/__tests__/contributors.test.ts
+++ b/src/lib/__tests__/contributors.test.ts
@@ -120,6 +120,9 @@ describe("contributors data layer", () => {
       await saveRevision("page-a", "# Page A\n\nv1", "alice");
       await saveRevision("page-a", "# Page A\n\nv2", "system");
       await saveRevision("page-a", "# Page A\n\nv3", "lint-fix");
+      // ...and a talk comment by an automation actor (the mergeTalkActivity path).
+      await createThread("page-a", "T", "alice", "post");
+      await addComment("page-a", 0, "lint-fix", "auto comment");
 
       // Live-scan path: system/lint-fix are credited to the agent (yoyo), never
       // shown as their own contributors.
@@ -129,6 +132,8 @@ describe("contributors data layer", () => {
       expect(handles).toContain("yoyo");
       expect(handles).not.toContain("system");
       expect(handles).not.toContain("lint-fix");
+      // The lint-fix comment counts toward yoyo, not its own handle.
+      expect(scanned.find((c) => c.handle === "yoyo")?.commentCount).toBe(1);
 
       // Index fast path (anonymous) stays clean too.
       const { rebuildContributorIndex } = await import("../contributor-index");

--- a/src/lib/__tests__/contributors.test.ts
+++ b/src/lib/__tests__/contributors.test.ts
@@ -111,7 +111,7 @@ describe("contributors data layer", () => {
       expect(contributors.map((c) => c.handle)).toEqual(["alice"]);
     });
 
-    it("excludes the 'system' seed/placeholder author (scan + index paths)", async () => {
+    it("folds automation authors (system/lint-fix) into the agent, not their own handles", async () => {
       await createPage(
         "page-a",
         "Page A",
@@ -119,17 +119,23 @@ describe("contributors data layer", () => {
       );
       await saveRevision("page-a", "# Page A\n\nv1", "alice");
       await saveRevision("page-a", "# Page A\n\nv2", "system");
+      await saveRevision("page-a", "# Page A\n\nv3", "lint-fix");
 
-      // Live-scan path.
+      // Live-scan path: system/lint-fix are credited to the agent (yoyo), never
+      // shown as their own contributors.
       const scanned = await listContributors({ id: "alice", handle: "alice" });
-      expect(scanned.map((c) => c.handle)).toContain("alice");
-      expect(scanned.map((c) => c.handle)).not.toContain("system");
+      const handles = scanned.map((c) => c.handle);
+      expect(handles).toContain("alice");
+      expect(handles).toContain("yoyo");
+      expect(handles).not.toContain("system");
+      expect(handles).not.toContain("lint-fix");
 
-      // Index fast path (anonymous) — the index stores system, listContributors filters it.
+      // Index fast path (anonymous) stays clean too.
       const { rebuildContributorIndex } = await import("../contributor-index");
       await rebuildContributorIndex();
-      const anon = await listContributors(null);
-      expect(anon.map((c) => c.handle)).not.toContain("system");
+      const anon = await listContributors(null).then((cs) => cs.map((c) => c.handle));
+      expect(anon).not.toContain("system");
+      expect(anon).not.toContain("lint-fix");
     });
 
     it("takes the contributor-index fast path ONLY for an anonymous viewer; a non-null principal uses the per-principal scan (sees their own private pages)", async () => {

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -166,6 +166,15 @@ describe("Chart.js injection", () => {
     expect(out).toContain("<h1>Art</h1>");
   });
 
+  it("truncates at the LAST </html> so a doc quoting </html> as text survives", () => {
+    const doc =
+      "<!doctype html><html><body><pre>close with &lt;/html&gt; then</pre><p>tail content</p></body></html>\n\n## Related\n\n- [x](x.md)";
+    const out = composeSrcDoc(doc);
+    expect(out).not.toContain("## Related");
+    // The real document (including the part after a text-mentioned tag) is kept.
+    expect(out).toContain("tail content");
+  });
+
   it("usesChartLib detects a new Chart(...) call", () => {
     expect(usesChartLib("<canvas></canvas><script>new Chart(el,{})</script>")).toBe(true);
     expect(usesChartLib("<script>const x = new  Chart( a )</script>")).toBe(true);

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -4,6 +4,7 @@ import {
   htmlToPlainText,
   stripHtmlFence,
   usesChartLib,
+  usesViewportUnits,
   HTML_SANDBOX,
   HTML_MAX_HEIGHT,
 } from "../html";
@@ -150,6 +151,21 @@ describe("composeSrcDoc", () => {
 });
 
 describe("Chart.js injection", () => {
+  it("usesViewportUnits detects 100vh/dvh app-style layouts", () => {
+    expect(usesViewportUnits("<div style='height:100vh'></div>")).toBe(true);
+    expect(usesViewportUnits("<style>.h{min-height:100dvh}</style>")).toBe(true);
+    expect(usesViewportUnits("<p>just prose, padding: 12px</p>")).toBe(false);
+  });
+
+  it("drops cross-reference markdown leaked after </html>", () => {
+    const leaked =
+      "<!doctype html><html><body><h1>Art</h1></body></html>\n\n## Related\n\n- [Other](other.md)\n";
+    const out = composeSrcDoc(leaked);
+    expect(out).not.toContain("## Related");
+    expect(out).not.toContain("other.md");
+    expect(out).toContain("<h1>Art</h1>");
+  });
+
   it("usesChartLib detects a new Chart(...) call", () => {
     expect(usesChartLib("<canvas></canvas><script>new Chart(el,{})</script>")).toBe(true);
     expect(usesChartLib("<script>const x = new  Chart( a )</script>")).toBe(true);

--- a/src/lib/__tests__/lint-fix.test.ts
+++ b/src/lib/__tests__/lint-fix.test.ts
@@ -309,6 +309,28 @@ describe("fixMissingCrossRef", () => {
     expect(mockedWriteWikiPageWithSideEffects).not.toHaveBeenCalled();
   });
 
+  it("skips an HTML artifact source (never appends markdown to its body)", async () => {
+    mockedReadWikiPage.mockResolvedValueOnce({
+      slug: "art",
+      title: "Art",
+      content: "<!doctype html><html><body>x</body></html>",
+      path: "/wiki/art.md",
+    });
+    mockedReadWikiPageWithFrontmatter.mockResolvedValueOnce({
+      slug: "art",
+      title: "Art",
+      frontmatter: { type: "html" },
+      body: "<!doctype html><html><body>x</body></html>",
+      path: "/wiki/art.md",
+    } as unknown as Awaited<ReturnType<typeof readWikiPageWithFrontmatter>>);
+
+    const result = await fixMissingCrossRef("art", "target");
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("HTML artifacts");
+    expect(mockedWriteWikiPageWithSideEffects).not.toHaveBeenCalled();
+  });
+
   it("inserts link into existing Related section", async () => {
     mockedReadWikiPage
       .mockResolvedValueOnce({

--- a/src/lib/__tests__/lint-fix.test.ts
+++ b/src/lib/__tests__/lint-fix.test.ts
@@ -11,6 +11,7 @@ vi.mock("../wiki", () => ({
   listWikiPages: vi.fn(),
   updateIndex: vi.fn(),
   appendToLog: vi.fn(),
+  isArtifactType: (t: string | undefined) => t === "html",
 }));
 
 vi.mock("../lifecycle", () => ({

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -640,6 +640,37 @@ describe("updateRelatedPages", () => {
     expect(page!.content).toContain("**See also:** [New Page](new-page.md)");
   });
 
+  it("PRESERVES the page's frontmatter when appending a See-also", async () => {
+    await ensureDirectories();
+    await writeWikiPage(
+      "owned",
+      '---\nowner: alice\nvisibility: private\ntags: ["x"]\n---\n\n# Owned\n\nBody.',
+    );
+
+    await updateRelatedPages("new-page", "New Page", ["owned"]);
+
+    const page = await readWikiPage("owned");
+    // The frontmatter block must survive the write-back (regression: building
+    // the update from the frontmatter-stripped body silently dropped it).
+    expect(page!.content).toContain("owner: alice");
+    expect(page!.content).toContain("visibility: private");
+    expect(page!.content).toContain("**See also:** [New Page](new-page.md)");
+  });
+
+  it("never appends a See-also to an HTML artifact", async () => {
+    await ensureDirectories();
+    await writeWikiPage(
+      "artifact",
+      "---\ntype: html\n---\n\n<!doctype html><html><body>x</body></html>",
+    );
+
+    const modified = await updateRelatedPages("new-page", "New Page", ["artifact"]);
+    expect(modified).toEqual([]);
+
+    const page = await readWikiPage("artifact");
+    expect(page!.content).not.toContain("See also");
+  });
+
   it("keeps the backlink index fresh for the appended See-also link", async () => {
     await ensureDirectories();
     await writeWikiPage("existing", "# Existing\n\nBody.");

--- a/src/lib/agent-handle.ts
+++ b/src/lib/agent-handle.ts
@@ -23,3 +23,26 @@ export function isAgentHandle(handle: string | null | undefined): boolean {
     handle.endsWith(`--${DEFAULT_AGENT_NAME}`)
   );
 }
+
+/**
+ * Non-human automation authors: the seed/system placeholder, the auto-linter,
+ * and the platform seed identity. They aren't people and shouldn't appear as
+ * their own contributors — their edits are part of the agent's autonomous
+ * upkeep, so {@link normalizeActor} folds them into the agent ("yoyo").
+ */
+const AUTOMATION_ACTORS = new Set(["system", "lint-fix", "yopedia"]);
+
+/** True when a handle is a non-human automation actor (seed/system/linter). */
+export function isAutomationActor(handle: string | null | undefined): boolean {
+  return !!handle && AUTOMATION_ACTORS.has(handle.trim().toLowerCase());
+}
+
+/**
+ * Normalize an author/actor for attribution: automation actors (system, the
+ * linter, the platform seed) are credited to the agent ("yoyo") so the
+ * contributor list reads as the real people plus the agent, not a scatter of
+ * one-off system handles. Real human/agent handles pass through unchanged.
+ */
+export function normalizeActor(handle: string): string {
+  return isAutomationActor(handle) ? DEFAULT_AGENT_NAME : handle;
+}

--- a/src/lib/contributors.ts
+++ b/src/lib/contributors.ts
@@ -18,6 +18,7 @@ import { listRevisions, type Revision } from "./revisions";
 import { getDiscussRelPrefix } from "./talk";
 import { isEnoent } from "./errors";
 import { logger } from "./logger";
+import { normalizeActor, isAutomationActor } from "./agent-handle";
 import type { ContributorProfile, TalkThread } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -84,10 +85,11 @@ export function reduceActivity(
   for (const revisions of revisionsPerPage) {
     for (const rev of revisions) {
       if (!rev.author) continue;
-      let act = map.get(rev.author);
+      const author = normalizeActor(rev.author);
+      let act = map.get(author);
       if (!act) {
         act = emptyActivity();
-        map.set(rev.author, act);
+        map.set(author, act);
       }
       act.editCount++;
       act.pagesEdited.add(rev.slug);
@@ -105,10 +107,11 @@ export function mergeTalkActivity(
   for (const thread of threads) {
     for (let i = 0; i < thread.comments.length; i++) {
       const comment = thread.comments[i];
-      let act = map.get(comment.author);
+      const author = normalizeActor(comment.author);
+      let act = map.get(author);
       if (!act) {
         act = emptyActivity();
-        map.set(comment.author, act);
+        map.set(author, act);
       }
       act.commentCount++;
       act.dates.push(comment.created);
@@ -335,12 +338,13 @@ export async function listContributors(
   return profiles.filter(isRealContributor);
 }
 
-/** Exclude the "system" seed/placeholder author — it isn't a real contributor
- *  (and has no `/u/<handle>` profile). An empty/whitespace handle is a real data
- *  defect (an edit attributed to a blank author); drop it from the list but log
- *  so the upstream attribution bug stays debuggable rather than silently hidden. */
+/** Keep only real contributors. Automation actors (system/lint-fix/yopedia) are
+ *  normally folded into the agent by {@link normalizeActor}, but a stale
+ *  precomputed index may still carry their raw handles, so exclude them here too.
+ *  An empty/whitespace handle is a real data defect (an edit attributed to a
+ *  blank author); drop it but log so the upstream bug stays debuggable. */
 function isRealContributor(p: ContributorProfile): boolean {
-  if (p.handle === "system") return false;
+  if (isAutomationActor(p.handle)) return false;
   if (p.handle.trim() === "") {
     logger.warn(
       "contributors",

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -225,10 +225,13 @@ export function composeSrcDoc(
   // Drop anything after the document's closing </html> — a self-contained
   // artifact ends there, so trailing content is leaked cross-reference markdown
   // (a "## Related"/"See also" block the wiki appends to linked pages), which
-  // would otherwise render as literal text below the artifact.
-  const closeHtml = src.match(/<\/html\s*>/i);
-  if (closeHtml?.index !== undefined) {
-    src = src.slice(0, closeHtml.index + closeHtml[0].length);
+  // would otherwise render as literal text below the artifact. Match the LAST
+  // </html> so a doc that legitimately quotes "</html>" as text (e.g. an HTML
+  // tutorial) keeps its real terminator and isn't truncated mid-document.
+  const closes = [...src.matchAll(/<\/html\s*>/gi)];
+  const lastClose = closes[closes.length - 1];
+  if (lastClose?.index !== undefined) {
+    src = src.slice(0, lastClose.index + lastClose[0].length);
   }
   const head = sandboxHead(src, chartLibSource, hideScrollbar);
 

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -145,6 +145,16 @@ export function usesChartLib(html: string): boolean {
 }
 
 /**
+ * Does the artifact lay itself out against the viewport (`100vh`/`100dvh`/etc.)?
+ * Such "app-style" documents define their own full-screen scroll viewport, so an
+ * auto-sizing iframe feedback-loops them to absurd heights. We instead give them
+ * a fixed-height frame and let them scroll inside it (see `HtmlPreview`).
+ */
+export function usesViewportUnits(html: string): boolean {
+  return /\b\d+(?:\.\d+)?(?:vh|dvh|svh|lvh)\b/i.test(html ?? "");
+}
+
+/**
  * Build the `<head>` injection for a given document: the CSP, `<base
  * target="_blank">` (links open in a new tab rather than navigating the frame to
  * an app route), the editorial baseline style, the Chart.js runtime (only when
@@ -211,7 +221,15 @@ export function composeSrcDoc(
   chartLibSource?: string,
   hideScrollbar?: boolean,
 ): string {
-  const src = stripHtmlFence(html);
+  let src = stripHtmlFence(html);
+  // Drop anything after the document's closing </html> — a self-contained
+  // artifact ends there, so trailing content is leaked cross-reference markdown
+  // (a "## Related"/"See also" block the wiki appends to linked pages), which
+  // would otherwise render as literal text below the artifact.
+  const closeHtml = src.match(/<\/html\s*>/i);
+  if (closeHtml?.index !== undefined) {
+    src = src.slice(0, closeHtml.index + closeHtml[0].length);
+  }
   const head = sandboxHead(src, chartLibSource, hideScrollbar);
 
   const headOpen = src.match(/<head[^>]*>/i);

--- a/src/lib/lint-fix.ts
+++ b/src/lib/lint-fix.ts
@@ -1,4 +1,4 @@
-import { readWikiPage, readWikiPageWithFrontmatter, listWikiPages, updateIndex, appendToLog } from "./wiki";
+import { readWikiPage, readWikiPageWithFrontmatter, listWikiPages, updateIndex, appendToLog, isArtifactType } from "./wiki";
 import { writeWikiPageWithSideEffects, deleteWikiPage } from "./lifecycle";
 import { callLLM, hasLLMKey } from "./llm";
 import { slugify } from "./slugify";
@@ -164,6 +164,24 @@ export async function fixMissingCrossRef(
   const sourcePage = await readWikiPage(slug);
   if (!sourcePage) {
     throw new FixNotFoundError(`Source page not found: ${slug}`);
+  }
+
+  // Never append a markdown "## Related" section to an HTML artifact — its body
+  // is a self-contained document and the markdown would render as literal text.
+  const sourceFm = await readWikiPageWithFrontmatter(slug);
+  if (
+    sourceFm &&
+    isArtifactType(
+      typeof sourceFm.frontmatter.type === "string"
+        ? sourceFm.frontmatter.type
+        : undefined,
+    )
+  ) {
+    return {
+      success: true,
+      slug,
+      message: `Skipped ${slug}: HTML artifacts don't take markdown cross-references`,
+    };
   }
 
   // Read the target page to get its title

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -130,37 +130,50 @@ export async function updateRelatedPages(
     const updatedSlugs: string[] = [];
 
     for (const slug of relatedSlugs) {
-      const page = await readWikiPage(slug);
+      const page = await readWikiPageWithFrontmatter(slug);
       if (!page) continue;
+
+      // Never append markdown cross-references to an HTML artifact — its body is
+      // a self-contained document, and the "See also" markdown would render as
+      // literal text below it.
+      if (
+        isArtifactType(
+          typeof page.frontmatter.type === "string"
+            ? page.frontmatter.type
+            : undefined,
+        )
+      ) {
+        continue;
+      }
 
       // Skip if already links to the new page (use proper link detection
       // rather than substring matching to avoid false positives when the slug
       // appears in prose without being a wiki link).
-      if (hasLinkTo(page.content, newSlug)) continue;
+      if (hasLinkTo(page.body, newSlug)) continue;
 
       const link = `[${newTitle}](${newSlug}.md)`;
       let updatedContent: string;
 
       // Check if there's already a "See also" section
       const seeAlsoPattern = /^(\*\*See also:\*\*.*)$/m;
-      const seeAlsoMatch = page.content.match(seeAlsoPattern);
+      const seeAlsoMatch = page.body.match(seeAlsoPattern);
 
       if (seeAlsoMatch) {
         // Append to existing "See also" line
-        updatedContent = page.content.replace(
+        updatedContent = page.body.replace(
           seeAlsoPattern,
           `${seeAlsoMatch[1]}, ${link}`,
         );
       } else {
         // Add a new "See also" section at the end
-        updatedContent = `${page.content.trimEnd()}\n\n**See also:** ${link}\n`;
+        updatedContent = `${page.body.trimEnd()}\n\n**See also:** ${link}\n`;
       }
 
       await writeWikiPage(slug, updatedContent);
       // Keep the backlink index consistent with the new outbound "See also"
       // link — writeWikiPage doesn't, so without this the index goes stale and
       // findBacklinks (which trusts the index) would never surface this edge.
-      await syncBacklinksForPage(slug, updatedContent, page.content);
+      await syncBacklinksForPage(slug, updatedContent, page.body);
       updatedSlugs.push(slug);
     }
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -130,50 +130,55 @@ export async function updateRelatedPages(
     const updatedSlugs: string[] = [];
 
     for (const slug of relatedSlugs) {
-      const page = await readWikiPageWithFrontmatter(slug);
-      if (!page) continue;
-
       // Never append markdown cross-references to an HTML artifact — its body is
       // a self-contained document, and the "See also" markdown would render as
-      // literal text below it.
+      // literal text below it. (Read frontmatter only for this type check.)
+      const meta = await readWikiPageWithFrontmatter(slug);
       if (
+        meta &&
         isArtifactType(
-          typeof page.frontmatter.type === "string"
-            ? page.frontmatter.type
+          typeof meta.frontmatter.type === "string"
+            ? meta.frontmatter.type
             : undefined,
         )
       ) {
         continue;
       }
 
+      // Operate on the FULL file content (frontmatter + body) so the write-back
+      // preserves the frontmatter block — writeWikiPage writes verbatim, and
+      // `readWikiPageWithFrontmatter.body` would have stripped the frontmatter.
+      const page = await readWikiPage(slug);
+      if (!page) continue;
+
       // Skip if already links to the new page (use proper link detection
       // rather than substring matching to avoid false positives when the slug
       // appears in prose without being a wiki link).
-      if (hasLinkTo(page.body, newSlug)) continue;
+      if (hasLinkTo(page.content, newSlug)) continue;
 
       const link = `[${newTitle}](${newSlug}.md)`;
       let updatedContent: string;
 
       // Check if there's already a "See also" section
       const seeAlsoPattern = /^(\*\*See also:\*\*.*)$/m;
-      const seeAlsoMatch = page.body.match(seeAlsoPattern);
+      const seeAlsoMatch = page.content.match(seeAlsoPattern);
 
       if (seeAlsoMatch) {
         // Append to existing "See also" line
-        updatedContent = page.body.replace(
+        updatedContent = page.content.replace(
           seeAlsoPattern,
           `${seeAlsoMatch[1]}, ${link}`,
         );
       } else {
         // Add a new "See also" section at the end
-        updatedContent = `${page.body.trimEnd()}\n\n**See also:** ${link}\n`;
+        updatedContent = `${page.content.trimEnd()}\n\n**See also:** ${link}\n`;
       }
 
       await writeWikiPage(slug, updatedContent);
       // Keep the backlink index consistent with the new outbound "See also"
       // link — writeWikiPage doesn't, so without this the index goes stale and
       // findBacklinks (which trusts the index) would never surface this edge.
-      await syncBacklinksForPage(slug, updatedContent, page.body);
+      await syncBacklinksForPage(slug, updatedContent, page.content);
       updatedSlugs.push(slug);
     }
 


### PR DESCRIPTION
Three issues surfaced by `about-poke`.

## 1. `## Related` markdown leaked into the rendered artifact
The cross-reference appenders add a markdown "See also"/"## Related" block to a *linked* page's body. For an HTML artifact that body is a self-contained document, so the markdown rendered as **literal text** below the artifact.
- **Guard both appenders** (`updateRelatedPages`, lint-fix's `fixMissingCrossRef`) to skip HTML artifacts.
- **Defensively truncate** anything after `</html>` in `composeSrcDoc` — this also cleans **already-corrupted** artifacts at render time (no migration needed).

## 2. Inline view still had a scrollbar
An "app-style" artifact (full-viewport `100vh` layout) made the auto-sizing iframe feedback-loop to absurd heights → a long page with a scrollbar. Now detect viewport units (`usesViewportUnits`) and give such artifacts a **fixed, scroll-hidden frame** (`80vh` inline, full viewport in the `/share` view) instead of auto-height. Document-style artifacts keep auto-height (no scrollbar, natural flow).

## 3. "@lint-fix" / "@system" shown as contributors
Non-human automation authors aren't people. Per your call, **fold them into the agent ("yoyo")**: `normalizeActor` maps `system`/`lint-fix`/`yopedia` → `yoyo` in the contributor activity scan, and `isRealContributor` excludes their raw handles from any stale precomputed index. So the list reads as the real people + the agent. (The deployed contributor index self-heals on its next rebuild; until then the raw handles are filtered out.)

## Verification
- `pnpm build` clean; lint clean; `pnpm test` green (2890, +new): `usesViewportUnits`, the post-`</html>` strip, `normalizeActor`/`isAutomationActor`, and the contributor folding (system/lint-fix → yoyo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)