### PR TITLE
Bake yoyo illustrations at save + slide presentation min-height

### DIFF
--- a/src/components/SlidePreview.tsx
+++ b/src/components/SlidePreview.tsx
@@ -53,7 +53,7 @@ export function SlidePreview({ content }: SlidePreviewProps) {
         {slides.map((slide, i) => (
           <div
             key={i}
-            className="relative rounded-lg border border-foreground/10 bg-foreground/[0.02] p-6"
+            className="relative flex min-h-[20rem] flex-col justify-center rounded-lg border border-foreground/10 bg-foreground/[0.02] p-8"
           >
             <span className="absolute top-3 right-3 text-xs font-medium text-foreground/40 bg-foreground/5 rounded-full px-2 py-0.5">
               {i + 1}
@@ -70,7 +70,7 @@ export function SlidePreview({ content }: SlidePreviewProps) {
   return (
     <div className="space-y-4">
       {/* Slide card */}
-      <div className="relative rounded-lg border border-foreground/10 bg-foreground/[0.02] p-6 min-h-[12rem]">
+      <div className="relative flex min-h-[24rem] flex-col justify-center rounded-lg border border-foreground/10 bg-foreground/[0.02] p-8">
         <span className="absolute top-3 right-3 text-xs font-medium text-foreground/40 bg-foreground/5 rounded-full px-2 py-0.5">
           {safeIndex + 1}
         </span>

--- a/src/lib/__tests__/illustration-render.test.ts
+++ b/src/lib/__tests__/illustration-render.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   htmlHasYoyoIllustration,
+  markdownHasYoyoIllustration,
   renderYoyoIllustrationsInHtml,
+  renderYoyoIllustrationsInMarkdown,
   MAX_ILLUSTRATIONS,
 } from "../illustration-render";
 
@@ -77,5 +79,98 @@ describe("renderYoyoIllustrationsInHtml", () => {
       async () => "data:image/jpeg;base64,A$$B$&C",
     );
     expect(out).toContain('src="data:image/jpeg;base64,A$$B$&C"');
+  });
+
+  it("keeps the directive in place when generation fails and onMissing=keep", async () => {
+    const html = fig('data-scene="x"');
+    const out = await renderYoyoIllustrationsInHtml(html, async () => null, {
+      onMissing: "keep",
+    });
+    expect(out).toBe(html);
+  });
+});
+
+const mdFence = (scene = "yoyo carrying a box") =>
+  "```yoyo-illustration\n" + scene + "\n```";
+
+describe("markdownHasYoyoIllustration", () => {
+  it("detects a yoyo-illustration fence", () => {
+    expect(markdownHasYoyoIllustration(mdFence())).toBe(true);
+  });
+  it("is false otherwise", () => {
+    expect(markdownHasYoyoIllustration("```mermaid\ngraph TD\n```")).toBe(false);
+    expect(markdownHasYoyoIllustration("a yoyo-illustration in prose")).toBe(false);
+  });
+});
+
+describe("renderYoyoIllustrationsInMarkdown", () => {
+  it("returns markdown unchanged and never fetches with no directive", async () => {
+    let calls = 0;
+    const md = "# Slide\n\nbody";
+    const out = await renderYoyoIllustrationsInMarkdown(md, async () => {
+      calls++;
+      return "data:x";
+    });
+    expect(out).toBe(md);
+    expect(calls).toBe(0);
+  });
+
+  it("bakes the fence into a markdown image", async () => {
+    const out = await renderYoyoIllustrationsInMarkdown(
+      mdFence("yoyo holding a map"),
+      async () => "data:image/jpeg;base64,AAAA",
+    );
+    expect(out).toBe("![yoyo holding a map](data:image/jpeg;base64,AAAA)");
+  });
+
+  it("passes the trimmed scene to the fetcher", async () => {
+    let got = "";
+    await renderYoyoIllustrationsInMarkdown(
+      "```yoyo-illustration\n  spaced scene  \n```",
+      async (scene) => {
+        got = scene;
+        return "data:x";
+      },
+    );
+    expect(got).toBe("spaced scene");
+  });
+
+  it("sanitizes brackets/newlines out of the alt text", async () => {
+    const out = await renderYoyoIllustrationsInMarkdown(
+      "```yoyo-illustration\na [boxed] idea\n```",
+      async () => "data:x",
+    );
+    expect(out).toBe("![a boxed idea](data:x)");
+  });
+
+  it("drops a fence whose generation fails by default", async () => {
+    const out = await renderYoyoIllustrationsInMarkdown(mdFence(), async () => null);
+    expect(out).toBe("");
+  });
+
+  it("keeps the fence in place when generation fails and onMissing=keep", async () => {
+    const md = mdFence("x");
+    const out = await renderYoyoIllustrationsInMarkdown(md, async () => null, {
+      onMissing: "keep",
+    });
+    expect(out).toBe(md);
+  });
+
+  it(`caps generation at MAX_ILLUSTRATIONS (${MAX_ILLUSTRATIONS})`, async () => {
+    let calls = 0;
+    const md = Array.from({ length: 5 }, (_, i) => mdFence("s" + i)).join("\n\n");
+    await renderYoyoIllustrationsInMarkdown(md, async () => {
+      calls++;
+      return "data:img";
+    });
+    expect(calls).toBe(MAX_ILLUSTRATIONS);
+  });
+
+  it("does not corrupt $-patterns in the baked image (function replacement)", async () => {
+    const out = await renderYoyoIllustrationsInMarkdown(
+      mdFence("s"),
+      async () => "data:image/jpeg;base64,A$$B$&C",
+    );
+    expect(out).toBe("![s](data:image/jpeg;base64,A$$B$&C)");
   });
 });

--- a/src/lib/__tests__/query.test.ts
+++ b/src/lib/__tests__/query.test.ts
@@ -916,6 +916,37 @@ describe("saveAnswerToWiki", () => {
     expect(headingCount).toBe(1);
   });
 
+  it("bakes illustration directives at save time, keeping unfillable ones and leaving mermaid alone", async () => {
+    await ensureDirectories();
+    // No XAI_API_KEY in the test env → generation returns null, so the bake runs
+    // in the save path but each directive is *kept* (onMissing: "keep"), not
+    // stripped. This proves: (1) baking is wired before the write, (2) a
+    // transient/no-key failure never drops the directive from the stored page,
+    // and (3) mermaid (free, client-rendered) is untouched by baking.
+    await saveAnswerToWiki(
+      "Baked Deck",
+      [
+        "# Baked Deck",
+        "",
+        "```yoyo-illustration",
+        "yoyo holding a lantern",
+        "```",
+        "",
+        "```mermaid",
+        "flowchart LR; A-->B",
+        "```",
+      ].join("\n"),
+    );
+
+    const page = await readWikiPage("baked-deck");
+    expect(page).not.toBeNull();
+    // Directive preserved for on-demand fallback (not silently dropped)...
+    expect(page!.content).toContain("```yoyo-illustration");
+    expect(page!.content).toContain("yoyo holding a lantern");
+    // ...and the mermaid block is left exactly as written.
+    expect(page!.content).toContain("flowchart LR; A-->B");
+  });
+
   it("updates existing index entry on re-save", async () => {
     await ensureDirectories();
 

--- a/src/lib/illustration-render.ts
+++ b/src/lib/illustration-render.ts
@@ -57,6 +57,18 @@ function escapeHtml(s: string): string {
     .replace(/"/g, "&quot;");
 }
 
+/**
+ * What to do with a directive whose scene can't be generated.
+ * - `"drop"` (default): remove the placeholder — right for client-side iframe
+ *   rendering, where a leftover `data-scene` figure would just be blank.
+ * - `"keep"`: leave the original directive untouched — right for **baking at
+ *   save time**, so a transient generation failure doesn't permanently strip the
+ *   directive (an on-demand viewer can still fill it later).
+ */
+export interface RenderOptions {
+  onMissing?: "drop" | "keep";
+}
+
 /** True when an HTML document contains a `yoyo-illustration` figure. Pure. */
 export function htmlHasYoyoIllustration(html: string): boolean {
   return /<figure\b[^>]*\bclass=["'][^"']*\byoyo-illustration\b/i.test(html);
@@ -65,11 +77,12 @@ export function htmlHasYoyoIllustration(html: string): boolean {
 /**
  * Replace up to {@link MAX_ILLUSTRATIONS} `yoyo-illustration` figures in an HTML
  * string with the generated image (parallel). A figure whose scene can't be
- * generated is dropped (no broken placeholder).
+ * generated is dropped (default) or left in place (`onMissing: "keep"`).
  */
 export async function renderYoyoIllustrationsInHtml(
   html: string,
   fetcher: IllustrateFetcher = defaultFetcher,
+  { onMissing = "drop" }: RenderOptions = {},
 ): Promise<string> {
   const matches = [...html.matchAll(FIGURE_RE)].slice(0, MAX_ILLUSTRATIONS);
   if (matches.length === 0) return html;
@@ -90,8 +103,55 @@ export async function renderYoyoIllustrationsInHtml(
       ? `<figure class="yoyo-illustration"><img src="${image}" alt="${escapeHtml(
           alt,
         )}" style="max-width:100%;height:auto" /></figure>`
-      : ""; // generation failed — drop the placeholder
+      : onMissing === "keep"
+        ? match // preserve the directive — a viewer can still fill it on demand
+        : ""; // generation failed — drop the placeholder
     // Function replacement: a data-URI / alt text may contain `$&`/`$1`.
+    out = out.replace(match, () => replacement);
+  }
+  return out;
+}
+
+/** A ` ```yoyo-illustration ` fenced block; the body is the scene. */
+const MD_FENCE_RE = /```yoyo-illustration\b[^\n]*\n([\s\S]*?)\n```/g;
+
+/** True when markdown (e.g. slides) contains a `yoyo-illustration` fence. Pure. */
+export function markdownHasYoyoIllustration(md: string): boolean {
+  return /```yoyo-illustration\b/.test(md);
+}
+
+/**
+ * Replace up to {@link MAX_ILLUSTRATIONS} ` ```yoyo-illustration ` fences in a
+ * markdown string (slides) with a baked `![scene](data:...)` image. A fence
+ * whose scene can't be generated is dropped (default) or left in place
+ * (`onMissing: "keep"`). Used to bake slide illustrations at save time.
+ */
+export async function renderYoyoIllustrationsInMarkdown(
+  md: string,
+  fetcher: IllustrateFetcher = defaultFetcher,
+  { onMissing = "drop" }: RenderOptions = {},
+): Promise<string> {
+  const matches = [...md.matchAll(MD_FENCE_RE)].slice(0, MAX_ILLUSTRATIONS);
+  if (matches.length === 0) return md;
+
+  const filled = await Promise.all(
+    matches.map(async (m) => {
+      const scene = m[1].trim();
+      const image = scene ? await fetcher(scene, "English") : null;
+      return { match: m[0], image, alt: scene };
+    }),
+  );
+
+  let out = md;
+  for (const { match, image, alt } of filled) {
+    // Markdown alt can't span lines or hold `]` — collapse to a safe one-liner.
+    const safeAlt = alt.replace(/\s+/g, " ").replace(/[[\]]/g, "").trim();
+    const replacement = image
+      ? `![${safeAlt}](${image})`
+      : onMissing === "keep"
+        ? match
+        : "";
+    // Function replacement: a data-URI may contain `$&`/`$1`.
     out = out.replace(match, () => replacement);
   }
   return out;

--- a/src/lib/illustration-render.ts
+++ b/src/lib/illustration-render.ts
@@ -65,7 +65,7 @@ function escapeHtml(s: string): string {
  *   save time**, so a transient generation failure doesn't permanently strip the
  *   directive (an on-demand viewer can still fill it later).
  */
-export interface RenderOptions {
+export interface IllustrationRenderOptions {
   onMissing?: "drop" | "keep";
 }
 
@@ -82,7 +82,7 @@ export function htmlHasYoyoIllustration(html: string): boolean {
 export async function renderYoyoIllustrationsInHtml(
   html: string,
   fetcher: IllustrateFetcher = defaultFetcher,
-  { onMissing = "drop" }: RenderOptions = {},
+  { onMissing = "drop" }: IllustrationRenderOptions = {},
 ): Promise<string> {
   const matches = [...html.matchAll(FIGURE_RE)].slice(0, MAX_ILLUSTRATIONS);
   if (matches.length === 0) return html;
@@ -125,11 +125,17 @@ export function markdownHasYoyoIllustration(md: string): boolean {
  * markdown string (slides) with a baked `![scene](data:...)` image. A fence
  * whose scene can't be generated is dropped (default) or left in place
  * (`onMissing: "keep"`). Used to bake slide illustrations at save time.
+ *
+ * Labels bake in English — a slide fence carries no lang hint (unlike the HTML
+ * `data-lang`). A *kept* fence still renders in our app (the slide/page
+ * MarkdownRenderer routes it to `<YoyoIllustration>`), but shows as a literal
+ * code block in a plain-markdown viewer; that's the accepted price of not
+ * permanently dropping a directive on a transient failure.
  */
 export async function renderYoyoIllustrationsInMarkdown(
   md: string,
   fetcher: IllustrateFetcher = defaultFetcher,
-  { onMissing = "drop" }: RenderOptions = {},
+  { onMissing = "drop" }: IllustrationRenderOptions = {},
 ): Promise<string> {
   const matches = [...md.matchAll(MD_FENCE_RE)].slice(0, MAX_ILLUSTRATIONS);
   if (matches.length === 0) return md;

--- a/src/lib/illustration.ts
+++ b/src/lib/illustration.ts
@@ -2,6 +2,10 @@ import { getStorage } from "./storage";
 import { isEnoent } from "./errors";
 import { logger } from "./logger";
 import { YOYO_REFERENCE_PNG_BASE64 } from "./vendor/yoyo-reference.generated";
+import {
+  renderYoyoIllustrationsInHtml,
+  renderYoyoIllustrationsInMarkdown,
+} from "./illustration-render";
 
 /**
  * yoyo brand illustrations via the xAI Grok image API. The static brand DNA
@@ -150,6 +154,26 @@ export async function generateYoyoIllustration(
     .writeFile(relPathFor(key), dataUri)
     .catch((err) => logger.warn("illustration", "illustration cache write failed", err));
   return dataUri;
+}
+
+/**
+ * Bake any `yoyo-illustration` directives in a saved answer into the content
+ * itself — generating each image server-side (cache-first) and embedding the
+ * `data:` URI — so the stored artifact is self-contained: it renders for every
+ * viewer (including anonymous shares) with no per-view fetch or auth. Called at
+ * save time. Generation failures leave the directive in place (`onMissing:
+ * "keep"`) so a transient hiccup never permanently strips it. Returns the
+ * content unchanged when it carries no directives or there's no API key.
+ */
+export async function bakeYoyoIllustrations(
+  content: string,
+  isHtml: boolean,
+): Promise<string> {
+  const fetcher = (scene: string, lang: string) =>
+    generateYoyoIllustration(scene, lang);
+  return isHtml
+    ? renderYoyoIllustrationsInHtml(content, fetcher, { onMissing: "keep" })
+    : renderYoyoIllustrationsInMarkdown(content, fetcher, { onMissing: "keep" });
 }
 
 export const _internal = { buildIllustrationPrompt, cacheKeyFor };

--- a/src/lib/illustration.ts
+++ b/src/lib/illustration.ts
@@ -163,7 +163,9 @@ export async function generateYoyoIllustration(
  * viewer (including anonymous shares) with no per-view fetch or auth. Called at
  * save time. Generation failures leave the directive in place (`onMissing:
  * "keep"`) so a transient hiccup never permanently strips it. Returns the
- * content unchanged when it carries no directives or there's no API key.
+ * content unchanged when it carries no directives; a missing API key (or any
+ * generation failure) likewise leaves every directive in place via that same
+ * `onMissing: "keep"`.
  */
 export async function bakeYoyoIllustrations(
   content: string,

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -9,6 +9,7 @@ import {
 } from "./wiki";
 import { slugify } from "./slugify";
 import { htmlToPlainText, stripHtmlFence } from "./html";
+import { bakeYoyoIllustrations } from "./illustration";
 import { extractSummary } from "./ingest";
 import { loadPageConventions } from "./schema";
 import { serializeFrontmatter } from "./frontmatter";
@@ -326,7 +327,7 @@ export async function query(
  */
 export async function saveAnswerToWiki(
   title: string,
-  content: string,
+  rawContent: string,
   explicitSlug?: string,
   sources?: string[],
   contentType: "markdown" | "html" = "markdown",
@@ -340,6 +341,14 @@ export async function saveAnswerToWiki(
   }
 
   const isHtml = contentType === "html";
+
+  // Bake any `yoyo-illustration` directives into the content now (generate the
+  // image server-side, embed the data URI) so the SAVED artifact is permanent
+  // and self-contained — every viewer, including anonymous shares, sees it with
+  // no per-view fetch or auth. Mermaid stays client-rendered (it's free). A
+  // directive whose image can't be generated is left in place for on-demand
+  // fallback. No-op when there are no directives.
+  const content = await bakeYoyoIllustrations(rawContent, isHtml);
 
   // Strip any markdown code fence the model wrapped the document in, so the saved
   // page is clean HTML (stored as-is apart from that, with no H1 prepend — the


### PR DESCRIPTION
Addresses two slide/illustration issues from testing.

## 1. Slides need a min-height
Slide cards auto-sized to their content, so a short slide (e.g. a title) collapsed and a deck looked cramped/uneven. Each card now gets a presentation-like **min-height** (24rem single-view, 20rem show-all) with vertically-centered content, so a deck reads as slides rather than boxes. (`src/components/SlidePreview.tsx`)

## 2. Bake illustrations at save time (was on-demand per view)
Previously a `yoyo-illustration` directive was filled **client-side on every view** via `/api/illustrate` — wasteful, auth-gated (so anonymous shares saw nothing), and the image was never embedded in the saved artifact.

Now `saveAnswerToWiki` **bakes** directives into the stored content at save time:
- each scene is generated **server-side** (cache-first via `generateYoyoIllustration`) and the `data:` URI is embedded directly,
- so the saved page is **self-contained** — renders for every viewer (incl. anonymous) with **no per-view fetch or auth**,
- **Mermaid stays client-rendered** (it's free / no API cost),
- a scene that **can't** be generated keeps its directive in place (`onMissing: "keep"`), so a transient failure never permanently strips it — the on-demand path still serves as a fallback.

### Changes
- `illustration-render.ts` — `onMissing: "drop" | "keep"` option; new markdown variant `renderYoyoIllustrationsInMarkdown` + `markdownHasYoyoIllustration` (slide ` \`\`\`yoyo-illustration ` fences → `![scene](data:...)`).
- `illustration.ts` — `bakeYoyoIllustrations(content, isHtml)` wires the server generator as the fetcher.
- `query.ts` — `saveAnswerToWiki` bakes `rawContent` before write.

### Trade-off
Baked `data:` URIs (jpeg base64, ~tens–hundreds of KB each, capped at 3/doc) live in the stored page — larger pages in exchange for permanent, shareable, fetch-free illustrations. This is the explicit intent ("bake at save, it's waste if on demand").

### Notes
- The pre-save preview still fills illustrations on-demand (so you see them before saving); the cache means save-time generation reuses that work.
- "Illustration didn't show correctly" in slides: most likely no directive was emitted for that deck, or a Grok call failed. Baking makes a successful generation permanent; worth a `wrangler tail` check on the live site to confirm Grok returns an image end-to-end.

## Verification
- `pnpm build` clean · 2988 tests pass (13 new) · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)