### PR TITLE
Add an /about page introducing yopedia

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,7 +1,10 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 
-export const metadata = {
-  title: "What is yopedia — clean knowledge, built by agents",
+export const metadata: Metadata = {
+  // `absolute` opts out of the root layout's "%s · yopedia" template so the
+  // title isn't double-branded ("… · yopedia").
+  title: { absolute: "What is yopedia — clean knowledge, built by agents" },
   description:
     "yopedia is a living knowledge base, built by agents, where every fact is cited and every page stays current. GitHub for cited, agent-maintained knowledge.",
 };

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,180 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "What is yopedia — clean knowledge, built by agents",
+  description:
+    "yopedia is a living knowledge base, built by agents, where every fact is cited and every page stays current. GitHub for cited, agent-maintained knowledge.",
+};
+
+const DIFFERENTIATORS: [string, string][] = [
+  [
+    "Cited to the fact",
+    "Every claim links back to where it came from. You can verify, not just believe — and so can your agent.",
+  ],
+  [
+    "Always current",
+    "New sources don't pile up — they reconcile into one canonical page, contradictions surfaced rather than buried. Knowledge that maintains itself.",
+  ],
+  [
+    "Built by agents, for agents",
+    "yopedia speaks MCP and a clean API. Your agent — or ours, yoyo — reads and writes it directly. A shared brain, not a private scratchpad.",
+  ],
+];
+
+export default function AboutPage() {
+  return (
+    <div className="fade">
+      {/* Hero */}
+      <section className="shell" style={{ paddingTop: 80, paddingBottom: 18 }}>
+        <p className="fmark rise" style={{ marginBottom: 26 }}>
+          what is yopedia
+        </p>
+        <h1
+          className="display rise"
+          style={{
+            fontSize: "clamp(40px, 6.8vw, 84px)",
+            margin: 0,
+            maxWidth: "18ch",
+            animationDelay: ".05s",
+          }}
+        >
+          The knowledge base that cites its sources{" "}
+          <span style={{ fontStyle: "italic", color: "var(--accent)" }}>and</span>{" "}
+          never goes stale.
+        </h1>
+        <p
+          className="rise"
+          style={{
+            fontSize: 19,
+            color: "var(--ink-2)",
+            lineHeight: 1.6,
+            maxWidth: "54ch",
+            marginTop: 30,
+            animationDelay: ".1s",
+          }}
+        >
+          Every fact traced to where it came from. Every page kept current by
+          agents. One clean source of truth your AI can actually trust.
+        </p>
+      </section>
+
+      {/* The problem */}
+      <section className="shell" style={{ marginTop: 72, maxWidth: 720 }}>
+        <p className="fmark" style={{ marginBottom: 14 }}>
+          the problem
+        </p>
+        <h2
+          style={{
+            fontSize: 26,
+            fontWeight: 600,
+            letterSpacing: "-.02em",
+            margin: "0 0 16px",
+          }}
+        >
+          AI got smart. Its knowledge never got trustworthy.
+        </h2>
+        <p style={{ fontSize: 16.5, color: "var(--ink-2)", lineHeight: 1.7, margin: 0 }}>
+          We have infinite information and almost no knowledge we can rely on. AI{" "}
+          <strong>hallucinates</strong> — confident answers, no source to check.
+          Notes <strong>rot</strong> into a graveyard you&apos;ll never reopen.
+          Your assistant <strong>forgets</strong>, so you re-explain the same
+          context every session. And every tool is a <strong>silo</strong> — your
+          knowledge trapped in one app, one model, one machine. Smarter models
+          didn&apos;t fix this. The problem was never intelligence; it was{" "}
+          <em>trust, freshness, and ownership</em> of what the AI knows.
+        </p>
+      </section>
+
+      {/* What it is */}
+      <section className="shell" style={{ marginTop: 64, maxWidth: 720 }}>
+        <p className="fmark" style={{ marginBottom: 14 }}>
+          so we built knowledge differently
+        </p>
+        <p style={{ fontSize: 18.5, lineHeight: 1.6, margin: "0 0 18px" }}>
+          <strong>
+            yopedia is a living knowledge base, built by agents, where every fact
+            is cited and every page stays current.
+          </strong>
+        </p>
+        <p style={{ fontSize: 16.5, color: "var(--ink-2)", lineHeight: 1.7, margin: 0 }}>
+          Point an agent at anything — a URL, a tweet, a PDF, a YouTube video, a
+          paper — and yopedia turns it into a clean page: distilled,{" "}
+          <strong>cited to its source</strong>, and{" "}
+          <strong>merged into one canonical page per concept</strong>. No
+          duplicates, no frozen snapshots. Ask a question and you get an answer
+          grounded in those pages, with citations — not a guess. Think of it as{" "}
+          <em>GitHub for knowledge</em>: agents write it, the public commons is
+          open to everyone, and your private knowledge stays yours.
+        </p>
+      </section>
+
+      {/* Three differentiators */}
+      <section className="shell" style={{ marginTop: 72 }}>
+        <p className="fmark" style={{ marginBottom: 24 }}>
+          three ideas nobody else combines
+        </p>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(230px, 1fr))",
+            gap: 40,
+          }}
+        >
+          {DIFFERENTIATORS.map(([title, desc], i) => (
+            <div key={title}>
+              <span
+                className="receipt"
+                style={{ fontSize: 12, color: "var(--accent)" }}
+              >
+                0{i + 1}
+              </span>
+              <h3
+                style={{
+                  fontSize: 19,
+                  fontWeight: 600,
+                  letterSpacing: "-.01em",
+                  margin: "10px 0 8px",
+                }}
+              >
+                {title}
+              </h3>
+              <p style={{ fontSize: 15, color: "var(--ink-2)", lineHeight: 1.6, margin: 0 }}>
+                {desc}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* The bigger idea */}
+      <section className="shell" style={{ marginTop: 80, maxWidth: 720 }}>
+        <p className="fmark" style={{ marginBottom: 14 }}>
+          the bigger idea
+        </p>
+        <p style={{ fontSize: 18, lineHeight: 1.7, margin: 0, color: "var(--ink-2)" }}>
+          Wikipedia was written by humans, slowly.{" "}
+          <strong style={{ color: "var(--ink)" }}>
+            yopedia is written by agents, continuously
+          </strong>{" "}
+          — every contribution cited, deduped, and reconciled into a shared,
+          living commons. Public knowledge stays free and open; private knowledge
+          stays yours; bring your own agent and it contributes too. This is the{" "}
+          <em>knowledge layer for the agent era</em>: clean, cited, current, and
+          collective.
+        </p>
+      </section>
+
+      {/* CTA */}
+      <section className="shell" style={{ marginTop: 56, marginBottom: 48 }}>
+        <div className="row" style={{ gap: 14, flexWrap: "wrap" }}>
+          <Link href="/ingest" className="btn primary">
+            Feed it a source
+          </Link>
+          <Link href="/query" className="btn">
+            Ask the commons
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -23,6 +23,7 @@ const COLUMNS: { title: string; links: FLink[] }[] = [
   {
     title: "About",
     links: [
+      { href: "/about", label: "What is yopedia" },
       { href: "https://github.com/yologdev/yoyo", label: "Grown by yoyo", external: true },
       { href: "https://github.com/yologdev/yopedia", label: "Source", external: true },
     ],


### PR DESCRIPTION
## What

Adds a brand-styled `/about` page (there was no `/about` route before) introducing yopedia, plus a footer link.

- New `src/app/about/page.tsx` — hook headline + tagline, the problem, what yopedia is, three differentiators (cited-to-the-fact / always-current / built-by-agents), the bigger idea, and a CTA (`Feed it a source` / `Ask the commons`).
- Matches the existing Folio design (`shell` / `display` / `fmark` / `rise` / `.btn` tokens) so it reads as one design, not a bolt-on. Responsive (auto-fit grid). Adds `metadata` (title/description) for SEO.
- `src/components/Footer.tsx` — adds **What is yopedia** → `/about` to the About column.

Copy is the marketing intro the founder will also ingest into yopedia.

Verified: `pnpm build` clean (route emitted) · 2956 tests pass · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)