### PR TITLE
Fix 404 link after saving an HTML artifact; lead profile with artifacts

### DIFF
--- a/src/app/api/query/save/route.ts
+++ b/src/app/api/query/save/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { saveAnswerToWiki } from "@/lib/query";
 import { getPrincipal } from "@/lib/auth";
+import { commonsPath, pagePath, ownerToTenant } from "@/lib/links";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 
@@ -73,7 +74,15 @@ export async function POST(request: NextRequest) {
       owner,  // author — same as owner for web saves
     );
 
-    return NextResponse.json({ slug: result.slug, success: true });
+    // Return the CANONICAL url so the client links correctly. An HTML answer is
+    // an owned artifact → it lives at `/u/<tenant>/<slug>` and 404s at the
+    // commons `/wiki/<slug>`. A markdown save is a public commons page.
+    const url =
+      isHtml && owner
+        ? pagePath(ownerToTenant(owner), result.slug)
+        : commonsPath(result.slug);
+
+    return NextResponse.json({ slug: result.slug, url, success: true });
   } catch (error) {
     logger.error("query", "Save answer error", error);
     return NextResponse.json(

--- a/src/app/u/[handle]/page.tsx
+++ b/src/app/u/[handle]/page.tsx
@@ -183,23 +183,24 @@ export default async function UserPage({
         <p style={{ color: "var(--muted)" }}>No public pages yet.</p>
       )}
 
-      {/* Commons pages → a user-scoped activity trail (ingests + edits). */}
-      {trail.length > 0 && (
-        <section style={{ marginBottom: 40 }}>
-          <p className="fmark" style={{ marginBottom: 14 }}>
-            Activity
-          </p>
-          <Trail events={trail} />
-        </section>
-      )}
-
-      {/* Saved HTML artifacts → cards. */}
+      {/* Saved HTML artifacts → cards. Shown above the activity trail: an
+          artifact is the person's actual work, so it leads. */}
       {artifacts.length > 0 && (
-        <section>
+        <section style={{ marginBottom: 40 }}>
           <p className="fmark" style={{ marginBottom: 14 }}>
             {artifacts.length} {artifacts.length === 1 ? "artifact" : "artifacts"}
           </p>
           <ProfileBlogIndex pages={artifacts} discussionStats={discussionStats} />
+        </section>
+      )}
+
+      {/* Commons pages → a user-scoped activity trail (ingests + edits). */}
+      {trail.length > 0 && (
+        <section>
+          <p className="fmark" style={{ marginBottom: 14 }}>
+            Activity
+          </p>
+          <Trail events={trail} />
         </section>
       )}
 

--- a/src/components/QueryResultPanel.tsx
+++ b/src/components/QueryResultPanel.tsx
@@ -14,6 +14,8 @@ import type { QueryFormat } from "@/lib/query-format";
 interface SaveState {
   status: "idle" | "editing" | "saving" | "saved" | "error";
   slug?: string;
+  /** Canonical URL from the save API — correct for owned artifacts (`/u/...`). */
+  url?: string;
   error?: string;
 }
 
@@ -119,7 +121,7 @@ export function QueryResultPanel({
         return;
       }
 
-      setSaveState({ status: "saved", slug: data.slug });
+      setSaveState({ status: "saved", slug: data.slug, url: data.url });
 
       // Mark the history entry as saved
       if (currentHistoryId) {
@@ -268,7 +270,7 @@ export function QueryResultPanel({
             <Alert variant="success">
               {isHtml ? "Saved to your pages." : "Saved to the wiki."}{" "}
               <Link
-                href={hrefForSlug(saveState.slug)}
+                href={saveState.url ?? hrefForSlug(saveState.slug)}
                 className="underline font-medium hover:opacity-80"
               >
                 View →

--- a/src/lib/__tests__/query-save-route.test.ts
+++ b/src/lib/__tests__/query-save-route.test.ts
@@ -105,6 +105,19 @@ describe("POST /api/query/save", () => {
     expect((await res.json()).url).toBe("/u/test-user/test-page");
   });
 
+  it("normalizes the owner handle into the artifact url tenant (case-insensitive)", async () => {
+    mockedGetPrincipal.mockResolvedValueOnce({ id: "u", handle: "Test-User" });
+    const req = makeRequest({
+      title: "Chart",
+      content: "<!doctype html><html><body>x</body></html>",
+      format: "html",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    // ownerToTenant lowercases the handle → the link must resolve, not 404.
+    expect((await res.json()).url).toBe("/u/test-user/test-page");
+  });
+
   it("rejects an HTML save with 401 when the principal can't be resolved", async () => {
     mockedGetPrincipal.mockResolvedValueOnce(null);
     const req = makeRequest({

--- a/src/lib/__tests__/query-save-route.test.ts
+++ b/src/lib/__tests__/query-save-route.test.ts
@@ -58,6 +58,8 @@ describe("POST /api/query/save", () => {
       undefined,
       undefined,
     );
+    // A markdown save is a public commons page → /wiki/<slug>.
+    expect((await res.json()).url).toBe("/wiki/test-page");
   });
 
   it("calls saveAnswerToWiki without sources when sources is omitted", async () => {
@@ -99,6 +101,8 @@ describe("POST /api/query/save", () => {
       "test-user",
       "test-user",
     );
+    // The HTML artifact lives at the owner-scoped URL (it 404s at /wiki/<slug>).
+    expect((await res.json()).url).toBe("/u/test-user/test-page");
   });
 
   it("rejects an HTML save with 401 when the principal can't be resolved", async () => {


### PR DESCRIPTION
## Two fixes

### 1. Saved-HTML-artifact link 404
After saving an HTML answer, the "View →" link 404'd. The client built it via `hrefForSlug` (`useSlugTenants`), which falls back to `/wiki/<slug>` for any slug not yet in its cached slug→tenant map — and a **just-saved HTML artifact is owner-scoped**, so it 404s at the commons `/wiki/<slug>` (same class as the Trail #537 bug).

**Fix:** `/api/query/save` now returns the **canonical `url`** (the server knows the owner): `/u/<tenant>/<slug>` for an `html` artifact, `/wiki/<slug>` for a markdown commons save. `QueryResultPanel` links to that `url` (falling back to `hrefForSlug` only if absent).

### 2. Profile: artifacts above Activity
On `/u/<handle>`, the saved-artifacts section now renders **above** the Activity trail — an artifact is the person's actual work, so it leads.

## Tests
`query-save-route.test.ts` asserts the returned `url` is owner-scoped (`/u/test-user/test-page`) for html and commons (`/wiki/test-page`) for markdown.

Verified: `pnpm build` clean · 2956 tests pass · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)