### PR TITLE
Map-reduce long-source synthesis (accurate, prose, fast)

### DIFF
--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -2571,12 +2571,14 @@ describe("ingest — chunked LLM calls", () => {
 
   it("map-reduces long content: maps each chunk from source, then merges into one article", async () => {
     mockedHasLLMKey.mockReturnValue(true);
-    // Distinguish MAP calls (per-chunk, from source) from the single REDUCE call
-    // (merges the partials) by which system prompt each receives.
-    mockedCallLLM.mockImplementation(async (system: string) => {
-      if (/distilling ONE part/.test(system)) return "Distilled note from a chunk.";
-      // REDUCE
-      return "CONCEPT: Topic\nTAGS: t\n\n# Topic\n\n## Summary\n\nMerged.\n\n## Key Points\n\n- point";
+    // Route MAP vs REDUCE off the USER message structure (stable behavior), not
+    // prompt prose: reduce is fed the merged "# Part N" notes; map is fed a raw
+    // "Part k of N of the source" chunk.
+    mockedCallLLM.mockImplementation(async (_system: string, user: string) => {
+      if (/^# Part 1\b/.test(user)) {
+        return "CONCEPT: Topic\nTAGS: t\n\n# Topic\n\n## Summary\n\nMerged.\n\n## Key Points\n\n- point";
+      }
+      return "Distilled note from a chunk.";
     });
 
     const longContent = Array.from(

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -2569,14 +2569,14 @@ describe("ingest — chunked LLM calls", () => {
     mockedCallLLM.mockReset();
   });
 
-  it("refines long content into one article (folds chunks in, doesn't append)", async () => {
+  it("map-reduces long content: maps each chunk from source, then merges into one article", async () => {
     mockedHasLLMKey.mockReturnValue(true);
-    // Each call returns a DISTINCT full article so we can tell whether the final
-    // page is the last refinement (correct) or a concatenation of all chunks.
-    let call = 0;
-    mockedCallLLM.mockImplementation(async () => {
-      call += 1;
-      return `CONCEPT: Topic\nTAGS: t\n\n# Topic\n\n## Summary\n\nRefined v${call}.\n\n## Key Points\n\n- point ${call}`;
+    // Distinguish MAP calls (per-chunk, from source) from the single REDUCE call
+    // (merges the partials) by which system prompt each receives.
+    mockedCallLLM.mockImplementation(async (system: string) => {
+      if (/distilling ONE part/.test(system)) return "Distilled note from a chunk.";
+      // REDUCE
+      return "CONCEPT: Topic\nTAGS: t\n\n# Topic\n\n## Summary\n\nMerged.\n\n## Key Points\n\n- point";
     });
 
     const longContent = Array.from(
@@ -2586,20 +2586,21 @@ describe("ingest — chunked LLM calls", () => {
     expect(longContent.length).toBeGreaterThan(MAX_LLM_INPUT_CHARS);
 
     const result = await ingest("Topic", longContent);
-    const calls = mockedCallLLM.mock.calls.length;
-    expect(calls).toBeGreaterThan(1);
+    const calls = mockedCallLLM.mock.calls;
 
-    // The 2nd call is a REFINE call: it gets the prior article as "Current
-    // article", not a fresh continuation that would append a new section block.
-    expect(mockedCallLLM.mock.calls[1][0]).toMatch(/COMPLETE, updated article/);
-    expect(mockedCallLLM.mock.calls[1][1]).toContain("# Current article");
-    expect(mockedCallLLM.mock.calls[1][1]).toContain("Refined v1");
+    // N map calls (one per chunk, each fed the SOURCE part — never a prior
+    // summary, so no cross-chunk drift) + exactly one reduce call.
+    const mapCalls = calls.filter((c) => /distilling ONE part/.test(c[0]));
+    const reduceCalls = calls.filter((c) => /given faithful NOTES/.test(c[0]));
+    expect(mapCalls.length).toBeGreaterThan(1);
+    expect(reduceCalls).toHaveLength(1);
+    expect(mapCalls[0][1]).toMatch(/Part 1 of \d+ of the source/);
+    // The reduce input is the merged per-part notes, not a single chunk.
+    expect(reduceCalls[0][1]).toContain("# Part 1");
 
-    // The persisted page is the LAST refinement only — no pile-up of every
-    // chunk's sections, and exactly one "## Key Points".
+    // The persisted page is the reduce output — one clean set of sections.
     const page = await readWikiPageWithFrontmatter(result.primarySlug);
-    expect(page!.content).toContain(`Refined v${calls}`);
-    expect(page!.content).not.toContain("Refined v1");
+    expect(page!.content).toContain("Merged.");
     expect(page!.content.match(/## Key Points/g) ?? []).toHaveLength(1);
 
     mockedHasLLMKey.mockReturnValue(false);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -136,6 +136,21 @@ export const LLM_MAX_OUTPUT_TOKENS = 4096;
 export const INGEST_MAX_OUTPUT_TOKENS = 8192;
 
 /**
+ * Output-token cap for a single MAP partial when long-source synthesis distils
+ * one chunk. Smaller than {@link INGEST_MAX_OUTPUT_TOKENS}: a chunk is only
+ * ~{@link MAX_LLM_INPUT_CHARS} of source, and bounding each partial keeps the
+ * combined notes fed to the REDUCE step well within one input.
+ */
+export const INGEST_MAP_MAX_OUTPUT_TOKENS = 2400;
+
+/**
+ * Max MAP chunks distilled concurrently. Parallelism cuts the wall-clock of a
+ * long transcript from the sum of all chunks to a few batches, while the cap
+ * keeps us within the LLM provider's burst/rate limits.
+ */
+export const INGEST_MAP_CONCURRENCY = 4;
+
+/**
  * Output-token cap for query answers. Higher than the default so multi-section
  * answers, tables, and longer syntheses aren't truncated mid-response.
  */

--- a/src/lib/ingest-jobs.ts
+++ b/src/lib/ingest-jobs.ts
@@ -16,11 +16,12 @@ export type IngestJobStatus = "queued" | "processing" | "done" | "failed";
  * A job that's been `queued`/`processing` longer than this is treated as
  * `failed` ON READ — the consumer worker likely died mid-run (a long video can
  * hit the CPU limit) and would never write a terminal status, leaving the UI
- * polling "working…" forever. Generous: well past the client's ~5min poll cap
- * and any real ingest time, and the queue refreshes `updatedAt` on each retry,
- * so a job actively being retried is never falsely flagged.
+ * polling "working…" forever. Generous: well past any real ingest time (a long
+ * transcript's map/reduce synthesis runs in a few parallel batches, not tens of
+ * minutes), and the queue refreshes `updatedAt` on each retry, so a job actively
+ * being retried is never falsely flagged.
  */
-export const INGEST_JOB_STALE_MS = 10 * 60 * 1000;
+export const INGEST_JOB_STALE_MS = 20 * 60 * 1000;
 
 /**
  * The status a reader should act on: a non-terminal job that hasn't advanced in

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -95,6 +95,8 @@ export function computeConfidence(
 import {
   MAX_LLM_INPUT_CHARS,
   INGEST_MAX_OUTPUT_TOKENS,
+  INGEST_MAP_MAX_OUTPUT_TOKENS,
+  INGEST_MAP_CONCURRENCY,
   MAX_APPENDED_IMAGES,
   MAX_CONTENT_LENGTH,
   MAX_PDF_SIZE,
@@ -806,24 +808,42 @@ Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. KEEP the o
 Write a focused, distilled page, not a transcript of the source. Output the CONCEPT, ALIASES, and TAGS lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
 
 /**
- * System prompt for refining a long source document chunk-by-chunk. When the
- * source is too long for one call, we synthesize the first chunk into a full
- * article, then fold each remaining chunk INTO that article with this prompt —
- * a running "refine" rather than appending. The model returns the COMPLETE,
- * rewritten article each step, so the page keeps ONE set of sections (no
- * "Key Points (additional)" pileup) however many chunks the source spans.
+ * MAP step of the long-source synthesis. Each chunk is distilled DIRECTLY from
+ * the source (not from a running summary), so coverage stays faithful and
+ * specifics don't drift — the accuracy property the old append path had. The
+ * partials carry no CONCEPT marker and no fixed section scaffold; the reduce
+ * step imposes the final structure. Bullets are reined in here so the merged
+ * page reads as prose, not a wall of fragments.
  */
-const REFINE_SYSTEM_PROMPT = `You are a wiki editor improving a wiki article with more of its source document. You are given the CURRENT article (built from earlier parts) and the NEXT part of the same source. Fold the new material into the current article and return the COMPLETE, updated article.
+const MAP_SYSTEM_PROMPT = `You are a wiki editor distilling ONE part of a long source document into faithful notes that will later be merged with the other parts.
 
-Rules:
-- Keep the three leading header lines exactly in this form, refining them only if the new material genuinely warrants it:
+From THIS part of the source, capture the substantive material a reader needs: the explanations, definitions, mechanisms, claims, examples, names, and numbers actually present. Be FAITHFUL — preserve concrete specifics exactly; do not generalize them away, and invent nothing not in this part.
+
+Write mostly in concise prose. Use a bullet only for genuinely list-like material — do not turn every sentence into a bullet. Omit boilerplate, marketing, repetition, and tangents. Do NOT add a title, a "Summary", or section headings — output only the distilled notes for this part.
+
+Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. Keep genuine content images (diagrams, figures, charts, screenshots) by writing the SAME token on its own line where relevant; omit decorative/branding/UI ones. Never invent tokens or change their numbers.
+
+Output pure markdown and nothing else. Do not wrap in code fences.`;
+
+/**
+ * REDUCE step: merge the per-chunk notes into ONE coherent article with the
+ * standard structure. This is a MERGE/REORGANISE, not a re-summary — it must
+ * keep the concrete substance the map step preserved (so a long source stays as
+ * accurate as the old append path) while collapsing the parts into a single set
+ * of sections (fixing the "(additional)" pileup the refine approach replaced).
+ */
+const REDUCE_SYSTEM_PROMPT = `You are a wiki editor. You are given faithful NOTES distilled from consecutive parts of ONE source document (delimited as "Part 1", "Part 2", ...). Combine them into a single coherent wiki article.
+
+This is a MERGE, not a new summary: keep the concrete substance from the notes — specifics, names, numbers, claims, examples — and drop only true duplication. Do not compress the material down to generic bullet points or lose detail that the notes preserved.
+
+Begin your output with these three header lines in EXACTLY this form:
 CONCEPT: <canonical concept name>
-ALIASES: <comma-separated synonyms, or "none">
+ALIASES: <comma-separated alternative names / synonyms for the concept, or "none">
 TAGS: <3-6 lowercase, hyphenated topic tags, comma-separated>
-- Then the article: one \`# Title\`, then EXACTLY ONE of each \`## Summary\`, \`## Key Points\`, \`## Concepts\`, \`## Details\` — never create a second copy of a section or a "(additional)" variant. Integrate the new key points, concepts, and details into the existing sections.
-- Preserve everything already covered; add what's genuinely new from the next part; merge duplicates and resolve overlaps. Keep it distilled — summarize, don't transcribe. Update the Summary to reflect the whole article so far. Invent nothing unsupported by the source.
 
-Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. Keep tokens already in the article and add new genuine-content ones (diagrams, figures, charts, screenshots) on their own line where relevant; omit decorative/branding/UI ones. Never invent tokens or change their numbers; output each kept token verbatim.
+Then the article: one \`# Title\` (the canonical concept), then EXACTLY ONE of each \`## Summary\`, \`## Key Points\`, \`## Concepts\`, \`## Details\`. Reorganise the merged notes into these sections — never emit a section twice or an "(additional)" variant. Prefer readable prose; use bullets only where the material is genuinely list-like. The \`## Details\` section should carry the substance in prose and lists, not a flat dump of every bullet.
+
+Images: the notes may contain placeholder tokens like \`[[IMG:1]]\`. Keep each genuine-content token on its own line at the most relevant point; never invent tokens or change their numbers; output each kept token verbatim.
 
 Output the CONCEPT, ALIASES, and TAGS lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
 
@@ -1391,23 +1411,40 @@ export async function ingest(
       // Short content — single LLM call (no behaviour change)
       wikiContent = await callLLM(systemPrompt, chunks[0], llmOptions);
     } else {
-      // Long content — synthesize the first chunk into a full article, then
-      // REFINE it with each remaining chunk (fold new material into the existing
-      // sections). This keeps one coherent page with a single set of sections,
-      // instead of appending a fresh "Key Points / Concepts / Details" block per
-      // chunk (which a long transcript turned into a wall of "(additional)").
-      wikiContent = await callLLM(systemPrompt, chunks[0], llmOptions);
-
-      for (let i = 1; i < chunks.length; i++) {
-        const refined = await callLLM(
-          REFINE_SYSTEM_PROMPT,
-          `# Current article\n\n${wikiContent}\n\n# Next part of the source (part ${i + 1} of ${chunks.length})\n\n${chunks[i]}`,
-          llmOptions,
+      // Long content — MAP/REDUCE. Distil each chunk straight from the SOURCE
+      // (in bounded-concurrency batches), then merge the partials into one
+      // article. Mapping from source keeps coverage faithful and stops the
+      // cross-chunk drift a sequential refine caused; merging collapses the
+      // parts into a single set of sections (no "(additional)" pileup); and the
+      // parallel map keeps a long transcript well under the request budget that
+      // sequential synthesis blew past.
+      const mapOptions = { maxOutputTokens: INGEST_MAP_MAX_OUTPUT_TOKENS };
+      const partials: string[] = [];
+      for (let i = 0; i < chunks.length; i += INGEST_MAP_CONCURRENCY) {
+        const batch = chunks.slice(i, i + INGEST_MAP_CONCURRENCY);
+        const mapped = await Promise.all(
+          batch.map((chunk, j) =>
+            callLLM(
+              MAP_SYSTEM_PROMPT,
+              `Part ${i + j + 1} of ${chunks.length} of the source:\n\n${chunk}`,
+              mapOptions,
+            ),
+          ),
         );
-        // Refine REPLACES the whole article, so an empty/blank response would
-        // discard everything synthesized so far — keep the prior draft instead.
-        if (refined.trim()) wikiContent = refined;
+        partials.push(...mapped);
       }
+
+      const notes = partials
+        .map((p, i) => ({ part: i + 1, text: p.trim() }))
+        .filter((p) => p.text)
+        .map((p) => `# Part ${p.part}\n\n${p.text}`)
+        .join("\n\n");
+      if (!notes) {
+        // Every map call came back blank — surface a real failure rather than
+        // reducing nothing into a hallucinated page.
+        throw new Error("synthesis produced no content from the source");
+      }
+      wikiContent = await callLLM(REDUCE_SYSTEM_PROMPT, notes, llmOptions);
     }
 
     // Restore the kept [[IMG:n]] tokens to real refs (omitted ones are dropped).


### PR DESCRIPTION
## Why

Two prior approaches to synthesizing a long source (e.g. a 2-hour podcast transcript) each had a flaw:

- **Append** (original): accurate — each chunk synthesized **straight from the source**, nothing dropped — but duplicated the section structure (the "Key Points (additional)" pileup).
- **Refine** (#529): one clean structure, but a lossy **telephone game** — each step re-summarized the *previous summary*, so specifics **drifted** and it padded with **bullets**. It was also ~8 sequential full-article rewrites → slow enough to trip the 10-min stall watchdog, so real ingests came back **failed**.

User feedback: *"the old append path has more accurate content… the new approach had too much bullets, content drifted too."*

## What

Parallel **MAP / REDUCE**:

- **MAP** — distil each chunk **directly from the source**, in bounded-concurrency batches (`INGEST_MAP_CONCURRENCY=4`, `INGEST_MAP_MAX_OUTPUT_TOKENS=2400`). Faithful per-chunk coverage, **no cross-chunk drift** (the accuracy the append path had). The map prompt is prose-first to curb bullet bloat.
- **REDUCE** — one pass merging the partials into a single `CONCEPT`-marked article with **exactly one** of each `Summary / Key Points / Concepts / Details`. It's a **merge, not a re-summary**: told to keep the concrete substance (names, numbers, claims, examples) and drop only true duplication, prose-preferred.

Result: append's accuracy + refine's clean structure + neither's failure mode.

## Speed

Parallel map drops wall-clock from the **sum** of all chunks to a few **batches** (~2-3 min), so it stays well under the worker budget — sidestepping the slow-vs-killed question that made #529 stall. Watchdog bumped `INGEST_JOB_STALE_MS` 10→20 min for headroom.

## Robustness

If every map partial comes back blank, throw (→ a visible `failed` job with a reason) rather than reduce nothing into a hallucinated page.

## Tests

Long-content test rewritten: asserts N map calls (each fed `Part k of … the source`) + exactly one reduce call (fed the merged `# Part` notes), and the persisted page is the reduce output with one set of sections. Single-chunk path unchanged.

Verified: `pnpm build` clean · 2930 tests pass · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)