### PR TITLE
Fix YouTube transcript: Supadata uses x-api-key, not Bearer

### DIFF
--- a/src/lib/__tests__/youtube.test.ts
+++ b/src/lib/__tests__/youtube.test.ts
@@ -228,6 +228,12 @@ describe("fetchYouTubeTranscript", () => {
       segments: [{ text: "API transcript", offset: 0, duration: 4000 }],
       language: "en",
     });
+    // Supadata authenticates via `x-api-key`, NOT Authorization: Bearer —
+    // the wrong header 401s and silently degrades to a metadata-only page.
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("api.supadata.ai"),
+      expect.objectContaining({ headers: { "x-api-key": "test-key" } }),
+    );
   });
 
   it("returns null when both library and API fail", async () => {

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -149,7 +149,9 @@ async function fetchTranscriptViaApi(
   try {
     const res = await fetch(
       `https://api.supadata.ai/v1/youtube/transcript?videoId=${videoId}&text=true`,
-      { headers: { Authorization: `Bearer ${apiKey}` } },
+      // Supadata authenticates with an `x-api-key` header (NOT Authorization:
+      // Bearer) — the wrong header 401s and silently yields a metadata-only page.
+      { headers: { "x-api-key": apiKey } },
     );
 
     if (!res.ok) {


### PR DESCRIPTION
**Why YouTube ingests came back metadata-only:** the Supadata transcript fallback authenticated with `Authorization: Bearer <key>`, but [Supadata's API](https://docs.supadata.ai/youtube/get-transcript) requires an **`x-api-key`** header. So even with `YOUTUBE_TRANSCRIPT_API_KEY` set, every call 401'd → `fetchYouTubeTranscript` returned null → the page fell back to "*Captions are unavailable… based on video metadata only.*".

Fix: send `x-api-key: <key>`. Added a header assertion to the fallback test — the existing test mocked `fetch` to return ok regardless of headers, which is exactly why the wrong header slipped through.

`pnpm build` clean; `pnpm test` green (2903).

> After merge+deploy: re-ingest a YouTube video with captions and the transcript should come through (assuming the Supadata key is set on the Worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)