### PR TITLE
Add a YouTube tab to /ingest

### DIFF
--- a/src/app/ingest/page.tsx
+++ b/src/app/ingest/page.tsx
@@ -6,15 +6,26 @@ import { IngestReview } from "@/components/IngestReview";
 import { IngestStepper } from "@/components/IngestStepper";
 import { IngestSynthesis } from "@/components/IngestSynthesis";
 import { Icon } from "@/components/folio/icons";
-import { useIngest, type Mode } from "@/hooks/useIngest";
+import { useIngest, isUrlMode, type Mode } from "@/hooks/useIngest";
 
 const TABS: { mode: Mode; label: string }[] = [
   { mode: "url", label: "URL" },
   { mode: "pdf", label: "PDF" },
   { mode: "xpost", label: "X post" },
+  { mode: "youtube", label: "YouTube" },
   { mode: "text", label: "Paste text" },
   { mode: "image", label: "Image" },
 ];
+
+/** Per-URL-mode input hints. */
+const URL_HINTS: Partial<Record<Mode, { placeholder: string; label: string }>> = {
+  xpost: { placeholder: "https://x.com/user/status/…", label: "X post URL" },
+  youtube: {
+    placeholder: "https://youtube.com/watch?v=…",
+    label: "YouTube video URL",
+  },
+  url: { placeholder: "https://example.com/article", label: "Source URL" },
+};
 
 const FEATURES: [string, string][] = [
   ["One canonical page", "duplicate sources merge, never fork"],
@@ -150,8 +161,8 @@ export default function IngestPage() {
             })}
           </div>
 
-          {/* URL / X post: one inline input + Ingest button */}
-          {(mode === "url" || mode === "xpost") && (
+          {/* URL / X post / YouTube: one inline input + Ingest button */}
+          {isUrlMode(mode) && (
             <form onSubmit={handleSourceSubmit}>
               <div
                 className="row"
@@ -170,12 +181,8 @@ export default function IngestPage() {
                   value={url}
                   onChange={(e) => setUrl(e.target.value)}
                   required
-                  placeholder={
-                    mode === "xpost"
-                      ? "https://x.com/user/status/…"
-                      : "https://example.com/article"
-                  }
-                  aria-label={mode === "xpost" ? "X post URL" : "Source URL"}
+                  placeholder={(URL_HINTS[mode] ?? URL_HINTS.url)!.placeholder}
+                  aria-label={(URL_HINTS[mode] ?? URL_HINTS.url)!.label}
                   style={{
                     flex: 1,
                     minWidth: 0,
@@ -196,6 +203,11 @@ export default function IngestPage() {
                   Ingest <Icon.arrow width="16" height="16" />
                 </button>
               </div>
+              {mode === "youtube" && (
+                <p className="mt-2 text-xs text-foreground/40">
+                  Pulls the video&apos;s transcript + metadata into a cited page.
+                </p>
+              )}
               {error && (
                 <Alert variant="error" className="mt-4">
                   {error}

--- a/src/hooks/useIngest.ts
+++ b/src/hooks/useIngest.ts
@@ -4,8 +4,14 @@ import { useState } from "react";
 import type { PreviewData } from "@/components/IngestReview";
 import type { IngestPreviewMeta } from "@/lib/types";
 
-export type Mode = "url" | "pdf" | "xpost" | "text" | "image" | "batch";
+export type Mode = "url" | "pdf" | "xpost" | "youtube" | "text" | "image" | "batch";
 export type Stage = "form" | "synthesis" | "review" | "success";
+
+/** Modes whose source is a single URL (routed through the same /api/ingest URL
+ *  path — the backend auto-detects X posts and YouTube videos by their URL). */
+export function isUrlMode(m: Mode): boolean {
+  return m === "url" || m === "xpost" || m === "youtube";
+}
 
 export interface IngestResponse {
   rawPath: string;
@@ -61,7 +67,7 @@ export function validateIngestInput(
   content: string,
   url: string,
 ): string | null {
-  if (mode === "url" || mode === "xpost") {
+  if (isUrlMode(mode)) {
     if (!url.trim()) {
       return "Please enter a URL";
     }
@@ -106,7 +112,7 @@ export function useIngest(): UseIngestReturn {
       setTitle("");
       setContent("");
     }
-    if (newMode !== "url" && newMode !== "xpost") {
+    if (!isUrlMode(newMode)) {
       setUrl("");
     }
     if (newMode !== "image") {
@@ -136,7 +142,7 @@ export function useIngest(): UseIngestReturn {
     setStage("synthesis");
 
     try {
-      const usesUrl = mode === "url" || mode === "xpost";
+      const usesUrl = isUrlMode(mode);
       const body = usesUrl
         ? { url: url.trim(), preview: true }
         : { title, content, preview: true };

--- a/src/lib/__tests__/ingest-helpers.test.ts
+++ b/src/lib/__tests__/ingest-helpers.test.ts
@@ -33,6 +33,20 @@ describe("validateIngestInput", () => {
     ).toBeNull();
   });
 
+  // ── YouTube mode (a URL mode — must validate a URL, not fall to text) ──
+
+  it("youtube mode with empty URL → 'Please enter a URL'", () => {
+    expect(validateIngestInput("youtube", "", "", "")).toBe(
+      "Please enter a URL",
+    );
+  });
+
+  it("youtube mode with a valid URL → null", () => {
+    expect(
+      validateIngestInput("youtube", "", "", "https://youtube.com/watch?v=abc"),
+    ).toBeNull();
+  });
+
   // ── Text mode ─────────────────────────────────────────────────────────
 
   it("text mode with empty title → null (title is optional, derived from content)", () => {


### PR DESCRIPTION
YouTube ingestion (from #361) was wired **backend-only** — `ingestUrl` auto-detects a YouTube URL (`isYouTubeUrl`) and pulls the transcript — so it was undiscoverable in the UI (the tabs were URL · PDF · X post · Paste text · Image).

Adds a dedicated **YouTube** tab next to X post. It routes a YouTube URL through the same `/api/ingest` URL path (the backend already detects + transcribes it), so **no backend change** — just UI wiring + a placeholder/hint. Extracted `isUrlMode()` to share the URL-mode branching across the hook + page.

`pnpm build` clean; lint clean.

> Note: transcript fetching needs the `YOUTUBE_TRANSCRIPT_API_KEY` (Supadata) secret set on the Worker, or the free scraper fallback (often blocked from Cloudflare IPs) will fail. See the chat for cost details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)