### PR TITLE
Fix Grok image-edits call (JSON, not multipart) — illustrations now generate

### DIFF
--- a/src/lib/__tests__/illustration.test.ts
+++ b/src/lib/__tests__/illustration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { _internal } from "../illustration";
 import { SLIDES_FORMAT_INSTRUCTION, HTML_FORMAT_INSTRUCTION } from "../query";
 
@@ -28,5 +28,55 @@ describe("format instructions", () => {
     expect(HTML_FORMAT_INSTRUCTION).toContain("yoyo-illustration");
     // HTML uses the figure convention the renderer keys on.
     expect(HTML_FORMAT_INSTRUCTION).toContain('class="yoyo-illustration"');
+  });
+
+  it("reliably requests an illustration (not just 'sparingly/may')", () => {
+    // Regression: the old phrasing ("you MAY ... most slides need none") made the
+    // model emit zero illustrations, so the feature never appeared.
+    expect(SLIDES_FORMAT_INSTRUCTION).toMatch(/exactly one|at least one/i);
+    expect(HTML_FORMAT_INSTRUCTION).toMatch(/at least one|exactly one|include one/i);
+  });
+});
+
+describe("callGrok request format", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("posts JSON (not multipart) with the reference image as a data-URI image_url", async () => {
+    // Regression: xAI's /v1/images/edits rejects multipart FormData (the
+    // OpenAI-SDK shape) — it must be application/json with image:{type,url}.
+    let captured: { url: string; init: RequestInit } | null = null;
+    vi.stubGlobal("fetch", async (url: string, init: RequestInit) => {
+      captured = { url, init };
+      return new Response(
+        JSON.stringify({ data: [{ b64_json: "QUJD" }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    const out = await _internal.callGrok("draw yoyo", "test-key");
+
+    expect(out).toBe("data:image/jpeg;base64,QUJD");
+    expect(captured).not.toBeNull();
+    const { url, init } = captured!;
+    expect(url).toBe("https://api.x.ai/v1/images/edits");
+    expect(init.method).toBe("POST");
+    // JSON, not FormData.
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["Authorization"]).toBe("Bearer test-key");
+    expect(init.body).toBeTypeOf("string");
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe("grok-imagine-image-quality");
+    expect(body.prompt).toBe("draw yoyo");
+    expect(body.image.type).toBe("image_url");
+    expect(body.image.url).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it("returns null and does not throw on a non-OK response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      async () => new Response("bad request", { status: 400 }),
+    );
+    await expect(_internal.callGrok("x", "k")).resolves.toBeNull();
   });
 });

--- a/src/lib/illustration.ts
+++ b/src/lib/illustration.ts
@@ -62,33 +62,28 @@ async function readCache(key: string): Promise<string | null> {
   }
 }
 
-function base64ToBytes(b64: string): Uint8Array {
-  const bin = atob(b64);
-  const bytes = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-  return bytes;
-}
-
-/** Call Grok's image-edits endpoint with the brand reference → a jpeg data URI. */
+/** Call Grok's image-edits endpoint with the brand reference → a jpeg data URI.
+ *
+ * xAI's `/v1/images/edits` is **JSON, not multipart** — the OpenAI-SDK
+ * `images.edit()` shape (a `FormData` file upload) is rejected with a 4xx. The
+ * reference image is passed inline as a base64 data URI in an `image_url`
+ * object. See https://github.com/vercel/ai/issues/12368. */
 async function callGrok(prompt: string, key: string): Promise<string | null> {
-  const form = new FormData();
-  form.append(
-    "image",
-    // Cast: the lib's BlobPart doesn't accept the generic Uint8Array<ArrayBufferLike>.
-    new Blob([base64ToBytes(YOYO_REFERENCE_PNG_BASE64) as BlobPart], {
-      type: "image/png",
-    }),
-    "yoyo-reference.png",
-  );
-  form.append("prompt", prompt);
-  form.append("model", XAI_IMAGE_MODEL);
-  form.append("n", "1");
-  form.append("response_format", "b64_json");
-
   const res = await fetch(XAI_EDITS_ENDPOINT, {
     method: "POST",
-    headers: { Authorization: `Bearer ${key}` },
-    body: form,
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: XAI_IMAGE_MODEL,
+      prompt,
+      image: {
+        type: "image_url",
+        url: `data:image/png;base64,${YOYO_REFERENCE_PNG_BASE64}`,
+      },
+      response_format: "b64_json",
+    }),
   });
   if (!res.ok) {
     const snip = (await res.text().catch(() => "")).slice(0, 200).replace(/\s+/g, " ");
@@ -178,4 +173,4 @@ export async function bakeYoyoIllustrations(
     : renderYoyoIllustrationsInMarkdown(content, fetcher, { onMissing: "keep" });
 }
 
-export const _internal = { buildIllustrationPrompt, cacheKeyFor };
+export const _internal = { buildIllustrationPrompt, cacheKeyFor, callGrok };

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -79,7 +79,7 @@ The first slide should be a title slide with \`# {question}\`.
 Each subsequent slide should cover one key point with a heading and 2-4 bullet points.
 Keep slides concise — aim for 5-8 slides total.
 When a point is structural — a flow, process, architecture, hierarchy, sequence, or relationship — prefer a **Mermaid diagram** over a wall of bullets. Put it in a fenced \`\`\`mermaid code block (e.g. \`graph TD\`, \`flowchart LR\`, \`sequenceDiagram\`); it renders as a diagram. Keep node labels short.
-Sparingly — for at most 1-2 slides where a metaphor, a key judgment, a before/after, or a change-of-state would land better as a picture than text — you MAY request a hand-drawn **yoyo illustration** with a fenced \`\`\`yoyo-illustration block whose body is a short SCENE: what the yoyo octopus is doing with its tentacles to express the idea, plus 2-4 short labels. Use it for feeling/metaphor (not data, not structure). Most slides need none.
+Include **exactly one** hand-drawn **yoyo illustration** in the deck — on the single slide where a metaphor, a key judgment, a before/after, or a change-of-state lands better as a picture than text (often the title slide or the core-insight slide). Add it with a fenced \`\`\`yoyo-illustration block whose body is a short SCENE: what the yoyo octopus is doing with its tentacles to express that idea, plus 2-4 short labels. Use it for feeling/metaphor (not data, not structure) — keep it to one, never more than two.
 Include a final "Sources" slide citing wiki pages as [Page Title](slug.md).
 Use standard Marp markdown (no custom directives needed).
 Start the response with the Marp front matter:
@@ -125,9 +125,9 @@ DIAGRAMS — use Mermaid for structure (Chart.js is for data)
 - Supports \`flowchart\`/\`graph\`, \`sequenceDiagram\`, \`classDiagram\`, \`stateDiagram\`, \`erDiagram\`, and more. Keep node labels short; it's themed automatically — do not set colors.
 
 ILLUSTRATIONS — a hand-drawn yoyo picture, sparingly (feeling, not data/structure)
-- For at most 1-3 places where a metaphor, a key judgment, a before/after, or a change-of-state would land better as a PICTURE than prose, you MAY request a hand-drawn brand illustration with an EMPTY figure that carries the scene:
+- Include **at least one** hand-drawn brand illustration (and up to 3, for the places where a metaphor, a key judgment, a before/after, or a change-of-state lands better as a PICTURE than prose). Request each with an EMPTY figure that carries the scene:
   \`<figure class="yoyo-illustration" data-scene="A short scene: what the yoyo octopus is doing with its tentacles to express the idea, plus 2-4 short labels"></figure>\`
-- It renders to a generated image automatically (leave the figure empty — no \`<img>\`). Use it for FEELING/METAPHOR; use Chart.js for data and Mermaid for structure. Most answers need none; never more than 3.
+- It renders to a generated image automatically (leave the figure empty — no \`<img>\`). Use it for FEELING/METAPHOR; use Chart.js for data and Mermaid for structure. Never more than 3.
 
 INTERACTIVITY (optional, encouraged where it adds insight)
 - You MAY add small inline \`<script>\` for sliders/toggles that recompute and update a chart (mutate \`chart.data\` then call \`chart.update()\`). It runs in a locked-down sandbox: no network, no access outside the document.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,6 +18,12 @@
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
+	// Persist Worker logs (errors/warns from e.g. illustration generation) so they
+	// can be queried after the fact via `wrangler tail` / the dashboard, not just
+	// live-streamed.
+	"observability": {
+		"enabled": true
+	},
 	"assets": {
 		"directory": ".open-next/assets",
 		"binding": "ASSETS"


### PR DESCRIPTION
## Root cause: no yoyo illustration ever generated

The Grok image-edits request was malformed. xAI's `/v1/images/edits` requires **`Content-Type: application/json`** with the reference image inline as a base64 **data-URI `image_url` object** — it **rejects** the OpenAI-SDK multipart `FormData` shape with a 4xx ([vercel/ai#12368](https://github.com/vercel/ai/issues/12368)). Our `callGrok` sent `FormData`, so **every** generation returned null and no illustration ever appeared — independent of the prompt.

**Fix:** rewrite `callGrok` to POST JSON:
```json
{ "model": "grok-imagine-image-quality", "prompt": "...",
  "image": { "type": "image_url", "url": "data:image/png;base64,<ref>" },
  "response_format": "b64_json" }
```
Drops the now-unused `FormData`/`Blob`/`base64ToBytes` plumbing (and its `as BlobPart` cast). Response handling (b64_json → data URI, url → fetch+inline) is unchanged.

## Secondary: the prompt almost never asked for one

The slides/HTML format instructions said *"sparingly … you MAY … most need none"*, so the model emitted **zero** directives even when generation works. Now:
- **slides** request **exactly one** yoyo illustration (on the best metaphor/title slide),
- **HTML** requests **at least one** (still capped at 3).

## Also
- **Enable Worker `observability`** in `wrangler.jsonc` — illustration error logs (`logger.error/warn`) are now queryable after the fact, not just live via `wrangler tail`. (This is why "check the last query log" came up empty — nothing was persisted.)

## Tests
- `callGrok` posts **JSON not multipart**, with the data-URI `image_url`, `Authorization` bearer, and parses a `b64_json` response → `data:image/jpeg` URI.
- `callGrok` returns null (no throw) on a non-OK response.
- The prompts reliably request an illustration (guards against regressing to "sparingly/may").

Build + lint clean · 2992 tests pass (3 new).

## Verify after deploy
Ask a slides question → a yoyo illustration should render. With observability on, `wrangler tail yopedia` (or the dashboard) will show the `illustration` log line if anything still fails (401/403 = key issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)