### PR TITLE
Async YouTube ingestion via the task queue (job-status feedback)

### DIFF
--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { ingest, ingestUrl } from "@/lib/ingest";
 import type { IngestOptions } from "@/lib/ingest";
 import { isUrl } from "@/lib/fetch";
+import { isYouTubeUrl } from "@/lib/youtube";
+import { enqueueTask } from "@/lib/tasks";
+import { createIngestJob, updateIngestJob } from "@/lib/ingest-jobs";
 import { getPrincipal, getServicePrincipal } from "@/lib/auth";
 import { ClientInputError, getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
@@ -86,7 +89,42 @@ export async function POST(request: NextRequest) {
 
     // URL path takes precedence
     if (url && typeof url === "string" && isUrl(url.trim())) {
-      const result = await ingestUrl(url.trim(), options);
+      const trimmedUrl = url.trim();
+
+      // YouTube transcripts are long → synchronous synthesis exceeds the Worker
+      // request budget. Enqueue the ingest and let the task-consumer process it;
+      // the client polls the job status (queued → done/failed).
+      if (isYouTubeUrl(trimmedUrl)) {
+        const jobId = crypto.randomUUID();
+        await createIngestJob({
+          jobId,
+          url: trimmedUrl,
+          owner: principal.handle,
+        });
+        const enqueued = await enqueueTask({
+          kind: "ingest",
+          url: trimmedUrl,
+          owner: options.owner,
+          author: options.author,
+          ...(options.tags && options.tags.length > 0
+            ? { tags: options.tags }
+            : {}),
+          jobId,
+        });
+        if (enqueued) {
+          return NextResponse.json({ queued: true, jobId });
+        }
+        // Off-Workers (local dev / tests): no queue — run it inline and mark the
+        // job done so the same client flow still resolves.
+        const result = await ingestUrl(trimmedUrl, options);
+        await updateIngestJob(jobId, {
+          status: "done",
+          slug: result.primarySlug,
+        });
+        return NextResponse.json(result);
+      }
+
+      const result = await ingestUrl(trimmedUrl, options);
       return NextResponse.json(result);
     }
 

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -101,16 +101,27 @@ export async function POST(request: NextRequest) {
           url: trimmedUrl,
           owner: principal.handle,
         });
-        const enqueued = await enqueueTask({
-          kind: "ingest",
-          url: trimmedUrl,
-          owner: options.owner,
-          author: options.author,
-          ...(options.tags && options.tags.length > 0
-            ? { tags: options.tags }
-            : {}),
-          jobId,
-        });
+        let enqueued: boolean;
+        try {
+          enqueued = await enqueueTask({
+            kind: "ingest",
+            url: trimmedUrl,
+            owner: options.owner,
+            author: options.author,
+            ...(options.tags && options.tags.length > 0
+              ? { tags: options.tags }
+              : {}),
+            jobId,
+          });
+        } catch (e) {
+          // Enqueue threw after the job was created → it would be orphaned at
+          // "queued"; mark it failed so it can't show "working…" forever.
+          await updateIngestJob(jobId, {
+            status: "failed",
+            error: getErrorMessage(e),
+          }).catch(() => {});
+          throw e; // surfaces as a 500 to the submitter
+        }
         if (enqueued) {
           return NextResponse.json({ queued: true, jobId });
         }

--- a/src/app/api/ingest/status/[jobId]/route.ts
+++ b/src/app/api/ingest/status/[jobId]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { getPrincipal } from "@/lib/auth";
+import { getIngestJob } from "@/lib/ingest-jobs";
+import { getErrorMessage } from "@/lib/errors";
+import { logger } from "@/lib/logger";
+
+/**
+ * GET /api/ingest/status/<jobId> — poll an async ingest job's outcome.
+ *
+ * Owner-gated: a missing job AND a job owned by someone else both return 404, so
+ * a job's existence is never leaked to a non-owner.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ jobId: string }> },
+) {
+  try {
+    const { jobId } = await params;
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    let job;
+    try {
+      job = await getIngestJob(jobId);
+    } catch {
+      // Malformed jobId (relPathFor throws) → treat as not found.
+      job = null;
+    }
+    if (!job || job.owner !== principal.handle) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      status: job.status,
+      slug: job.slug,
+      error: job.error,
+      url: job.url,
+      title: job.title,
+    });
+  } catch (err) {
+    logger.error("ingest", "ingest status error", err);
+    return NextResponse.json({ error: getErrorMessage(err) }, { status: 500 });
+  }
+}

--- a/src/app/api/ingest/status/[jobId]/route.ts
+++ b/src/app/api/ingest/status/[jobId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getPrincipal } from "@/lib/auth";
-import { getIngestJob } from "@/lib/ingest-jobs";
+import { getIngestJob, effectiveStatus } from "@/lib/ingest-jobs";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 
@@ -24,18 +24,24 @@ export async function GET(
     let job;
     try {
       job = await getIngestJob(jobId);
-    } catch {
-      // Malformed jobId (relPathFor throws) → treat as not found.
-      job = null;
+    } catch (e) {
+      // A malformed jobId (relPathFor throws) → 404; a real storage error must
+      // NOT be masked as 404 — rethrow it to the 500 handler below.
+      if (/invalid ingest job id/i.test(getErrorMessage(e))) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      throw e;
     }
     if (!job || job.owner !== principal.handle) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
+    // A stalled (dead-worker) job reads as failed so the UI stops waiting on it.
+    const eff = effectiveStatus(job);
     return NextResponse.json({
-      status: job.status,
+      status: eff.status,
       slug: job.slug,
-      error: job.error,
+      error: eff.error ?? job.error,
       url: job.url,
       title: job.title,
     });

--- a/src/app/api/tasks/run/route.ts
+++ b/src/app/api/tasks/run/route.ts
@@ -111,9 +111,19 @@ export async function POST(req: Request) {
   } catch (err) {
     const message = getErrorMessage(err);
     // Record the failure on a tracked async job so the user sees the reason
-    // (a later retry that succeeds will overwrite this back to "done").
+    // (a later retry that succeeds will overwrite this back to "done"). Guarded:
+    // a storage error here must not mask the original failure or skip the
+    // status mapping below.
     if (task.kind === "ingest" && task.jobId) {
-      await updateIngestJob(task.jobId, { status: "failed", error: message });
+      try {
+        await updateIngestJob(task.jobId, { status: "failed", error: message });
+      } catch (writeErr) {
+        logger.error(
+          "tasks",
+          `failed to record ingest job ${task.jobId} failure`,
+          writeErr,
+        );
+      }
     }
     // A missing page/thread is permanent → poison (4xx), don't retry forever.
     if (/not found/i.test(message)) {

--- a/src/app/api/tasks/run/route.ts
+++ b/src/app/api/tasks/run/route.ts
@@ -4,6 +4,7 @@ import { parseTask } from "@/lib/tasks";
 import { reconcileFromTalk } from "@/lib/reconcile";
 import { ingest, ingestUrl, reingest } from "@/lib/ingest";
 import { fixLintIssue } from "@/lib/lint-fix";
+import { updateIngestJob } from "@/lib/ingest-jobs";
 import { agentIdFor, DEFAULT_AGENT_NAME } from "@/lib/agents";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
@@ -95,12 +96,25 @@ export async function POST(req: Request) {
       ...(task.author ? { author: task.author, triggeredBy: task.author } : {}),
       ...(task.tags && task.tags.length > 0 ? { tags: task.tags } : {}),
     };
+    // For a tracked async job, record progress so the UI can poll the outcome.
+    if (task.jobId) await updateIngestJob(task.jobId, { status: "processing" });
     const result = task.url
       ? await ingestUrl(task.url, opts)
       : await ingest(task.title?.trim() || "Untitled", task.content ?? "", opts);
+    if (task.jobId) {
+      await updateIngestJob(task.jobId, {
+        status: "done",
+        slug: result.primarySlug,
+      });
+    }
     return NextResponse.json({ ok: true, slug: result.primarySlug });
   } catch (err) {
     const message = getErrorMessage(err);
+    // Record the failure on a tracked async job so the user sees the reason
+    // (a later retry that succeeds will overwrite this back to "done").
+    if (task.kind === "ingest" && task.jobId) {
+      await updateIngestJob(task.jobId, { status: "failed", error: message });
+    }
     // A missing page/thread is permanent → poison (4xx), don't retry forever.
     if (/not found/i.test(message)) {
       logger.warn("tasks", `task "${task.kind}" permanently failed: ${message}`);

--- a/src/app/ingest/page.tsx
+++ b/src/app/ingest/page.tsx
@@ -5,6 +5,7 @@ import { IngestSuccess } from "@/components/IngestSuccess";
 import { IngestReview } from "@/components/IngestReview";
 import { IngestStepper } from "@/components/IngestStepper";
 import { IngestSynthesis } from "@/components/IngestSynthesis";
+import { RecentIngests } from "@/components/RecentIngests";
 import { Icon } from "@/components/folio/icons";
 import { useIngest, isUrlMode, type Mode } from "@/hooks/useIngest";
 
@@ -76,7 +77,7 @@ export default function IngestPage() {
   }
 
   const currentStep: 1 | 2 | 3 =
-    stage === "review" ? 3 : stage === "synthesis" ? 2 : 1;
+    stage === "review" ? 3 : stage === "synthesis" || stage === "queued" ? 2 : 1;
   const sourceLabel =
     mode === "text"
       ? title.trim() || "your text"
@@ -120,6 +121,25 @@ export default function IngestPage() {
 
       {/* Step 2: synthesis */}
       {stage === "synthesis" && <IngestSynthesis sourceLabel={sourceLabel} />}
