### PR TITLE
Let ingested wiki pages include a Mermaid diagram where structural

### DIFF
--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -810,6 +810,8 @@ Then, on the following lines, the wiki article. Include:
 
 Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. KEEP the ones that are genuine content — diagrams, figures, charts, screenshots that illustrate the topic — by writing the SAME token on its own line at the most relevant point in the article (next to the text it illustrates). Omit any token whose image is clearly decorative/branding/UI. Never invent tokens or change their numbers; output each kept token verbatim.
 
+Diagrams: when the concept has a clear STRUCTURE (a flow, pipeline, architecture, hierarchy, sequence, or relationship), you MAY include ONE concise Mermaid diagram in a fenced \`\`\`mermaid code block (e.g. flowchart LR, graph TD, sequenceDiagram); it renders as a diagram. Use it only where it genuinely clarifies, base it strictly on the source, and keep node labels short. Most pages need none.
+
 Write a focused, distilled page, not a transcript of the source. Output the CONCEPT, ALIASES, and TAGS lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
 
 /**
@@ -850,6 +852,8 @@ Then the article: one \`# Title\` (the canonical concept), then EXACTLY ONE of e
 
 Images: the notes may contain placeholder tokens like \`[[IMG:1]]\`. Keep each genuine-content token on its own line at the most relevant point; never invent tokens or change their numbers; output each kept token verbatim.
 
+Diagrams: when the concept has a clear STRUCTURE (a flow, pipeline, architecture, hierarchy, sequence, or relationship), you MAY include ONE concise Mermaid diagram in a fenced \`\`\`mermaid code block (e.g. flowchart LR, graph TD, sequenceDiagram). Use it only where it genuinely clarifies, base it strictly on the notes, and keep node labels short. Most pages need none.
+
 Output the CONCEPT, ALIASES, and TAGS lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
 
 /**
@@ -862,7 +866,7 @@ const RECONCILE_SYSTEM_PROMPT = `You are a wiki editor maintaining a single cano
 
 Rules:
 - Preserve all substantive information from BOTH versions; integrate the new material rather than discarding what's already on the page.
-- Remove redundancy; keep the existing section structure (## Summary, ## Key Points, ## Concepts, ## Details) and any image markdown, without duplicating images.
+- Remove redundancy; keep the existing section structure (## Summary, ## Key Points, ## Concepts, ## Details) and any image markdown or Mermaid (\`\`\`mermaid) diagram blocks, without duplicating images or diagrams.
 - Do NOT invent anything not supported by either source.
 - If the new article CONTRADICTS the current page on any material fact, do not silently pick one side: keep both positions (attributing each) and begin your ENTIRE output with a single line, exactly:
 DISPUTED: yes


### PR DESCRIPTION
## What

Ingested wiki pages can now include a **Mermaid diagram** when the concept has a clear structure. The page renderer already supported ` ```mermaid ` blocks (via `MarkdownRenderer`, shipped in #548) — but the *ingest synthesis prompt* never asked for one, so pages never had diagrams. This closes that gap.

## How
- `INGEST_SYSTEM_PROMPT_BASE` (single-shot synthesis) + `REDUCE_SYSTEM_PROMPT` (long-content map-reduce) gain a concise "Diagrams" instruction: for a flow / pipeline / architecture / hierarchy / sequence / relationship, the model MAY include **one** concise Mermaid diagram, **sparingly** and **strictly grounded in the source**.
- `RECONCILE_SYSTEM_PROMPT` now preserves existing ` ```mermaid ` blocks alongside image markdown on re-ingest.

Free + safe (no image API), and the diagram is plain markdown — portable to the Obsidian silo export too.

## Verification
- `pnpm build` clean · 2977 tests pass · lint 0 errors.
- Manual after deploy: re-ingest a structural topic (e.g. an architecture/pipeline article) and confirm the page renders a Mermaid diagram where it helps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)