### PR TITLE
Refine long-source synthesis into one article (no "(additional)" pileup)

### DIFF
--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -2569,6 +2569,43 @@ describe("ingest — chunked LLM calls", () => {
     mockedCallLLM.mockReset();
   });
 
+  it("refines long content into one article (folds chunks in, doesn't append)", async () => {
+    mockedHasLLMKey.mockReturnValue(true);
+    // Each call returns a DISTINCT full article so we can tell whether the final
+    // page is the last refinement (correct) or a concatenation of all chunks.
+    let call = 0;
+    mockedCallLLM.mockImplementation(async () => {
+      call += 1;
+      return `CONCEPT: Topic\nTAGS: t\n\n# Topic\n\n## Summary\n\nRefined v${call}.\n\n## Key Points\n\n- point ${call}`;
+    });
+
+    const longContent = Array.from(
+      { length: 300 },
+      (_, i) => `Paragraph ${i} discusses topic number ${i} in detail with enough text to be substantial.`,
+    ).join("\n\n");
+    expect(longContent.length).toBeGreaterThan(MAX_LLM_INPUT_CHARS);
+
+    const result = await ingest("Topic", longContent);
+    const calls = mockedCallLLM.mock.calls.length;
+    expect(calls).toBeGreaterThan(1);
+
+    // The 2nd call is a REFINE call: it gets the prior article as "Current
+    // article", not a fresh continuation that would append a new section block.
+    expect(mockedCallLLM.mock.calls[1][0]).toMatch(/COMPLETE, updated article/);
+    expect(mockedCallLLM.mock.calls[1][1]).toContain("# Current article");
+    expect(mockedCallLLM.mock.calls[1][1]).toContain("Refined v1");
+
+    // The persisted page is the LAST refinement only — no pile-up of every
+    // chunk's sections, and exactly one "## Key Points".
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect(page!.content).toContain(`Refined v${calls}`);
+    expect(page!.content).not.toContain("Refined v1");
+    expect(page!.content.match(/## Key Points/g) ?? []).toHaveLength(1);
+
+    mockedHasLLMKey.mockReturnValue(false);
+    mockedCallLLM.mockReset();
+  });
+
   it("calls LLM exactly once for short content", async () => {
     mockedHasLLMKey.mockReturnValue(true);
     mockedCallLLM.mockResolvedValue("# Short Page\n\n## Summary\n\nBrief.");

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -1399,11 +1399,14 @@ export async function ingest(
       wikiContent = await callLLM(systemPrompt, chunks[0], llmOptions);
 
       for (let i = 1; i < chunks.length; i++) {
-        wikiContent = await callLLM(
+        const refined = await callLLM(
           REFINE_SYSTEM_PROMPT,
           `# Current article\n\n${wikiContent}\n\n# Next part of the source (part ${i + 1} of ${chunks.length})\n\n${chunks[i]}`,
           llmOptions,
         );
+        // Refine REPLACES the whole article, so an empty/blank response would
+        // discard everything synthesized so far — keep the prior draft instead.
+        if (refined.trim()) wikiContent = refined;
       }
     }
 

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -806,18 +806,26 @@ Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. KEEP the o
 Write a focused, distilled page, not a transcript of the source. Output the CONCEPT, ALIASES, and TAGS lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
 
 /**
- * System prompt for continuation chunks when a long source document has been
- * split into multiple parts. The LLM receives the article produced so far and
- * a new batch of source material and should produce only the *additional*
- * sections — no duplicate title or summary.
+ * System prompt for refining a long source document chunk-by-chunk. When the
+ * source is too long for one call, we synthesize the first chunk into a full
+ * article, then fold each remaining chunk INTO that article with this prompt —
+ * a running "refine" rather than appending. The model returns the COMPLETE,
+ * rewritten article each step, so the page keeps ONE set of sections (no
+ * "Key Points (additional)" pileup) however many chunks the source spans.
  */
-const CONTINUATION_SYSTEM_PROMPT = `You are a wiki editor. You have already started a wiki article from earlier parts of a long source document. You are now given additional source material.
+const REFINE_SYSTEM_PROMPT = `You are a wiki editor improving a wiki article with more of its source document. You are given the CURRENT article (built from earlier parts) and the NEXT part of the same source. Fold the new material into the current article and return the COMPLETE, updated article.
 
-Add new key points, concepts, and details from the additional source material. Do NOT repeat the title, summary, or any content already in the article. Only output the new sections or bullet points to append.
+Rules:
+- Keep the three leading header lines exactly in this form, refining them only if the new material genuinely warrants it:
+CONCEPT: <canonical concept name>
+ALIASES: <comma-separated synonyms, or "none">
+TAGS: <3-6 lowercase, hyphenated topic tags, comma-separated>
+- Then the article: one \`# Title\`, then EXACTLY ONE of each \`## Summary\`, \`## Key Points\`, \`## Concepts\`, \`## Details\` — never create a second copy of a section or a "(additional)" variant. Integrate the new key points, concepts, and details into the existing sections.
+- Preserve everything already covered; add what's genuinely new from the next part; merge duplicates and resolve overlaps. Keep it distilled — summarize, don't transcribe. Update the Summary to reflect the whole article so far. Invent nothing unsupported by the source.
 
-Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. Keep genuine content images (diagrams, figures, charts, screenshots) by writing the SAME token on its own line where relevant; omit any whose image is clearly decorative/branding/UI. Never invent tokens or change their numbers.
+Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. Keep tokens already in the article and add new genuine-content ones (diagrams, figures, charts, screenshots) on their own line where relevant; omit decorative/branding/UI ones. Never invent tokens or change their numbers; output each kept token verbatim.
 
-Output pure markdown and nothing else. Do not wrap in code fences.`;
+Output the CONCEPT, ALIASES, and TAGS lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
 
 /**
  * System prompt for reconciling an existing page with a newly ingested source
@@ -1383,18 +1391,19 @@ export async function ingest(
       // Short content — single LLM call (no behaviour change)
       wikiContent = await callLLM(systemPrompt, chunks[0], llmOptions);
     } else {
-      // Long content — call LLM per chunk, merge results
-      // First chunk produces the primary page structure
+      // Long content — synthesize the first chunk into a full article, then
+      // REFINE it with each remaining chunk (fold new material into the existing
+      // sections). This keeps one coherent page with a single set of sections,
+      // instead of appending a fresh "Key Points / Concepts / Details" block per
+      // chunk (which a long transcript turned into a wall of "(additional)").
       wikiContent = await callLLM(systemPrompt, chunks[0], llmOptions);
 
-      // Subsequent chunks add supplemental content
       for (let i = 1; i < chunks.length; i++) {
-        const continuation = await callLLM(
-          CONTINUATION_SYSTEM_PROMPT,
-          `# Existing article so far\n\n${wikiContent}\n\n# Additional source material (part ${i + 1} of ${chunks.length})\n\n${chunks[i]}`,
+        wikiContent = await callLLM(
+          REFINE_SYSTEM_PROMPT,
+          `# Current article\n\n${wikiContent}\n\n# Next part of the source (part ${i + 1} of ${chunks.length})\n\n${chunks[i]}`,
           llmOptions,
         );
-        wikiContent += "\n\n" + continuation;
       }
     }
 


### PR DESCRIPTION
## Problem

Async ingest finally lets a long source (a ~2-hour podcast transcript) run to completion — and exposed an old latent bug in multi-chunk synthesis. A long transcript is split into ~12k-char chunks; the old path synthesized chunk 1 into a full article, then **appended** each remaining chunk's output as a new block. Each continuation re-emitted its own `Key Points / Concepts / Details` (the model labels the repeats "(additional)"), so an 8-chunk source produced a wall of repeated sections in the TOC.

## Fix

Replace the append-continuation loop with a running **refine**: synthesize chunk 1, then fold each remaining chunk *into* that article — the model returns the COMPLETE rewritten article each step (`REFINE_SYSTEM_PROMPT`). Same number of LLM calls, but the page keeps **exactly one** of each `Summary / Key Points / Concepts / Details` no matter how many chunks the source spans.

- The refine prompt preserves the leading `CONCEPT: / ALIASES: / TAGS:` marker lines, so slug / alias / tag derivation downstream is unchanged.
- Short (single-chunk) content path is untouched.

## Trade-off

Each refine step rewrites the whole (distilled) article, so a long source uses somewhat more output tokens/time than blind appending — the necessary cost of a coherent page. Input per step is the running article (a summary, bounded) plus one raw chunk.

## Tests

- New: long content asserts the 2nd call is a refine (receives the prior article as `# Current article`) and the persisted page is the **last** refinement only — one `## Key Points`, no concatenation of every chunk.
- Existing multi-chunk / single-chunk call-count tests still pass.

Verified: `pnpm build` clean · 2923 tests pass · lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)