+
+      {/* Step 2 (async): a slow source (YouTube) was queued for background work. */}
+      {stage === "queued" && (
+        <div style={{ marginTop: 28 }}>
+          <p style={{ fontSize: 18, fontWeight: 600, color: "var(--ink)", margin: 0 }}>
+            Ingestion job sent.
+          </p>
+          <p style={{ marginTop: 8, color: "var(--muted)", maxWidth: "48ch" }}>
+            Your page is being built in the background — this can take a minute
+            for a long video. It&apos;ll appear here when it&apos;s ready. You can
+            leave this page; the outcome shows under <strong>Recent ingests</strong>.
+          </p>
+          {error && (
+            <Alert variant="error" className="mt-4">
+              {error}
+            </Alert>
+          )}
+        </div>
+      )}
 
       {/* Step 3: review */}
       {stage === "review" && preview && (
@@ -405,6 +425,8 @@ export default function IngestPage() {
               </div>
             ))}
           </div>
+
+          <RecentIngests />
         </>
       )}
     </main>

--- a/src/components/RecentIngests.tsx
+++ b/src/components/RecentIngests.tsx
@@ -32,6 +32,7 @@ export function RecentIngests() {
   useEffect(() => {
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let refreshes = 0;
 
     async function load() {
       const ids = getRecentJobIds();
@@ -53,8 +54,14 @@ export function RecentIngests() {
       if (cancelled) return;
       const live = results.filter((j): j is JobView => j !== null);
       setJobs(live);
-      // Keep refreshing while anything is still in flight.
-      if (live.some((j) => j.status === "queued" || j.status === "processing")) {
+      // Keep refreshing while anything is still in flight, with a hard cap
+      // (~6min) so a stuck job can't drive an endless background refresh. The
+      // server also ages a stalled job to `failed`, so this rarely matters.
+      refreshes += 1;
+      if (
+        refreshes < 90 &&
+        live.some((j) => j.status === "queued" || j.status === "processing")
+      ) {
         timer = setTimeout(load, 4000);
       }
     }

--- a/src/components/RecentIngests.tsx
+++ b/src/components/RecentIngests.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { getRecentJobIds } from "@/lib/recent-ingests";
+import { commonsPath } from "@/lib/links";
+
+interface JobView {
+  jobId: string;
+  status: "queued" | "processing" | "done" | "failed";
+  slug?: string;
+  error?: string;
+  url?: string;
+  title?: string;
+}
+
+const LABEL: Record<JobView["status"], { text: string; color: string }> = {
+  queued: { text: "queued", color: "var(--muted)" },
+  processing: { text: "working…", color: "var(--accent)" },
+  done: { text: "done", color: "var(--accent)" },
+  failed: { text: "failed", color: "var(--rust)" },
+};
+
+/**
+ * The recently-submitted async ingest jobs (from localStorage), each with its
+ * live status — so a user can see whether a queued ingest finished or failed,
+ * even after navigating away or reloading.
+ */
+export function RecentIngests() {
+  const [jobs, setJobs] = useState<JobView[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    async function load() {
+      const ids = getRecentJobIds();
+      if (ids.length === 0) {
+        if (!cancelled) setJobs([]);
+        return;
+      }
+      const results = await Promise.all(
+        ids.map(async (id): Promise<JobView | null> => {
+          try {
+            const res = await fetch(`/api/ingest/status/${id}`);
+            if (!res.ok) return null; // gone / not owner — drop quietly
+            return { jobId: id, ...(await res.json()) };
+          } catch {
+            return null;
+          }
+        }),
+      );
+      if (cancelled) return;
+      const live = results.filter((j): j is JobView => j !== null);
+      setJobs(live);
+      // Keep refreshing while anything is still in flight.
+      if (live.some((j) => j.status === "queued" || j.status === "processing")) {
+        timer = setTimeout(load, 4000);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  if (jobs.length === 0) return null;
+
+  return (
+    <section style={{ marginTop: 36, paddingTop: 24, borderTop: "1px solid var(--rule)" }}>
+      <p className="fmark" style={{ marginBottom: 12 }}>
+        Recent ingests
+      </p>
+      <ul className="stack" style={{ gap: 9, listStyle: "none", margin: 0, padding: 0 }}>
+        {jobs.map((j) => {
+          const label = LABEL[j.status];
+          return (
+            <li
+              key={j.jobId}
+              className="row"
+              style={{ gap: 10, alignItems: "baseline", flexWrap: "wrap" }}
+            >
+              <span
+                className="receipt"
+                style={{ fontSize: 11, color: label.color, minWidth: 60 }}
+              >
+                {label.text}
+              </span>
+              {j.status === "done" && j.slug ? (
+                <Link href={commonsPath(j.slug)} style={{ color: "var(--accent)", fontSize: 13.5 }}>
+                  {j.title || j.slug}
+                </Link>
+              ) : (
+                <span style={{ fontSize: 13.5, color: "var(--ink-2)", wordBreak: "break-all" }}>
+                  {j.title || j.url || j.jobId}
+                </span>
+              )}
+              {j.status === "failed" && j.error && (
+                <span className="receipt" style={{ fontSize: 11.5, color: "var(--rust)" }}>
+                  {j.error}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/hooks/useIngest.ts
+++ b/src/hooks/useIngest.ts
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import type { PreviewData } from "@/components/IngestReview";
 import type { IngestPreviewMeta } from "@/lib/types";
+import { rememberRecentJob } from "@/lib/recent-ingests";
 
 export type Mode = "url" | "pdf" | "xpost" | "youtube" | "text" | "image" | "batch";
-export type Stage = "form" | "synthesis" | "review" | "success";
+/** `queued` = an async job (YouTube) was accepted; the page polls its status. */
+export type Stage = "form" | "synthesis" | "review" | "success" | "queued";
 
 /** Modes whose source is a single URL (routed through the same /api/ingest URL
  *  path — the backend auto-detects X posts and YouTube videos by their URL). */
@@ -23,6 +25,9 @@ export interface IngestResponse {
   preview?: IngestPreviewMeta;
   sourceContent?: string;
   error?: string;
+  /** Async path (YouTube): the ingest was queued; poll `/api/ingest/status`. */
+  queued?: boolean;
+  jobId?: string;
 }
 
 export interface UseIngestReturn {
@@ -103,6 +108,54 @@ export function useIngest(): UseIngestReturn {
   const [result, setResult] = useState<IngestResponse | null>(null);
   const [preview, setPreview] = useState<PreviewData | null>(null);
 
+  // Poll handle for an async (queued) ingest; cleared on terminal state/unmount.
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  function stopPolling() {
+    if (pollRef.current) clearTimeout(pollRef.current);
+    pollRef.current = null;
+  }
+  useEffect(() => stopPolling, []);
+
+  /** Poll an async ingest job until it's done/failed (or a ~5min cap). */
+  function startPolling(jobId: string) {
+    stopPolling();
+    let tries = 0;
+    const tick = async () => {
+      tries += 1;
+      try {
+        const res = await fetch(`/api/ingest/status/${jobId}`);
+        if (res.ok) {
+          const data = await res.json();
+          if (data.status === "done" && data.slug) {
+            setResult({
+              rawPath: "",
+              primarySlug: data.slug,
+              relatedUpdated: [],
+              wikiPages: [],
+              indexUpdated: true,
+            });
+            setStage("success");
+            return;
+          }
+          if (data.status === "failed") {
+            setError(data.error || "Ingestion failed");
+            setStage("form");
+            return;
+          }
+        }
+      } catch {
+        // Transient network blip — keep polling.
+      }
+      if (tries >= 100) {
+        setError("Still processing — check Recent ingests in a moment.");
+        setStage("form");
+        return;
+      }
+      pollRef.current = setTimeout(tick, 3000);
+    };
+    pollRef.current = setTimeout(tick, 2000);
+  }
+
   function switchMode(newMode: Mode) {
     setMode(newMode);
     setError(null);
@@ -158,6 +211,15 @@ export function useIngest(): UseIngestReturn {
       if (!res.ok) {
         setError(data.error || "Something went wrong");
         setStage("form");
+        return;
+      }
+
+      // Async path (YouTube): the ingest was queued — remember it and poll the
+      // job status instead of showing a synchronous preview/review.
+      if (data.queued && data.jobId) {
+        rememberRecentJob(data.jobId);
+        setStage("queued");
+        startPolling(data.jobId);
         return;
       }
 
@@ -383,6 +445,7 @@ export function useIngest(): UseIngestReturn {
   }
 
   function reset() {
+    stopPolling();
     setTitle("");
     setContent("");
     setUrl("");

--- a/src/lib/__tests__/ingest-jobs.test.ts
+++ b/src/lib/__tests__/ingest-jobs.test.ts
@@ -6,6 +6,8 @@ import {
   createIngestJob,
   getIngestJob,
   updateIngestJob,
+  effectiveStatus,
+  INGEST_JOB_STALE_MS,
 } from "../ingest-jobs";
 import { _resetStorage } from "../storage";
 
@@ -64,5 +66,30 @@ describe("ingest-jobs", () => {
 
   it("rejects a path-traversing job id", async () => {
     await expect(getIngestJob("../secrets")).rejects.toThrow(/invalid ingest job id/);
+  });
+});
+
+describe("effectiveStatus (stale detection)", () => {
+  const iso = (msAgo: number) => new Date(Date.now() - msAgo).toISOString();
+
+  it("ages a long-stuck processing job to failed", () => {
+    const eff = effectiveStatus({ status: "processing", updatedAt: iso(INGEST_JOB_STALE_MS + 1000) });
+    expect(eff.status).toBe("failed");
+    expect(eff.error).toMatch(/stalled/i);
+  });
+
+  it("leaves a recently-updated processing job alone", () => {
+    expect(effectiveStatus({ status: "processing", updatedAt: iso(1000) })).toEqual({
+      status: "processing",
+    });
+  });
+
+  it("never overrides a terminal status", () => {
+    expect(effectiveStatus({ status: "done", updatedAt: iso(INGEST_JOB_STALE_MS * 10) })).toEqual({
+      status: "done",
+    });
+    expect(effectiveStatus({ status: "failed", updatedAt: iso(INGEST_JOB_STALE_MS * 10) })).toEqual({
+      status: "failed",
+    });
   });
 });

--- a/src/lib/__tests__/ingest-jobs.test.ts
+++ b/src/lib/__tests__/ingest-jobs.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  createIngestJob,
+  getIngestJob,
+  updateIngestJob,
+} from "../ingest-jobs";
+import { _resetStorage } from "../storage";
+
+let tmpDir: string;
+let originalDataDir: string | undefined;
+let originalWikiDir: string | undefined;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ingest-jobs-test-"));
+  originalDataDir = process.env.DATA_DIR;
+  originalWikiDir = process.env.WIKI_DIR;
+  process.env.DATA_DIR = tmpDir;
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  _resetStorage();
+});
+
+afterEach(async () => {
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+  if (originalWikiDir === undefined) delete process.env.WIKI_DIR;
+  else process.env.WIKI_DIR = originalWikiDir;
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("ingest-jobs", () => {
+  it("create → get round-trips a queued job", async () => {
+    await createIngestJob({ jobId: "abc-123", url: "https://youtu.be/x", owner: "alice" });
+    const job = await getIngestJob("abc-123");
+    expect(job).toMatchObject({
+      jobId: "abc-123",
+      url: "https://youtu.be/x",
+      owner: "alice",
+      status: "queued",
+    });
+    expect(job!.createdAt).toBeTruthy();
+  });
+
+  it("update merges a patch and re-stamps updatedAt", async () => {
+    await createIngestJob({ jobId: "j1", url: "u", owner: "alice" });
+    const done = await updateIngestJob("j1", { status: "done", slug: "my-page" });
+    expect(done).toMatchObject({ status: "done", slug: "my-page", owner: "alice" });
+    const reread = await getIngestJob("j1");
+    expect(reread!.status).toBe("done");
+    expect(reread!.slug).toBe("my-page");
+  });
+
+  it("get returns null for a missing job", async () => {
+    expect(await getIngestJob("nope")).toBeNull();
+  });
+
+  it("update is a no-op (null) for a missing job — never resurrects it", async () => {
+    expect(await updateIngestJob("ghost", { status: "failed", error: "x" })).toBeNull();
+    expect(await getIngestJob("ghost")).toBeNull();
+  });
+
+  it("rejects a path-traversing job id", async () => {
+    await expect(getIngestJob("../secrets")).rejects.toThrow(/invalid ingest job id/);
+  });
+});

--- a/src/lib/__tests__/ingest-routes.test.ts
+++ b/src/lib/__tests__/ingest-routes.test.ts
@@ -30,8 +30,17 @@ vi.mock("@/lib/auth", () => ({
 // The async batch path enqueues; default to "queued" (true).
 vi.mock("@/lib/tasks", () => ({ enqueueTask: vi.fn(async () => true) }));
 
+vi.mock("@/lib/ingest-jobs", () => ({
+  createIngestJob: vi.fn(async () => ({})),
+  updateIngestJob: vi.fn(async () => ({})),
+}));
+vi.mock("@/lib/youtube", () => ({
+  isYouTubeUrl: (u: string) => /youtu\.?be|youtube\.com/i.test(u),
+}));
+
 import { ingest, ingestUrl, reingest } from "@/lib/ingest";
 import { enqueueTask } from "@/lib/tasks";
+import { createIngestJob } from "@/lib/ingest-jobs";
 import { readWikiPageWithFrontmatter } from "@/lib/wiki";
 import { getPrincipal } from "@/lib/auth";
 import { getServicePrincipal } from "@/lib/auth";
@@ -48,6 +57,7 @@ const mockedReadWikiPage = vi.mocked(readWikiPageWithFrontmatter);
 const mockedGetPrincipal = vi.mocked(getPrincipal);
 const mockedGetServicePrincipal = vi.mocked(getServicePrincipal);
 const mockedEnqueue = vi.mocked(enqueueTask);
+const mockedCreateJob = vi.mocked(createIngestJob);
 
 function makeRequest(url: string, body: unknown, token?: string): NextRequest {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
@@ -98,6 +108,42 @@ describe("POST /api/ingest — text title optional", () => {
       makeRequest("http://localhost/api/ingest", { title: "Only a title" }),
     );
     expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/ingest — YouTube goes async (queued)", () => {
+  it("enqueues a YouTube URL and returns { queued, jobId } without running ingest", async () => {
+    mockedEnqueue.mockResolvedValue(true);
+    const res = await POST(
+      makeRequest("http://localhost/api/ingest", {
+        url: "https://youtu.be/dQw4w9WgXcQ",
+        preview: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.queued).toBe(true);
+    expect(typeof data.jobId).toBe("string");
+    expect(mockedCreateJob).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://youtu.be/dQw4w9WgXcQ", owner: "test-user" }),
+    );
+    expect(mockedEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "ingest", url: "https://youtu.be/dQw4w9WgXcQ" }),
+    );
+    expect(mockedIngestUrl).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a synchronous ingest when the queue is unavailable (off-Workers)", async () => {
+    mockedEnqueue.mockResolvedValue(false);
+    mockedIngestUrl.mockResolvedValue(fakeResult);
+    const res = await POST(
+      makeRequest("http://localhost/api/ingest", {
+        url: "https://youtu.be/abc",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedIngestUrl).toHaveBeenCalled();
+    expect((await res.json()).primarySlug).toBe("test-page");
   });
 });
 

--- a/src/lib/__tests__/ingest-status-route.test.ts
+++ b/src/lib/__tests__/ingest-status-route.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("@/lib/ingest-jobs", () => ({
+vi.mock("@/lib/ingest-jobs", async (importActual) => ({
+  // Keep the real (pure) effectiveStatus; only stub the storage-backed read.
+  ...(await importActual<typeof import("@/lib/ingest-jobs")>()),
   getIngestJob: vi.fn(),
 }));
 vi.mock("@/lib/auth", () => ({
@@ -64,5 +66,21 @@ describe("GET /api/ingest/status/[jobId]", () => {
     const res = await call("j1");
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ status: "done", slug: "my-page" });
+  });
+
+  it("reports a long-stalled processing job as failed (dead worker)", async () => {
+    mockedGetJob.mockResolvedValue({
+      jobId: "j1",
+      url: "https://youtu.be/x",
+      owner: "alice",
+      status: "processing",
+      createdAt: "",
+      updatedAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+    });
+    const res = await call("j1");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("failed");
+    expect(body.error).toMatch(/stalled/i);
   });
 });

--- a/src/lib/__tests__/ingest-status-route.test.ts
+++ b/src/lib/__tests__/ingest-status-route.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/ingest-jobs", () => ({
+  getIngestJob: vi.fn(),
+}));
+vi.mock("@/lib/auth", () => ({
+  getPrincipal: vi.fn(),
+}));
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { getIngestJob } from "@/lib/ingest-jobs";
+import { getPrincipal } from "@/lib/auth";
+import { GET } from "@/app/api/ingest/status/[jobId]/route";
+
+const mockedGetJob = vi.mocked(getIngestJob);
+const mockedGetPrincipal = vi.mocked(getPrincipal);
+
+const call = (jobId: string) =>
+  GET(new Request("http://localhost/api/ingest/status/" + jobId), {
+    params: Promise.resolve({ jobId }),
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetPrincipal.mockResolvedValue({ id: "alice", handle: "alice" });
+});
+
+describe("GET /api/ingest/status/[jobId]", () => {
+  it("401 when not signed in", async () => {
+    mockedGetPrincipal.mockResolvedValueOnce(null);
+    expect((await call("j1")).status).toBe(401);
+  });
+
+  it("404 when the job is missing", async () => {
+    mockedGetJob.mockResolvedValue(null);
+    expect((await call("j1")).status).toBe(404);
+  });
+
+  it("404 when the job is owned by someone else (no existence leak)", async () => {
+    mockedGetJob.mockResolvedValue({
+      jobId: "j1",
+      url: "u",
+      owner: "bob",
+      status: "done",
+      slug: "s",
+      createdAt: "",
+      updatedAt: "",
+    });
+    expect((await call("j1")).status).toBe(404);
+  });
+
+  it("returns the status to the owner", async () => {
+    mockedGetJob.mockResolvedValue({
+      jobId: "j1",
+      url: "https://youtu.be/x",
+      owner: "alice",
+      status: "done",
+      slug: "my-page",
+      createdAt: "",
+      updatedAt: "",
+    });
+    const res = await call("j1");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: "done", slug: "my-page" });
+  });
+});

--- a/src/lib/__tests__/tasks-route.test.ts
+++ b/src/lib/__tests__/tasks-route.test.ts
@@ -8,11 +8,13 @@ vi.mock("@/lib/ingest", () => ({
   reingest: vi.fn(),
 }));
 vi.mock("@/lib/lint-fix", () => ({ fixLintIssue: vi.fn() }));
+vi.mock("@/lib/ingest-jobs", () => ({ updateIngestJob: vi.fn(async () => ({})) }));
 
 import { getServicePrincipal } from "@/lib/auth";
 import { reconcileFromTalk } from "@/lib/reconcile";
 import { ingest, ingestUrl, reingest } from "@/lib/ingest";
 import { fixLintIssue } from "@/lib/lint-fix";
+import { updateIngestJob } from "@/lib/ingest-jobs";
 
 const mockedGetService = vi.mocked(getServicePrincipal);
 const mockedReconcile = vi.mocked(reconcileFromTalk);
@@ -20,6 +22,7 @@ const mockedIngest = vi.mocked(ingest);
 const mockedIngestUrl = vi.mocked(ingestUrl);
 const mockedReingest = vi.mocked(reingest);
 const mockedFixLint = vi.mocked(fixLintIssue);
+const mockedUpdateJob = vi.mocked(updateIngestJob);
 
 async function run(body: unknown) {
   const { POST } = await import("@/app/api/tasks/run/route");
@@ -114,6 +117,46 @@ describe("POST /api/tasks/run", () => {
     const res = await run({ kind: "maintain", op: "staleness", slug: "s" });
     expect(res.status).toBe(200);
     expect(mockedReingest).toHaveBeenCalledWith("s", expect.objectContaining({ author: "yoyo" }));
+  });
+
+  it("drives a tracked ingest job processing → done on success", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedIngestUrl.mockResolvedValue({ primarySlug: "made" } as any);
+    const res = await run({
+      kind: "ingest",
+      url: "https://youtu.be/x",
+      owner: "alice",
+      jobId: "job-1",
+    });
+    expect(res.status).toBe(200);
+    expect(mockedUpdateJob).toHaveBeenNthCalledWith(1, "job-1", { status: "processing" });
+    expect(mockedUpdateJob).toHaveBeenNthCalledWith(2, "job-1", {
+      status: "done",
+      slug: "made",
+    });
+  });
+
+  it("records a tracked ingest job as failed when ingest throws", async () => {
+    mockedIngestUrl.mockRejectedValueOnce(new Error("LLM timeout"));
+    const res = await run({
+      kind: "ingest",
+      url: "https://youtu.be/x",
+      owner: "alice",
+      jobId: "job-2",
+    });
+    expect(res.status).toBe(500); // transient → retry
+    expect(mockedUpdateJob).toHaveBeenNthCalledWith(1, "job-2", { status: "processing" });
+    expect(mockedUpdateJob).toHaveBeenNthCalledWith(2, "job-2", {
+      status: "failed",
+      error: "LLM timeout",
+    });
+  });
+
+  it("leaves an untracked ingest task (no jobId) alone — no job writes", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedIngestUrl.mockResolvedValue({ primarySlug: "made" } as any);
+    await run({ kind: "ingest", url: "https://example.com", owner: "alice" });
+    expect(mockedUpdateJob).not.toHaveBeenCalled();
   });
 
   it("maps a 'not found' failure to 422 (poison), other failures to 500 (retry)", async () => {

--- a/src/lib/__tests__/tasks.test.ts
+++ b/src/lib/__tests__/tasks.test.ts
@@ -77,6 +77,16 @@ describe("parseTask", () => {
     expect(parseTask({ kind: "ingest" })).toBeNull();
   });
 
+  it("preserves a jobId on an ingest task (async status tracking)", () => {
+    expect(
+      parseTask({ kind: "ingest", url: "https://youtu.be/x", jobId: "job-1" }),
+    ).toMatchObject({ kind: "ingest", url: "https://youtu.be/x", jobId: "job-1" });
+    // No jobId → absent (not undefined-key noise).
+    expect(parseTask({ kind: "ingest", url: "https://x.com" })).not.toHaveProperty(
+      "jobId",
+    );
+  });
+
   it("accepts maintain tasks; reconcile needs a threadIndex", () => {
     expect(parseTask({ kind: "maintain", op: "staleness", slug: "p" })).toEqual({
       kind: "maintain",

--- a/src/lib/ingest-jobs.ts
+++ b/src/lib/ingest-jobs.ts
@@ -1,0 +1,93 @@
+/**
+ * Status records for ASYNC ingest jobs (currently YouTube — see the queue path
+ * in `/api/ingest`). A slow ingest is enqueued to the task queue instead of run
+ * synchronously; this lets the UI poll the outcome ("done → here's your page" /
+ * "failed → reason") rather than hanging the request. One JSON file per job under
+ * `ingest-jobs/<jobId>.json`, owner-stamped so a status read can be gated.
+ */
+
+import { getStorage } from "./storage";
+import { isEnoent } from "./errors";
+import { logger } from "./logger";
+
+export type IngestJobStatus = "queued" | "processing" | "done" | "failed";
+
+export interface IngestJob {
+  jobId: string;
+  /** The source URL being ingested. */
+  url: string;
+  /** Handle of the user who triggered it — only they may read the status. */
+  owner: string;
+  status: IngestJobStatus;
+  /** Resulting page slug, once `done`. */
+  slug?: string;
+  /** Failure reason, once `failed`. */
+  error?: string;
+  /** Display title for the recent-ingests list (best-effort). */
+  title?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** jobIds are UUIDs; reject anything else so a crafted id can't escape the prefix. */
+function relPathFor(jobId: string): string {
+  if (!/^[a-zA-Z0-9-]{1,64}$/.test(jobId)) {
+    throw new Error(`invalid ingest job id: ${jobId}`);
+  }
+  return `ingest-jobs/${jobId}.json`;
+}
+
+/** Create a job in the `queued` state. */
+export async function createIngestJob(input: {
+  jobId: string;
+  url: string;
+  owner: string;
+  title?: string;
+}): Promise<IngestJob> {
+  const now = new Date().toISOString();
+  const job: IngestJob = {
+    jobId: input.jobId,
+    url: input.url,
+    owner: input.owner,
+    title: input.title,
+    status: "queued",
+    createdAt: now,
+    updatedAt: now,
+  };
+  await getStorage().writeFile(relPathFor(input.jobId), JSON.stringify(job));
+  return job;
+}
+
+/** Read a job, or `null` if it doesn't exist. */
+export async function getIngestJob(jobId: string): Promise<IngestJob | null> {
+  try {
+    const raw = await getStorage().readFile(relPathFor(jobId));
+    return JSON.parse(raw) as IngestJob;
+  } catch (err) {
+    if (isEnoent(err)) return null;
+    throw err;
+  }
+}
+
+/**
+ * Merge a patch into an existing job and re-stamp `updatedAt`. No-op (returns
+ * `null`) if the job is gone — a status update must never resurrect or partially
+ * write a record.
+ */
+export async function updateIngestJob(
+  jobId: string,
+  patch: Partial<Pick<IngestJob, "status" | "slug" | "error" | "title">>,
+): Promise<IngestJob | null> {
+  const existing = await getIngestJob(jobId);
+  if (!existing) {
+    logger.warn("ingest-jobs", `updateIngestJob: job ${jobId} not found`);
+    return null;
+  }
+  const updated: IngestJob = {
+    ...existing,
+    ...patch,
+    updatedAt: new Date().toISOString(),
+  };
+  await getStorage().writeFile(relPathFor(jobId), JSON.stringify(updated));
+  return updated;
+}

--- a/src/lib/ingest-jobs.ts
+++ b/src/lib/ingest-jobs.ts
@@ -12,6 +12,33 @@ import { logger } from "./logger";
 
 export type IngestJobStatus = "queued" | "processing" | "done" | "failed";
 
+/**
+ * A job that's been `queued`/`processing` longer than this is treated as
+ * `failed` ON READ — the consumer worker likely died mid-run (a long video can
+ * hit the CPU limit) and would never write a terminal status, leaving the UI
+ * polling "working…" forever. Generous: well past the client's ~5min poll cap
+ * and any real ingest time, and the queue refreshes `updatedAt` on each retry,
+ * so a job actively being retried is never falsely flagged.
+ */
+export const INGEST_JOB_STALE_MS = 10 * 60 * 1000;
+
+/**
+ * The status a reader should act on: a non-terminal job that hasn't advanced in
+ * {@link INGEST_JOB_STALE_MS} is reported as `failed` (it stalled), so the UI
+ * shows a reason and stops polling instead of waiting on a dead job forever.
+ */
+export function effectiveStatus(
+  job: Pick<IngestJob, "status" | "updatedAt">,
+): { status: IngestJobStatus; error?: string } {
+  if (job.status === "queued" || job.status === "processing") {
+    const age = Date.now() - Date.parse(job.updatedAt);
+    if (Number.isFinite(age) && age > INGEST_JOB_STALE_MS) {
+      return { status: "failed", error: "This ingest stalled — please try again." };
+    }
+  }
+  return { status: job.status };
+}
+
 export interface IngestJob {
   jobId: string;
   /** The source URL being ingested. */

--- a/src/lib/recent-ingests.ts
+++ b/src/lib/recent-ingests.ts
@@ -1,0 +1,30 @@
+/**
+ * Client-side memory of recently-submitted async ingest job ids (localStorage).
+ * Lets the /ingest page show a "Recent ingests" strip — with live status fetched
+ * per id — so an outcome (done / failed) is visible even after a reload, without
+ * a server-side per-user job index.
+ */
+
+const KEY = "yopedia_recent_ingests";
+const MAX = 8;
+
+export function rememberRecentJob(jobId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const ids = [jobId, ...getRecentJobIds().filter((id) => id !== jobId)];
+    window.localStorage.setItem(KEY, JSON.stringify(ids.slice(0, MAX)));
+  } catch {
+    // localStorage unavailable (private mode / quota) — non-critical.
+  }
+}
+
+export function getRecentJobIds(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    const ids: unknown = raw ? JSON.parse(raw) : [];
+    return Array.isArray(ids) ? ids.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -40,6 +40,9 @@ export type Task =
       owner?: string;
       author?: string;
       tags?: string[];
+      /** When set, the consumer records this async job's status (queued →
+       *  processing → done/failed) so the UI can poll the outcome. */
+      jobId?: string;
     }
   | {
       /** Autonomous maintenance, enqueued by the scan cron (Q2). `reconcile` a
@@ -160,6 +163,7 @@ export function parseTask(body: unknown): Task | null {
         ...(typeof t.owner === "string" ? { owner: t.owner } : {}),
         ...(typeof t.author === "string" ? { author: t.author } : {}),
         ...(tags && tags.length > 0 ? { tags } : {}),
+        ...(typeof t.jobId === "string" ? { jobId: t.jobId } : {}),
       };
     }
     case "maintain": {


### PR DESCRIPTION
Implements the approved plan: move YouTube ingestion off the synchronous request and onto the existing backend queue, with a job-status surface so the user learns the outcome.

## Why
A real YouTube transcript is long; synthesis makes one sequential LLM call per 12k-char chunk, so it fans out into 5–8 calls and blows past the Worker request budget → the connection drops → "Network error — could not reach the server". (#527 fixed the Supadata auth so transcripts actually fetch; this fixes the resulting timeout.)

## What
- **`/api/ingest`** — a **YouTube** URL is now *enqueued* (`kind:"ingest"` + a `jobId`) instead of run inline, returning `{ queued, jobId }`. Off-Workers (local dev/tests) it falls back to a synchronous run so nothing breaks. All other sources (URL/X/PDF/image/text) keep their fast sync preview→review flow.
- **`task-consumer`** already drains the queue → `/api/tasks/run` → `ingestUrl` (handles YouTube). The run route now records job status (`processing → done/failed`) around the ingest.
- **New `src/lib/ingest-jobs.ts`** — one owner-stamped JSON record per job; **`GET /api/ingest/status/<jobId>`** is owner-gated (404 for missing **or** not-owner — no existence leak).
- **UI** — a `queued` stage ("Ingestion job sent — your page will be ready soon") that polls the status → success (link to the page) or failure (the reason). Plus a **Recent ingests** strip (localStorage jobIds + live status) so an outcome is visible even after a reload.

## Error visibility (the asked-for concern)
Live poll on the page **+** durable job record **+** the Recent-ingests strip. The queue retries transient failures **3× then DLQs**, and the final reason is recorded and shown — nothing silently vanishes.

## Verification
- `pnpm build` clean; lint clean; `pnpm test` green (2915, +new): the job store round-trip, `parseTask` preserves `jobId`, the status route gates non-owners (404), and `/api/ingest` enqueues a YouTube URL → `{queued, jobId}` (with the off-Workers sync fallback).
- Manual (deployed): ingest a long captioned YouTube video → immediate "job sent", page appears shortly (no timeout); a captions-disabled video → "failed" with a reason in the live poll + Recent ingests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)