### PR TITLE
Fix two stale-display bugs in the activity / recent feeds

### DIFF
--- a/src/app/api/ingest/status/[jobId]/route.ts
+++ b/src/app/api/ingest/status/[jobId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getPrincipal } from "@/lib/auth";
 import { getIngestJob, effectiveStatus } from "@/lib/ingest-jobs";
+import { readWikiPage } from "@/lib/wiki";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 
@@ -38,6 +39,14 @@ export async function GET(
 
     // A stalled (dead-worker) job reads as failed so the UI stops waiting on it.
     const eff = effectiveStatus(job);
+
+    // The job record outlives its page: if a completed page was later deleted,
+    // the "Recent ingests" strip would show a dead link. Report the job as gone
+    // (404) so the client drops it quietly instead of linking to nothing.
+    if (eff.status === "done" && job.slug && !(await readWikiPage(job.slug))) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
     return NextResponse.json({
       status: eff.status,
       slug: job.slug,

--- a/src/app/api/ingest/status/[jobId]/route.ts
+++ b/src/app/api/ingest/status/[jobId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getPrincipal } from "@/lib/auth";
 import { getIngestJob, effectiveStatus } from "@/lib/ingest-jobs";
-import { readWikiPage } from "@/lib/wiki";
+import { wikiPageExists } from "@/lib/wiki";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 
@@ -42,9 +42,20 @@ export async function GET(
 
     // The job record outlives its page: if a completed page was later deleted,
     // the "Recent ingests" strip would show a dead link. Report the job as gone
-    // (404) so the client drops it quietly instead of linking to nothing.
-    if (eff.status === "done" && job.slug && !(await readWikiPage(job.slug))) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    // (404) so the client drops it quietly instead of linking to nothing. Only a
+    // GENUINE miss should drop it — a transient storage error must not, or a blip
+    // would silently evict a live job, so on a read error we fall through and
+    // return the job as-is.
+    if (eff.status === "done" && job.slug) {
+      let gone = false;
+      try {
+        gone = !(await wikiPageExists(job.slug));
+      } catch (e) {
+        logger.warn("ingest", `status: page existence check failed for ${job.slug}`, e);
+      }
+      if (gone) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
     }
 
     return NextResponse.json({

--- a/src/lib/__tests__/ingest-status-route.test.ts
+++ b/src/lib/__tests__/ingest-status-route.test.ts
@@ -8,16 +8,21 @@ vi.mock("@/lib/ingest-jobs", async (importActual) => ({
 vi.mock("@/lib/auth", () => ({
   getPrincipal: vi.fn(),
 }));
+vi.mock("@/lib/wiki", () => ({
+  readWikiPage: vi.fn(),
+}));
 vi.mock("@/lib/logger", () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
 import { getIngestJob } from "@/lib/ingest-jobs";
 import { getPrincipal } from "@/lib/auth";
+import { readWikiPage } from "@/lib/wiki";
 import { GET } from "@/app/api/ingest/status/[jobId]/route";
 
 const mockedGetJob = vi.mocked(getIngestJob);
 const mockedGetPrincipal = vi.mocked(getPrincipal);
+const mockedReadPage = vi.mocked(readWikiPage);
 
 const call = (jobId: string) =>
   GET(new Request("http://localhost/api/ingest/status/" + jobId), {
@@ -27,6 +32,9 @@ const call = (jobId: string) =>
 beforeEach(() => {
   vi.clearAllMocks();
   mockedGetPrincipal.mockResolvedValue({ id: "alice", handle: "alice" });
+  // Default: a done job's page still exists (override to null to simulate delete).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockedReadPage.mockResolvedValue({ slug: "x" } as any);
 });
 
 describe("GET /api/ingest/status/[jobId]", () => {
@@ -66,6 +74,20 @@ describe("GET /api/ingest/status/[jobId]", () => {
     const res = await call("j1");
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ status: "done", slug: "my-page" });
+  });
+
+  it("404s a done job whose page was deleted (drops a dead link from the strip)", async () => {
+    mockedGetJob.mockResolvedValue({
+      jobId: "j1",
+      url: "https://youtu.be/x",
+      owner: "alice",
+      status: "done",
+      slug: "deleted-page",
+      createdAt: "",
+      updatedAt: "",
+    });
+    mockedReadPage.mockResolvedValue(null); // page no longer exists
+    expect((await call("j1")).status).toBe(404);
   });
 
   it("reports a long-stalled processing job as failed (dead worker)", async () => {

--- a/src/lib/__tests__/ingest-status-route.test.ts
+++ b/src/lib/__tests__/ingest-status-route.test.ts
@@ -9,7 +9,7 @@ vi.mock("@/lib/auth", () => ({
   getPrincipal: vi.fn(),
 }));
 vi.mock("@/lib/wiki", () => ({
-  readWikiPage: vi.fn(),
+  wikiPageExists: vi.fn(),
 }));
 vi.mock("@/lib/logger", () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
@@ -17,12 +17,12 @@ vi.mock("@/lib/logger", () => ({
 
 import { getIngestJob } from "@/lib/ingest-jobs";
 import { getPrincipal } from "@/lib/auth";
-import { readWikiPage } from "@/lib/wiki";
+import { wikiPageExists } from "@/lib/wiki";
 import { GET } from "@/app/api/ingest/status/[jobId]/route";
 
 const mockedGetJob = vi.mocked(getIngestJob);
 const mockedGetPrincipal = vi.mocked(getPrincipal);
-const mockedReadPage = vi.mocked(readWikiPage);
+const mockedPageExists = vi.mocked(wikiPageExists);
 
 const call = (jobId: string) =>
   GET(new Request("http://localhost/api/ingest/status/" + jobId), {
@@ -32,9 +32,8 @@ const call = (jobId: string) =>
 beforeEach(() => {
   vi.clearAllMocks();
   mockedGetPrincipal.mockResolvedValue({ id: "alice", handle: "alice" });
-  // Default: a done job's page still exists (override to null to simulate delete).
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  mockedReadPage.mockResolvedValue({ slug: "x" } as any);
+  // Default: a done job's page still exists (override to false to simulate delete).
+  mockedPageExists.mockResolvedValue(true);
 });
 
 describe("GET /api/ingest/status/[jobId]", () => {
@@ -76,18 +75,44 @@ describe("GET /api/ingest/status/[jobId]", () => {
     expect(await res.json()).toMatchObject({ status: "done", slug: "my-page" });
   });
 
+  const doneJob = (over: Record<string, unknown> = {}) => ({
+    jobId: "j1",
+    url: "https://youtu.be/x",
+    owner: "alice",
+    status: "done" as const,
+    slug: "the-page",
+    createdAt: "",
+    updatedAt: "",
+    ...over,
+  });
+
   it("404s a done job whose page was deleted (drops a dead link from the strip)", async () => {
-    mockedGetJob.mockResolvedValue({
-      jobId: "j1",
-      url: "https://youtu.be/x",
-      owner: "alice",
-      status: "done",
-      slug: "deleted-page",
-      createdAt: "",
-      updatedAt: "",
-    });
-    mockedReadPage.mockResolvedValue(null); // page no longer exists
+    mockedGetJob.mockResolvedValue(doneJob({ slug: "deleted-page" }));
+    mockedPageExists.mockResolvedValue(false); // page no longer exists
     expect((await call("j1")).status).toBe(404);
+  });
+
+  it("returns the job (200) when the page-existence check errors — a storage blip must not evict a live job", async () => {
+    mockedGetJob.mockResolvedValue(doneJob());
+    mockedPageExists.mockRejectedValue(new Error("R2 timeout"));
+    const res = await call("j1");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: "done", slug: "the-page" });
+  });
+
+  it("does not existence-check a done job with no slug (returns 200)", async () => {
+    mockedGetJob.mockResolvedValue(doneJob({ slug: undefined }));
+    const res = await call("j1");
+    expect(res.status).toBe(200);
+    expect(mockedPageExists).not.toHaveBeenCalled();
+  });
+
+  it("never existence-checks a non-done job (a missing page can't 404 a failed job)", async () => {
+    mockedGetJob.mockResolvedValue(doneJob({ status: "failed", error: "boom", slug: "p" }));
+    mockedPageExists.mockResolvedValue(false);
+    const res = await call("j1");
+    expect(res.status).toBe(200);
+    expect(mockedPageExists).not.toHaveBeenCalled();
   });
 
   it("reports a long-stalled processing job as failed (dead worker)", async () => {

--- a/src/lib/__tests__/lifecycle.test.ts
+++ b/src/lib/__tests__/lifecycle.test.ts
@@ -792,6 +792,22 @@ describe("recent trail action labeling", () => {
     expect(actions.filter((a) => a === "re-ingested")).toHaveLength(1);
   });
 
+  it("folds an automation author (lint-fix) into the agent on the incremental push", async () => {
+    const { getRecentIndex } = await import("../recent-index");
+    await getStorage().putIndex("recent", []);
+
+    await writeWikiPageWithSideEffects(
+      makeOpts({ author: "lint-fix", content: "# Test Page\n\nv1." }),
+    );
+
+    const idx = (await getRecentIndex()) ?? [];
+    const ev = idx.find((e) => e.slug === "test-page");
+    expect(ev).toBeDefined();
+    // Raw "lint-fix" must not leak into the live "Recent" strip — it reads as yoyo.
+    expect(ev!.actor).toBe("yoyo");
+    expect(ev!.isAgent).toBe(true);
+  });
+
   it("labels a manual edit 'edited', not re-ingested", async () => {
     const { getRecentIndex } = await import("../recent-index");
     await getStorage().putIndex("recent", []);

--- a/src/lib/__tests__/trail.test.ts
+++ b/src/lib/__tests__/trail.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Isolate trailEventsForPages from storage: stub the page/revision reads and
+// keep the real actor-normalization (agent-handle) + parseSources.
+vi.mock("../wiki", () => ({
+  listReadableWikiPages: vi.fn(),
+  readWikiPageWithFrontmatter: vi.fn(),
+  isAgentScopedType: () => false,
+  ownerToTenant: (o?: string) => o ?? "commons",
+}));
+vi.mock("../revisions", () => ({ listRevisions: vi.fn() }));
+
+import { trailEventsForPages } from "../trail";
+import { readWikiPageWithFrontmatter } from "../wiki";
+import { listRevisions } from "../revisions";
+
+const mockedReadPage = vi.mocked(readWikiPageWithFrontmatter);
+const mockedListRevisions = vi.mocked(listRevisions);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("trailEventsForPages — actor normalization", () => {
+  it("folds an automation actor (lint-fix) into the agent for ingests and edits", async () => {
+    mockedReadPage.mockResolvedValue({
+      frontmatter: {
+        sources: JSON.stringify([
+          {
+            type: "youtube",
+            url: "https://youtu.be/x",
+            fetched: "2026-06-10T00:00:00.000Z",
+            triggered_by: "lint-fix",
+          },
+        ]),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    mockedListRevisions.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { author: "lint-fix", timestamp: 1_700_000_000_000, date: "2026-06-10" } as any,
+    ]);
+
+    const events = await trailEventsForPages([
+      { slug: "about-poke", title: "About Poke" },
+    ]);
+
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    // No raw automation actor leaks into the feed.
+    expect(events.every((e) => e.actor === "yoyo")).toBe(true);
+    expect(events.every((e) => e.isAgent)).toBe(true);
+    expect(events.map((e) => e.action).sort()).toEqual(["edited", "ingested"]);
+  });
+
+  it("keeps a real human actor unchanged", async () => {
+    mockedReadPage.mockResolvedValue({
+      frontmatter: {
+        sources: JSON.stringify([
+          {
+            type: "url",
+            url: "https://example.com",
+            fetched: "2026-06-10T00:00:00.000Z",
+            triggered_by: "alice",
+          },
+        ]),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    mockedListRevisions.mockResolvedValue([]);
+
+    const events = await trailEventsForPages([{ slug: "p", title: "P" }]);
+    expect(events).toHaveLength(1);
+    expect(events[0].actor).toBe("alice");
+    expect(events[0].isAgent).toBe(false);
+  });
+});

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -31,6 +31,7 @@ import { syncBacklinksForPage, removeBacklinksForSlug } from "./backlink-index";
 import { recordEditForAuthor } from "./contributor-index";
 import { pushRecentEvent, removeRecentForSlug } from "./recent-index";
 import { isAgentHandle } from "./agents";
+import { normalizeActor } from "./agent-handle";
 import { parseFrontmatter } from "./frontmatter";
 import { parseSources, newestSourceType } from "./sources";
 import type { LogOperation } from "./wiki";
@@ -476,11 +477,14 @@ async function runPageLifecycleOp(
                 parseSources(fm.sources as string | string[] | undefined),
               )
             : undefined;
+        // Fold automation actors (system / lint-fix / yopedia) into the agent so
+        // the incrementally-pushed event matches the scan/index normalization.
+        const actor = normalizeActor(op.author);
         await pushRecentEvent({
           ts: now,
           when: new Date(now).toISOString(),
-          actor: op.author,
-          isAgent: isAgentHandle(op.author),
+          actor,
+          isAgent: isAgentHandle(actor),
           // An ingest onto a page that already existed is a re-ingest — label
           // it distinctly (prevContent is undefined only for a brand-new page).
           action:

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -12,7 +12,8 @@ export interface TrailEvent {
   ts: number;
   /** ISO date string for display. */
   when: string;
-  /** Who acted — a human handle, an agent id, or "system". */
+  /** Who acted — a human handle or an agent id (automation actors like
+   * `system`/`lint-fix` are folded to the agent via {@link normalizeActor}). */
   actor: string;
   /** True when the actor is an autonomous agent (e.g. `yoyo`). */
   isAgent: boolean;

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -2,6 +2,7 @@ import { listReadableWikiPages, readWikiPageWithFrontmatter, isAgentScopedType, 
 import { listRevisions } from "./revisions";
 import { parseSources } from "./sources";
 import { isAgentHandle } from "./agents";
+import { normalizeActor } from "./agent-handle";
 import type { SourceEntry } from "./types";
 import type { Principal } from "./auth";
 
@@ -115,7 +116,9 @@ export async function trailEventsForPages(
         for (const s of sources) {
           const ts = Date.parse(s.fetched);
           if (Number.isNaN(ts)) continue;
-          const actor = s.triggered_by || "system";
+          // Fold automation actors (system / lint-fix / yopedia) into the agent
+          // so the trail reads as one yoyo, matching the contributor index.
+          const actor = normalizeActor(s.triggered_by || "system");
           evs.push({
             ts,
             when: s.fetched,
@@ -137,11 +140,12 @@ export async function trailEventsForPages(
         const revisions = await listRevisions(page.slug);
         for (const r of revisions) {
           if (!r.author) continue;
+          const actor = normalizeActor(r.author);
           evs.push({
             ts: r.timestamp,
             when: r.date,
-            actor: r.author,
-            isAgent: isAgentHandle(r.author),
+            actor,
+            isAgent: isAgentHandle(actor),
             action: "edited",
             slug: page.slug,
             title: page.title,

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -118,7 +118,7 @@ export async function trailEventsForPages(
           const ts = Date.parse(s.fetched);
           if (Number.isNaN(ts)) continue;
           // Fold automation actors (system / lint-fix / yopedia) into the agent
-          // so the trail reads as one yoyo, matching the contributor index.
+          // so the trail reads as one yoyo, matching the (rebuilt) contributor index.
           const actor = normalizeActor(s.triggered_by || "system");
           evs.push({
             ts,

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -259,6 +259,28 @@ export function _getPageCacheSize(): number {
 // Wiki page I/O
 // ---------------------------------------------------------------------------
 
+/**
+ * Whether a commons wiki page exists. Unlike {@link readWikiPage} (which
+ * swallows ALL read errors as `null`), this RE-THROWS a non-ENOENT storage
+ * failure so a caller can tell "the page is genuinely gone" from "the store
+ * hiccuped" — e.g. the ingest-status route must not drop a live job's strip
+ * entry on a transient blip. A malformed slug is treated as "no such page".
+ */
+export async function wikiPageExists(slug: string): Promise<boolean> {
+  try {
+    validateSlug(slug);
+  } catch {
+    return false;
+  }
+  try {
+    await getStorage().readFile(wikiRelPath(`${slug}.md`));
+    return true;
+  } catch (err) {
+    if (isEnoent(err)) return false;
+    throw err; // real storage error — let the caller decide, don't mask as "gone"
+  }
+}
+
 /** Read a wiki page by slug. Returns `null` when the file doesn't exist or the slug is invalid. */
 export async function readWikiPage(slug: string): Promise<WikiPage | null> {
   try {


### PR DESCRIPTION
Two stale-display bugs surfaced while testing async YouTube ingest:

## 1. The Trail showed raw automation actors

`@lint-fix edited about-poke` appeared in the activity feed. `trail.ts` (the scan) and `lifecycle.ts` (the incremental recent-index push) built `TrailEvent`s with the **raw** actor, skipping `normalizeActor` — which folds `system` / `lint-fix` / `yopedia` into the agent (`yoyo`), exactly as `contributors.ts` already does. So the contributor index reads as `yoyo` but the trail leaked `lint-fix`.

**Fix:** normalize the actor at event construction in both paths (ingest + edit in `trail.ts`, and the `pushRecentEvent` call in `lifecycle.ts`). `isAgent` is computed from the normalized actor. The precomputed `_idx:recent` self-heals on its daily rebuild (built from `scanTrail`).

## 2. Recent ingests linked to a deleted page

The owner-stamped ingest-job record outlives its page, so after you delete a page the "Recent ingests" strip still showed its `done` job as a **dead link**.

**Fix:** `GET /api/ingest/status/<jobId>` now 404s a `done` job whose page no longer exists (`readWikiPage` miss). The strip already drops 404s quietly, so the stale entry disappears.

## Tests

- New `trail.test.ts`: `lint-fix` → `yoyo` for both ingest and edit events; a real human actor (`alice`) is unchanged.
- `ingest-status-route.test.ts`: a `done` job whose page was deleted → 404 (existing done-job tests default `readWikiPage` to present).

Verified: `pnpm build` clean · 2926 tests pass · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)