### PR TITLE
Remote (HTTP) MCP endpoint + published SKILL.md

### DIFF
--- a/skills/yopedia-mcp/SKILL.md
+++ b/skills/yopedia-mcp/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: yopedia
+description: Read and ingest into yopedia — a cited, agent-maintained wiki — over the remote MCP endpoint. Use it to save URLs/notes into your own yopedia content and to query the wiki for cited answers.
+homepage: https://yopedia.yuanhao-li.workers.dev
+---
+
+# yopedia (remote MCP)
+
+yopedia is a cited, agent-maintained wiki. This skill lets any MCP-capable agent
+(Claude Desktop/Code, Cursor, OpenClaw, …) **read** the public commons and
+**ingest** content into the user's own yopedia — no browser extension, no
+copy-paste.
+
+## Connect
+
+The server speaks **stateless Streamable-HTTP JSON-RPC** at:
+
+```
+https://yopedia.yuanhao-li.workers.dev/api/mcp
+```
+
+- **Reads** (`search_wiki`, `read_page`, `list_pages`, `query_wiki`) need **no auth** — they run against the public commons.
+- **Writes** (`ingest_url`, `ingest_text`, `create_page`, `save_query_answer`, `reingest`) require a **Bearer token** and save into **that user's own content**.
+
+### Get a token (one-time)
+
+Your yopedia token is your **personal write credential — treat it like a
+password.** It's the token of your personal yopedia agent:
+
+1. Sign in to yopedia, then mint a token: `POST /api/agents/<your-agent-id>/token` (owner-only).
+2. Put it in the MCP client config as a Bearer header.
+
+### Client config examples
+
+**Claude Code:**
+```
+claude mcp add --transport http yopedia https://yopedia.yuanhao-li.workers.dev/api/mcp \
+  --header "Authorization: Bearer <YOUR_TOKEN>"
+```
+
+**Claude Desktop / Cursor** (`mcp.json`):
+```json
+{
+  "mcpServers": {
+    "yopedia": {
+      "url": "https://yopedia.yuanhao-li.workers.dev/api/mcp",
+      "headers": { "Authorization": "Bearer <YOUR_TOKEN>" }
+    }
+  }
+}
+```
+Omit the `Authorization` header for read-only access.
+
+## Tools
+
+| Tool | Auth | What it does |
+|------|------|--------------|
+| `search_wiki` | — | Full-text search the commons |
+| `read_page` | — | Read one page (markdown + frontmatter) by slug |
+| `list_pages` | — | List pages (sort: title/updated/confidence) |
+| `query_wiki` | — | LLM-synthesized, **cited** answer (format: prose/table/slides/html) |
+| `ingest_url` | Bearer | Fetch a URL (web/YouTube/X/PDF), summarize, save as your page |
+| `ingest_text` | Bearer | Save raw text/markdown as your page |
+| `create_page` | Bearer | Create a markdown page in your content |
+| `save_query_answer` | Bearer | Persist a Q&A as your page |
+| `reingest` | Bearer | Re-fetch a page's source and refresh it |
+
+## Typical use
+
+- "Add this to my wiki: <url>" → `ingest_url`. The agent ingests directly; the user never copy-pastes.
+- "What does my wiki say about agent harnesses?" → `query_wiki` (returns a cited answer).
+- "Save these notes as a page" → `ingest_text` / `create_page`.
+
+## Notes
+
+- The endpoint is POST-only stateless JSON-RPC (no SSE). Standard MCP clients connect over Streamable HTTP.
+- Ingested third-party content is treated as untrusted data when the wiki is read back (a data-vs-instructions boundary guards against indirect prompt injection).

--- a/src/app/api/__tests__/mcp-route.test.ts
+++ b/src/app/api/__tests__/mcp-route.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the auth resolution + the reused tool handlers so we test the ROUTE's
+// auth/attribution/transport logic in isolation (no storage/LLM).
+vi.mock("@/lib/agents", () => ({
+  verifyAgentToken: vi.fn(),
+  getAgent: vi.fn(),
+}));
+vi.mock("@/lib/auth", () => ({
+  getServicePrincipal: vi.fn(() => null),
+}));
+vi.mock("@/mcp", () => ({
+  handleSearchWiki: vi.fn(async () => []),
+  handleReadPage: vi.fn(),
+  handleListPages: vi.fn(),
+  handleQueryWiki: vi.fn(),
+  handleIngestUrl: vi.fn(),
+  handleIngestText: vi.fn(),
+  handleReingest: vi.fn(),
+  handleCreatePage: vi.fn(async () => ({ slug: "x", title: "X", created: true })),
+  handleSaveQueryAnswer: vi.fn(),
+}));
+
+import { verifyAgentToken, getAgent } from "@/lib/agents";
+import { getServicePrincipal } from "@/lib/auth";
+import { handleCreatePage } from "@/mcp";
+import { POST, GET } from "@/app/api/mcp/route";
+
+const mockedVerify = vi.mocked(verifyAgentToken);
+const mockedGetAgent = vi.mocked(getAgent);
+const mockedService = vi.mocked(getServicePrincipal);
+const mockedCreate = vi.mocked(handleCreatePage);
+
+function post(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/mcp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+const auth = (token: string) => ({ Authorization: `Bearer ${token}` });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedVerify.mockResolvedValue(null);
+  mockedGetAgent.mockResolvedValue(null);
+  mockedService.mockReturnValue(null);
+});
+
+describe("POST /api/mcp — auth resolution", () => {
+  it("allows unauthenticated reads (no token → tools/list 200)", async () => {
+    const res = await POST(post({ id: 1, method: "tools/list" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result.tools.length).toBeGreaterThan(0);
+  });
+
+  it("401s a presented-but-invalid token (not a silent downgrade to anon)", async () => {
+    // verifyAgentToken → null AND no service principal.
+    const res = await POST(post({ id: 1, method: "tools/list" }, auth("bogus")));
+    expect(res.status).toBe(401);
+  });
+
+  it("401s a valid token whose agent is gone (orphaned) — no anon downgrade", async () => {
+    mockedVerify.mockResolvedValue("alice--yoyo");
+    mockedGetAgent.mockResolvedValue(null); // deleted/renamed
+    const res = await POST(post({ id: 1, method: "tools/list" }, auth("t")));
+    expect(res.status).toBe(401);
+  });
+
+  it("500s (not 401) when the agent store errors — outage isn't masked as a bad token", async () => {
+    mockedVerify.mockResolvedValue("alice--yoyo");
+    mockedGetAgent.mockRejectedValue(new Error("R2 down"));
+    const res = await POST(post({ id: 1, method: "ping" }, auth("t")));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/mcp — write attribution", () => {
+  it("attributes a write to the agent's OWNER and ignores a spoofed arguments.owner", async () => {
+    mockedVerify.mockResolvedValue("alice--yoyo");
+    mockedGetAgent.mockResolvedValue({ owner: "alice" } as Awaited<ReturnType<typeof getAgent>>);
+
+    const res = await POST(
+      post(
+        {
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "create_page",
+            // Attacker tries to attribute the page to someone else.
+            arguments: { slug: "p", content: "# P", owner: "victim", author: "victim" },
+          },
+        },
+        auth("t"),
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedCreate).toHaveBeenCalledTimes(1);
+    const arg = mockedCreate.mock.calls[0][0];
+    // The resolved owner wins over the spoofed values.
+    expect(arg.owner).toBe("alice");
+    expect(arg.author).toBe("alice");
+  });
+
+  it("a write via the service token attributes to the service principal", async () => {
+    mockedService.mockReturnValue({ id: "service:sys", handle: "sys" });
+    const res = await POST(
+      post(
+        { id: 1, method: "tools/call", params: { name: "create_page", arguments: { slug: "p", content: "# P" } } },
+        auth("service-tok"),
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedCreate.mock.calls[0][0].owner).toBe("sys");
+  });
+
+  it("a write with no token returns an auth-required isError (handler not called)", async () => {
+    const res = await POST(
+      post({ id: 1, method: "tools/call", params: { name: "create_page", arguments: { slug: "p", content: "# P" } } }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result.isError).toBe(true);
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/mcp — transport", () => {
+  it("rejects an oversized batch with -32600/400", async () => {
+    const batch = Array.from({ length: 21 }, (_, i) => ({ id: i, method: "ping" }));
+    const res = await POST(post(batch));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe(-32600);
+  });
+
+  it("accepts a batch at the cap and returns an array of responses", async () => {
+    const batch = Array.from({ length: 20 }, (_, i) => ({ id: i, method: "ping" }));
+    const res = await POST(post(batch));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(20);
+  });
+
+  it("a batch of only notifications → 202 no body", async () => {
+    const res = await POST(post([{ method: "notifications/initialized" }]));
+    expect(res.status).toBe(202);
+  });
+
+  it("malformed JSON body → -32700/400", async () => {
+    const res = await POST(post("{not json"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe(-32700);
+  });
+
+  it("GET is 405 with Allow: POST", async () => {
+    const res = GET();
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("POST");
+  });
+});

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { verifyAgentToken, getAgent } from "@/lib/agents";
-import { getServicePrincipal } from "@/lib/auth";
-import { dispatchMcp, type JsonRpcRequest } from "@/lib/mcp-http";
+import { getServicePrincipal, type Principal } from "@/lib/auth";
+import { dispatchMcp, MCP_MAX_BATCH, type JsonRpcRequest } from "@/lib/mcp-http";
 import { logger } from "@/lib/logger";
 
 /**
@@ -23,16 +23,19 @@ import { logger } from "@/lib/logger";
  * Middleware-exempt (authenticates in-route via the token, not a Clerk session).
  */
 
-/** Resolve the write-owner handle from a Bearer token. Returns `{ owner }` on
- *  success (owner may be null = unauthenticated reads), or `{ unauthorized }`
- *  when a token was presented but is invalid. */
-async function resolveOwner(
+/** Resolve the calling principal from a Bearer token. Returns `{ principal }`
+ *  on success (principal may be null = unauthenticated reads), or
+ *  `{ unauthorized }` when a token was presented but is invalid. A per-user
+ *  agent token resolves to its human OWNER (handle), so writes attribute to and
+ *  are authorized as that user; the service token resolves to the trusted
+ *  service principal. */
+async function resolvePrincipal(
   req: Request,
-): Promise<{ owner: string | null } | { unauthorized: true }> {
+): Promise<{ principal: Principal | null } | { unauthorized: true }> {
   const bearer = req.headers
     .get("authorization")
     ?.match(/^Bearer\s+(.+)$/i)?.[1];
-  if (!bearer) return { owner: null };
+  if (!bearer) return { principal: null };
 
   const agentId = await verifyAgentToken(bearer);
   if (agentId) {
@@ -40,11 +43,14 @@ async function resolveOwner(
     // Token valid but the agent is gone (deleted/renamed) → no owner to
     // attribute to: reject rather than silently downgrade to anonymous.
     if (!agent?.owner) return { unauthorized: true };
-    return { owner: agent.owner };
+    // Act as the agent's human owner (handle-keyed ownership). The non-service
+    // id means this is NOT a write-anything principal — it can only write the
+    // owner's own pages + the public commons (canWriteFrontmatter).
+    return { principal: { id: `agent:${agentId}`, handle: agent.owner } };
   }
 
   const service = getServicePrincipal(req);
-  if (service) return { owner: service.handle };
+  if (service) return { principal: service };
 
   return { unauthorized: true };
 }
@@ -53,14 +59,14 @@ const PARSE_ERROR: JsonRpcRequest = {};
 
 export async function POST(req: Request) {
   try {
-    const auth = await resolveOwner(req);
+    const auth = await resolvePrincipal(req);
     if ("unauthorized" in auth) {
       return NextResponse.json(
         { error: "Invalid token." },
         { status: 401 },
       );
     }
-    const owner = auth.owner;
+    const principal = auth.principal;
 
     let body: unknown;
     try {
@@ -74,9 +80,20 @@ export async function POST(req: Request) {
 
     // JSON-RPC batch (array) or single message.
     if (Array.isArray(body)) {
+      if (body.length > MCP_MAX_BATCH) {
+        // Each message can fan out to a fetch + LLM call — cap the burst.
+        return NextResponse.json(
+          {
+            jsonrpc: "2.0",
+            id: null,
+            error: { code: -32600, message: `Batch too large (max ${MCP_MAX_BATCH}).` },
+          },
+          { status: 400 },
+        );
+      }
       const responses = (
         await Promise.all(
-          body.map((m) => dispatchMcp((m ?? PARSE_ERROR) as JsonRpcRequest, owner)),
+          body.map((m) => dispatchMcp((m ?? PARSE_ERROR) as JsonRpcRequest, principal)),
         )
       ).filter((r) => r !== null);
       // All notifications → 202 with no body.
@@ -84,7 +101,7 @@ export async function POST(req: Request) {
       return NextResponse.json(responses);
     }
 
-    const res = await dispatchMcp((body ?? PARSE_ERROR) as JsonRpcRequest, owner);
+    const res = await dispatchMcp((body ?? PARSE_ERROR) as JsonRpcRequest, principal);
     if (res === null) return new NextResponse(null, { status: 202 });
     return NextResponse.json(res);
   } catch (err) {

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server";
+import { verifyAgentToken, getAgent } from "@/lib/agents";
+import { getServicePrincipal } from "@/lib/auth";
+import { dispatchMcp, type JsonRpcRequest } from "@/lib/mcp-http";
+import { logger } from "@/lib/logger";
+
+/**
+ * Remote (HTTP) MCP endpoint — stateless Streamable-HTTP JSON-RPC. External
+ * agents (Claude Desktop/Code, Cursor, OpenClaw) POST one MCP message per
+ * request: `initialize`, `tools/list`, `tools/call`. See `src/lib/mcp-http.ts`.
+ *
+ * Auth is by Bearer token and resolves a write `owner`:
+ *   - a per-user **agent token** (minted via /api/agents/[id]/token) → the
+ *     agent's human **owner**, so writes land in THAT user's content. This is
+ *     the user's personal write credential (treat it like a password). It is a
+ *     deliberately broader grant than the per-agent `/api/agents/[id]/ingest`
+ *     route, which scopes writes to agent-knowledge — here the human is driving
+ *     their own client, so their writes are their own pages.
+ *   - the **service token** → the configured service principal.
+ *   - **no token** → reads still work (public commons); write tools return an
+ *     auth-required tool error.
+ *
+ * Middleware-exempt (authenticates in-route via the token, not a Clerk session).
+ */
+
+/** Resolve the write-owner handle from a Bearer token. Returns `{ owner }` on
+ *  success (owner may be null = unauthenticated reads), or `{ unauthorized }`
+ *  when a token was presented but is invalid. */
+async function resolveOwner(
+  req: Request,
+): Promise<{ owner: string | null } | { unauthorized: true }> {
+  const bearer = req.headers
+    .get("authorization")
+    ?.match(/^Bearer\s+(.+)$/i)?.[1];
+  if (!bearer) return { owner: null };
+
+  const agentId = await verifyAgentToken(bearer);
+  if (agentId) {
+    const agent = await getAgent(agentId).catch(() => null);
+    // Token valid but the agent is gone (deleted/renamed) → no owner to
+    // attribute to: reject rather than silently downgrade to anonymous.
+    if (!agent?.owner) return { unauthorized: true };
+    return { owner: agent.owner };
+  }
+
+  const service = getServicePrincipal(req);
+  if (service) return { owner: service.handle };
+
+  return { unauthorized: true };
+}
+
+const PARSE_ERROR: JsonRpcRequest = {};
+
+export async function POST(req: Request) {
+  try {
+    const auth = await resolveOwner(req);
+    if ("unauthorized" in auth) {
+      return NextResponse.json(
+        { error: "Invalid token." },
+        { status: 401 },
+      );
+    }
+    const owner = auth.owner;
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json(
+        { jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } },
+        { status: 400 },
+      );
+    }
+
+    // JSON-RPC batch (array) or single message.
+    if (Array.isArray(body)) {
+      const responses = (
+        await Promise.all(
+          body.map((m) => dispatchMcp((m ?? PARSE_ERROR) as JsonRpcRequest, owner)),
+        )
+      ).filter((r) => r !== null);
+      // All notifications → 202 with no body.
+      if (responses.length === 0) return new NextResponse(null, { status: 202 });
+      return NextResponse.json(responses);
+    }
+
+    const res = await dispatchMcp((body ?? PARSE_ERROR) as JsonRpcRequest, owner);
+    if (res === null) return new NextResponse(null, { status: 202 });
+    return NextResponse.json(res);
+  } catch (err) {
+    logger.error("mcp", "remote MCP request failed", err);
+    return NextResponse.json(
+      { jsonrpc: "2.0", id: null, error: { code: -32603, message: "Internal error" } },
+      { status: 500 },
+    );
+  }
+}
+
+/** The transport is stateless POST-only (no SSE/session stream). */
+export function GET() {
+  return NextResponse.json(
+    { error: "Method Not Allowed — POST JSON-RPC to this endpoint." },
+    { status: 405, headers: { Allow: "POST" } },
+  );
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -23,36 +23,41 @@ import { logger } from "@/lib/logger";
  * Middleware-exempt (authenticates in-route via the token, not a Clerk session).
  */
 
-/** Resolve the calling principal from a Bearer token. Returns `{ principal }`
- *  on success (principal may be null = unauthenticated reads), or
- *  `{ unauthorized }` when a token was presented but is invalid. A per-user
- *  agent token resolves to its human OWNER (handle), so writes attribute to and
- *  are authorized as that user; the service token resolves to the trusted
- *  service principal. */
-async function resolvePrincipal(
-  req: Request,
-): Promise<{ principal: Principal | null } | { unauthorized: true }> {
+/** `kind:"ok"` carries the caller (null = unauthenticated reads); `unauthorized`
+ *  means a token was presented but is invalid → 401. Literal discriminant so the
+ *  three outcomes are compiler-checked, not a structural `in` probe. */
+type AuthResult =
+  | { kind: "ok"; principal: Principal | null }
+  | { kind: "unauthorized" };
+
+/** Resolve the calling principal from a Bearer token. A per-user agent token
+ *  resolves to its human OWNER (handle), so writes attribute to and are
+ *  authorized as that user; the service token resolves to the trusted service
+ *  principal; no token → unauthenticated (reads only). */
+async function resolvePrincipal(req: Request): Promise<AuthResult> {
   const bearer = req.headers
     .get("authorization")
     ?.match(/^Bearer\s+(.+)$/i)?.[1];
-  if (!bearer) return { principal: null };
+  if (!bearer) return { kind: "ok", principal: null };
 
   const agentId = await verifyAgentToken(bearer);
   if (agentId) {
-    const agent = await getAgent(agentId).catch(() => null);
-    // Token valid but the agent is gone (deleted/renamed) → no owner to
+    // getAgent returns null on not-found (→ reject) and throws only on a real
+    // storage error (→ propagates to the outer catch → logged 500, not masked
+    // as a bad token). Token valid but the agent is gone → no owner to
     // attribute to: reject rather than silently downgrade to anonymous.
-    if (!agent?.owner) return { unauthorized: true };
+    const agent = await getAgent(agentId);
+    if (!agent?.owner) return { kind: "unauthorized" };
     // Act as the agent's human owner (handle-keyed ownership). The non-service
     // id means this is NOT a write-anything principal — it can only write the
     // owner's own pages + the public commons (canWriteFrontmatter).
-    return { principal: { id: `agent:${agentId}`, handle: agent.owner } };
+    return { kind: "ok", principal: { id: `agent:${agentId}`, handle: agent.owner } };
   }
 
   const service = getServicePrincipal(req);
-  if (service) return { principal: service };
+  if (service) return { kind: "ok", principal: service };
 
-  return { unauthorized: true };
+  return { kind: "unauthorized" };
 }
 
 const PARSE_ERROR: JsonRpcRequest = {};
@@ -60,7 +65,7 @@ const PARSE_ERROR: JsonRpcRequest = {};
 export async function POST(req: Request) {
   try {
     const auth = await resolvePrincipal(req);
-    if ("unauthorized" in auth) {
+    if (auth.kind === "unauthorized") {
       return NextResponse.json(
         { error: "Invalid token." },
         { status: 401 },

--- a/src/lib/__tests__/mcp-http.test.ts
+++ b/src/lib/__tests__/mcp-http.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  dispatchMcp,
+  MCP_TOOLS,
+  MCP_PROTOCOL_VERSION,
+  MCP_SERVER_INFO,
+} from "../mcp-http";
+
+// These exercise the JSON-RPC envelope + auth gating, which need no storage/LLM
+// (a write tool is rejected BEFORE its handler runs when there's no owner).
+
+describe("dispatchMcp — protocol", () => {
+  it("initialize returns protocol version + serverInfo + tools capability", async () => {
+    const res = await dispatchMcp({ id: 1, method: "initialize" }, null);
+    expect(res).not.toBeNull();
+    expect(res!.result).toMatchObject({
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      serverInfo: MCP_SERVER_INFO,
+      capabilities: { tools: {} },
+    });
+  });
+
+  it("ping returns an empty result", async () => {
+    const res = await dispatchMcp({ id: 2, method: "ping" }, null);
+    expect(res!.result).toEqual({});
+  });
+
+  it("notifications get no response (null)", async () => {
+    expect(await dispatchMcp({ method: "notifications/initialized" }, null)).toBeNull();
+  });
+
+  it("unknown method is a JSON-RPC method-not-found error", async () => {
+    const res = await dispatchMcp({ id: 3, method: "frobnicate" }, null);
+    expect(res!.error?.code).toBe(-32601);
+  });
+
+  it("echoes the request id (incl. null)", async () => {
+    const res = await dispatchMcp({ id: "abc", method: "ping" }, null);
+    expect(res!.id).toBe("abc");
+  });
+});
+
+describe("dispatchMcp — tools/list", () => {
+  it("lists the curated tools with name/description/inputSchema", async () => {
+    const res = await dispatchMcp({ id: 1, method: "tools/list" }, null);
+    const tools = (res!.result as { tools: { name: string; inputSchema: unknown }[] }).tools;
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("search_wiki");
+    expect(names).toContain("query_wiki");
+    expect(names).toContain("ingest_url");
+    expect(names).toContain("ingest_text");
+    // Every descriptor carries a schema; the internal `write`/`run` fields are
+    // NOT leaked to the wire.
+    for (const t of tools) {
+      expect(t.inputSchema).toBeTypeOf("object");
+      expect(t).not.toHaveProperty("write");
+      expect(t).not.toHaveProperty("run");
+    }
+  });
+});
+
+describe("dispatchMcp — tools/call auth gating", () => {
+  it("rejects an unknown tool as an isError result (not a crash)", async () => {
+    const res = await dispatchMcp(
+      { id: 1, method: "tools/call", params: { name: "no_such_tool", arguments: {} } },
+      "alice",
+    );
+    const r = res!.result as { isError?: boolean; content: { text: string }[] };
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/unknown tool/i);
+  });
+
+  it("blocks a WRITE tool when unauthenticated (owner=null) before running it", async () => {
+    const res = await dispatchMcp(
+      { id: 1, method: "tools/call", params: { name: "ingest_url", arguments: { url: "https://example.com" } } },
+      null,
+    );
+    const r = res!.result as { isError?: boolean; content: { text: string }[] };
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/authentication required/i);
+  });
+
+  it("every write tool is gated and every read tool is open", () => {
+    const writes = MCP_TOOLS.filter((t) => t.write).map((t) => t.name);
+    const reads = MCP_TOOLS.filter((t) => !t.write).map((t) => t.name);
+    expect(writes).toEqual(
+      expect.arrayContaining(["ingest_url", "ingest_text", "create_page", "save_query_answer", "reingest"]),
+    );
+    expect(reads).toEqual(
+      expect.arrayContaining(["search_wiki", "read_page", "list_pages", "query_wiki"]),
+    );
+  });
+});

--- a/src/lib/__tests__/mcp-http.test.ts
+++ b/src/lib/__tests__/mcp-http.test.ts
@@ -1,13 +1,45 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
 import {
   dispatchMcp,
   MCP_TOOLS,
+  MCP_MAX_BATCH,
   MCP_PROTOCOL_VERSION,
   MCP_SERVER_INFO,
 } from "../mcp-http";
+import { ensureDirectories } from "../wiki";
+import { _resetStorage } from "../storage";
+import type { Principal } from "../auth";
 
-// These exercise the JSON-RPC envelope + auth gating, which need no storage/LLM
-// (a write tool is rejected BEFORE its handler runs when there's no owner).
+const ALICE: Principal = { id: "agent:a--yoyo", handle: "alice" };
+
+// Most cases exercise the JSON-RPC envelope + auth gating, which need no
+// storage/LLM (a write tool is rejected BEFORE its handler runs when there's no
+// principal). The reingest-ACL case touches storage, so set up a temp wiki.
+let tmpDir: string;
+let prevWiki: string | undefined;
+let prevRaw: string | undefined;
+let prevData: string | undefined;
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-http-test-"));
+  prevWiki = process.env.WIKI_DIR;
+  prevRaw = process.env.RAW_DIR;
+  prevData = process.env.DATA_DIR;
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetStorage();
+  await ensureDirectories();
+});
+afterEach(async () => {
+  process.env.WIKI_DIR = prevWiki;
+  process.env.RAW_DIR = prevRaw;
+  process.env.DATA_DIR = prevData;
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
 
 describe("dispatchMcp — protocol", () => {
   it("initialize returns protocol version + serverInfo + tools capability", async () => {
@@ -63,14 +95,14 @@ describe("dispatchMcp — tools/call auth gating", () => {
   it("rejects an unknown tool as an isError result (not a crash)", async () => {
     const res = await dispatchMcp(
       { id: 1, method: "tools/call", params: { name: "no_such_tool", arguments: {} } },
-      "alice",
+      ALICE,
     );
     const r = res!.result as { isError?: boolean; content: { text: string }[] };
     expect(r.isError).toBe(true);
     expect(r.content[0].text).toMatch(/unknown tool/i);
   });
 
-  it("blocks a WRITE tool when unauthenticated (owner=null) before running it", async () => {
+  it("blocks a WRITE tool when unauthenticated (principal=null) before running it", async () => {
     const res = await dispatchMcp(
       { id: 1, method: "tools/call", params: { name: "ingest_url", arguments: { url: "https://example.com" } } },
       null,
@@ -78,6 +110,16 @@ describe("dispatchMcp — tools/call auth gating", () => {
     const r = res!.result as { isError?: boolean; content: { text: string }[] };
     expect(r.isError).toBe(true);
     expect(r.content[0].text).toMatch(/authentication required/i);
+  });
+
+  it("reingest denies (cloaked) a missing/unauthorized page before any fetch", async () => {
+    const res = await dispatchMcp(
+      { id: 1, method: "tools/call", params: { name: "reingest", arguments: { slug: "does-not-exist" } } },
+      ALICE,
+    );
+    const r = res!.result as { isError?: boolean; content: { text: string }[] };
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/not found or you don't have permission/i);
   });
 
   it("every write tool is gated and every read tool is open", () => {
@@ -89,5 +131,9 @@ describe("dispatchMcp — tools/call auth gating", () => {
     expect(reads).toEqual(
       expect.arrayContaining(["search_wiki", "read_page", "list_pages", "query_wiki"]),
     );
+  });
+
+  it("exposes a batch cap constant", () => {
+    expect(MCP_MAX_BATCH).toBeGreaterThan(0);
   });
 });

--- a/src/lib/__tests__/middleware-write-gate.test.ts
+++ b/src/lib/__tests__/middleware-write-gate.test.ts
@@ -29,6 +29,8 @@ describe("write-gate in-route auth exemptions", () => {
     // Wiki routes: POST /api/wiki (create) and PUT/PATCH/DELETE /api/wiki/:slug
     expect(authenticatesInRoute("/api/wiki")).toBe(true);
     expect(authenticatesInRoute("/api/wiki/transformers")).toBe(true);
+    // Remote MCP — Bearer token (per-user agent token / service token).
+    expect(authenticatesInRoute("/api/mcp")).toBe(true);
   });
 
   it("does NOT exempt normal write paths (they need a Clerk session)", () => {

--- a/src/lib/mcp-http.ts
+++ b/src/lib/mcp-http.ts
@@ -1,0 +1,303 @@
+/**
+ * Stateless JSON-RPC dispatch for the REMOTE (HTTP) MCP endpoint at
+ * `/api/mcp`. yopedia's MCP server is otherwise stdio-only; this exposes the
+ * same tools to external agents (Claude Desktop/Code, Cursor, OpenClaw) over
+ * HTTP so they can read and ingest into a DEPLOYED instance.
+ *
+ * Transport: Streamable-HTTP in **stateless** mode — each POST is one
+ * self-contained JSON-RPC message (no SSE, no session). That's the only viable
+ * shape on this stack (Cloudflare Workers, no Durable Objects for the SDK's
+ * session-backed transport), and it's enough for `initialize` → `tools/list` →
+ * `tools/call`.
+ *
+ * Tool handlers are REUSED from the stdio server (`@/mcp`) — single source of
+ * truth, no parallel write-path to drift (see `.yoyo/learnings.md`). We expose a
+ * curated subset (read + ingestion/query), not all 43 tools: smaller surface,
+ * less agent context.
+ *
+ * Auth/attribution lives in the route (`src/app/api/mcp/route.ts`): a Bearer
+ * token resolves to an `owner` handle; WRITE tools require it and attribute the
+ * page to that owner. Reads run unauthenticated against the public commons.
+ */
+import {
+  handleSearchWiki,
+  handleReadPage,
+  handleListPages,
+  handleQueryWiki,
+  handleIngestUrl,
+  handleIngestText,
+  handleReingest,
+  handleCreatePage,
+  handleSaveQueryAnswer,
+} from "@/mcp";
+
+/** Protocol version we advertise in `initialize`. */
+export const MCP_PROTOCOL_VERSION = "2025-06-18";
+export const MCP_SERVER_INFO = { name: "yopedia", version: "1.0.0" } as const;
+
+// ---------------------------------------------------------------------------
+// JSON-RPC envelope
+// ---------------------------------------------------------------------------
+
+export interface JsonRpcRequest {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+function ok(id: JsonRpcRequest["id"], result: unknown): JsonRpcResponse {
+  return { jsonrpc: "2.0", id: id ?? null, result };
+}
+function rpcError(
+  id: JsonRpcRequest["id"],
+  code: number,
+  message: string,
+): JsonRpcResponse {
+  return { jsonrpc: "2.0", id: id ?? null, error: { code, message } };
+}
+
+/** A tool result in MCP's content shape. `isError` surfaces a handled failure. */
+function toolResult(data: unknown, isError = false) {
+  return {
+    content: [{ type: "text" as const, text: jsonText(data) }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+function jsonText(data: unknown): string {
+  return typeof data === "string" ? data : JSON.stringify(data, null, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Curated tool registry
+// ---------------------------------------------------------------------------
+
+interface ToolDef {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  /** Write tools require an authenticated `owner`; reads don't. */
+  write: boolean;
+  run: (
+    args: Record<string, unknown>,
+    owner: string | null,
+  ) => Promise<unknown>;
+}
+
+const str = (description: string) => ({ type: "string", description });
+const optStr = str;
+const schema = (
+  props: Record<string, unknown>,
+  required: string[] = [],
+): Record<string, unknown> => ({
+  type: "object",
+  properties: props,
+  ...(required.length ? { required } : {}),
+});
+
+/** Owner-attribution for writes: every write tool stamps the resolved owner. */
+function attributed(
+  args: Record<string, unknown>,
+  owner: string,
+): Record<string, unknown> {
+  // Handlers destructure only the fields they accept; extra keys are ignored.
+  return { ...args, owner, author: owner, triggeredBy: owner };
+}
+
+export const MCP_TOOLS: ToolDef[] = [
+  {
+    name: "search_wiki",
+    description: "Search yopedia wiki pages by query string (public commons).",
+    inputSchema: schema(
+      {
+        query: str("Search query"),
+        limit: { type: "number", description: "Max results (default 10)" },
+        scope: optStr("Optional scope, e.g. 'agent:yoyo'"),
+      },
+      ["query"],
+    ),
+    write: false,
+    run: (a) => handleSearchWiki(a as Parameters<typeof handleSearchWiki>[0]),
+  },
+  {
+    name: "read_page",
+    description: "Read a single wiki page (markdown + frontmatter) by slug.",
+    inputSchema: schema({ slug: str("Page slug") }, ["slug"]),
+    write: false,
+    run: (a) => handleReadPage(a as Parameters<typeof handleReadPage>[0]),
+  },
+  {
+    name: "list_pages",
+    description: "List wiki pages, optionally sorted.",
+    inputSchema: schema({
+      sort: optStr("title | updated | confidence"),
+      limit: { type: "number", description: "Max results" },
+    }),
+    write: false,
+    run: (a) => handleListPages(a as Parameters<typeof handleListPages>[0]),
+  },
+  {
+    name: "query_wiki",
+    description:
+      "Ask a question; returns an LLM-synthesized, cited answer from the wiki.",
+    inputSchema: schema(
+      {
+        question: str("The question to answer"),
+        format: optStr("prose | table | slides | html (default prose)"),
+        scope: optStr("Optional scope, e.g. 'agent:yoyo'"),
+      },
+      ["question"],
+    ),
+    write: false,
+    run: (a) => handleQueryWiki(a as Parameters<typeof handleQueryWiki>[0]),
+  },
+  {
+    name: "ingest_url",
+    description:
+      "Fetch a URL (web/YouTube/X/PDF), summarize, and save it as a wiki page in YOUR content.",
+    inputSchema: schema(
+      {
+        url: str("The URL to ingest"),
+        tags: { type: "array", items: { type: "string" }, description: "Optional tags" },
+      },
+      ["url"],
+    ),
+    write: true,
+    run: (a, owner) =>
+      handleIngestUrl(
+        attributed(a, owner!) as Parameters<typeof handleIngestUrl>[0],
+      ),
+  },
+  {
+    name: "ingest_text",
+    description: "Ingest raw text/markdown as a wiki page in YOUR content.",
+    inputSchema: schema(
+      {
+        content: str("The text to ingest"),
+        title: optStr("Optional title"),
+        tags: { type: "array", items: { type: "string" }, description: "Optional tags" },
+      },
+      ["content"],
+    ),
+    write: true,
+    run: (a, owner) =>
+      handleIngestText(
+        attributed(a, owner!) as Parameters<typeof handleIngestText>[0],
+      ),
+  },
+  {
+    name: "create_page",
+    description: "Create a new wiki page (markdown) in YOUR content.",
+    inputSchema: schema(
+      {
+        slug: str("Page slug"),
+        content: str("Markdown body"),
+        tags: { type: "array", items: { type: "string" }, description: "Optional tags" },
+      },
+      ["slug", "content"],
+    ),
+    write: true,
+    run: (a, owner) =>
+      handleCreatePage(
+        attributed(a, owner!) as Parameters<typeof handleCreatePage>[0],
+      ),
+  },
+  {
+    name: "save_query_answer",
+    description: "Persist a question + answer as a wiki page in YOUR content.",
+    inputSchema: schema(
+      {
+        question: str("The question"),
+        answer: str("The answer (markdown/html/slides)"),
+        slug: optStr("Optional explicit slug"),
+        sources: { type: "array", items: { type: "string" }, description: "Cited slugs" },
+        format: optStr("markdown | html | slides"),
+      },
+      ["question", "answer"],
+    ),
+    write: true,
+    run: (a, owner) =>
+      handleSaveQueryAnswer(
+        attributed(a, owner!) as Parameters<typeof handleSaveQueryAnswer>[0],
+      ),
+  },
+  {
+    name: "reingest",
+    description: "Re-fetch a page's original source and refresh it.",
+    inputSchema: schema({ slug: str("Page slug to re-ingest") }, ["slug"]),
+    write: true,
+    run: (a) => handleReingest(a as Parameters<typeof handleReingest>[0]),
+  },
+];
+
+/** Public (transport-facing) tool descriptor for `tools/list`. */
+function toolDescriptor(t: ToolDef) {
+  return { name: t.name, description: t.description, inputSchema: t.inputSchema };
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle one JSON-RPC message. `owner` is the resolved write-principal handle
+ * (or null when unauthenticated — reads still work). Returns `null` for
+ * notifications (no response body). Tool failures surface as an `isError` tool
+ * result, not a JSON-RPC error, matching the stdio server's convention.
+ */
+export async function dispatchMcp(
+  msg: JsonRpcRequest,
+  owner: string | null,
+): Promise<JsonRpcResponse | null> {
+  const { id, method } = msg;
+  switch (method) {
+    case "initialize":
+      return ok(id, {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: MCP_SERVER_INFO,
+      });
+    case "notifications/initialized":
+    case "notifications/cancelled":
+      return null; // notifications get no response
+    case "ping":
+      return ok(id, {});
+    case "tools/list":
+      return ok(id, { tools: MCP_TOOLS.map(toolDescriptor) });
+    case "tools/call": {
+      const params = (msg.params ?? {}) as {
+        name?: string;
+        arguments?: Record<string, unknown>;
+      };
+      const tool = MCP_TOOLS.find((t) => t.name === params.name);
+      if (!tool) {
+        return ok(id, toolResult(`Unknown tool: ${params.name}`, true));
+      }
+      if (tool.write && !owner) {
+        return ok(
+          id,
+          toolResult(
+            "Authentication required: this tool writes to your content. Send Authorization: Bearer <your yopedia token>.",
+            true,
+          ),
+        );
+      }
+      try {
+        const result = await tool.run(params.arguments ?? {}, owner);
+        return ok(id, toolResult(result));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return ok(id, toolResult(`Error: ${message}`, true));
+      }
+    }
+    default:
+      return rpcError(id, -32601, `Method not found: ${method ?? "(none)"}`);
+  }
+}

--- a/src/lib/mcp-http.ts
+++ b/src/lib/mcp-http.ts
@@ -95,7 +95,6 @@ interface ToolDef {
 }
 
 const str = (description: string) => ({ type: "string", description });
-const optStr = str;
 const schema = (
   props: Record<string, unknown>,
   required: string[] = [],
@@ -122,7 +121,7 @@ export const MCP_TOOLS: ToolDef[] = [
       {
         query: str("Search query"),
         limit: { type: "number", description: "Max results (default 10)" },
-        scope: optStr("Optional scope, e.g. 'agent:yoyo'"),
+        scope: str("Optional scope, e.g. 'agent:yoyo'"),
       },
       ["query"],
     ),
@@ -140,7 +139,7 @@ export const MCP_TOOLS: ToolDef[] = [
     name: "list_pages",
     description: "List wiki pages, optionally sorted.",
     inputSchema: schema({
-      sort: optStr("title | updated | confidence"),
+      sort: str("title | updated | confidence"),
       limit: { type: "number", description: "Max results" },
     }),
     write: false,
@@ -153,8 +152,8 @@ export const MCP_TOOLS: ToolDef[] = [
     inputSchema: schema(
       {
         question: str("The question to answer"),
-        format: optStr("prose | table | slides | html (default prose)"),
-        scope: optStr("Optional scope, e.g. 'agent:yoyo'"),
+        format: str("prose | table | slides | html (default prose)"),
+        scope: str("Optional scope, e.g. 'agent:yoyo'"),
       },
       ["question"],
     ),
@@ -184,7 +183,7 @@ export const MCP_TOOLS: ToolDef[] = [
     inputSchema: schema(
       {
         content: str("The text to ingest"),
-        title: optStr("Optional title"),
+        title: str("Optional title"),
         tags: { type: "array", items: { type: "string" }, description: "Optional tags" },
       },
       ["content"],
@@ -219,9 +218,9 @@ export const MCP_TOOLS: ToolDef[] = [
       {
         question: str("The question"),
         answer: str("The answer (markdown/html/slides)"),
-        slug: optStr("Optional explicit slug"),
+        slug: str("Optional explicit slug"),
         sources: { type: "array", items: { type: "string" }, description: "Cited slugs" },
-        format: optStr("markdown | html | slides"),
+        format: str("markdown | html | slides"),
       },
       ["question", "answer"],
     ),

--- a/src/lib/mcp-http.ts
+++ b/src/lib/mcp-http.ts
@@ -30,6 +30,9 @@ import {
   handleCreatePage,
   handleSaveQueryAnswer,
 } from "@/mcp";
+import { readWikiPageWithFrontmatter } from "@/lib/wiki";
+import { canWriteFrontmatter } from "@/lib/authz";
+import type { Principal } from "@/lib/auth";
 
 /** Protocol version we advertise in `initialize`. */
 export const MCP_PROTOCOL_VERSION = "2025-06-18";
@@ -83,11 +86,11 @@ interface ToolDef {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
-  /** Write tools require an authenticated `owner`; reads don't. */
+  /** Write tools require an authenticated principal; reads don't. */
   write: boolean;
   run: (
     args: Record<string, unknown>,
-    owner: string | null,
+    principal: Principal | null,
   ) => Promise<unknown>;
 }
 
@@ -170,9 +173,9 @@ export const MCP_TOOLS: ToolDef[] = [
       ["url"],
     ),
     write: true,
-    run: (a, owner) =>
+    run: (a, p) =>
       handleIngestUrl(
-        attributed(a, owner!) as Parameters<typeof handleIngestUrl>[0],
+        attributed(a, p!.handle) as Parameters<typeof handleIngestUrl>[0],
       ),
   },
   {
@@ -187,9 +190,9 @@ export const MCP_TOOLS: ToolDef[] = [
       ["content"],
     ),
     write: true,
-    run: (a, owner) =>
+    run: (a, p) =>
       handleIngestText(
-        attributed(a, owner!) as Parameters<typeof handleIngestText>[0],
+        attributed(a, p!.handle) as Parameters<typeof handleIngestText>[0],
       ),
   },
   {
@@ -204,9 +207,9 @@ export const MCP_TOOLS: ToolDef[] = [
       ["slug", "content"],
     ),
     write: true,
-    run: (a, owner) =>
+    run: (a, p) =>
       handleCreatePage(
-        attributed(a, owner!) as Parameters<typeof handleCreatePage>[0],
+        attributed(a, p!.handle) as Parameters<typeof handleCreatePage>[0],
       ),
   },
   {
@@ -223,9 +226,9 @@ export const MCP_TOOLS: ToolDef[] = [
       ["question", "answer"],
     ),
     write: true,
-    run: (a, owner) =>
+    run: (a, p) =>
       handleSaveQueryAnswer(
-        attributed(a, owner!) as Parameters<typeof handleSaveQueryAnswer>[0],
+        attributed(a, p!.handle) as Parameters<typeof handleSaveQueryAnswer>[0],
       ),
   },
   {
@@ -233,7 +236,21 @@ export const MCP_TOOLS: ToolDef[] = [
     description: "Re-fetch a page's original source and refresh it.",
     inputSchema: schema({ slug: str("Page slug to re-ingest") }, ["slug"]),
     write: true,
-    run: (a) => handleReingest(a as Parameters<typeof handleReingest>[0]),
+    // Enforce the same write ACL as the REST reingest route: you can only
+    // re-synthesize a page you may write (public commons = collectively
+    // editable; another user's PRIVATE page = denied). Without this, any
+    // token-holder could overwrite/fork others' pages. A missing/unauthorized
+    // page throws a single cloaked error (no private-page existence oracle).
+    run: async (a, p) => {
+      const slug = typeof a.slug === "string" ? a.slug : "";
+      const page = slug ? await readWikiPageWithFrontmatter(slug) : null;
+      if (!page || !canWriteFrontmatter(page.frontmatter, p)) {
+        throw new Error(
+          `Page not found or you don't have permission to re-ingest it: ${slug || "(missing slug)"}`,
+        );
+      }
+      return handleReingest({ slug });
+    },
   },
 ];
 
@@ -246,15 +263,19 @@ function toolDescriptor(t: ToolDef) {
 // Dispatch
 // ---------------------------------------------------------------------------
 
+/** Max JSON-RPC messages in one batch (cost/DoS guard — each may fan out to a
+ *  network fetch + LLM call). */
+export const MCP_MAX_BATCH = 20;
+
 /**
- * Handle one JSON-RPC message. `owner` is the resolved write-principal handle
- * (or null when unauthenticated — reads still work). Returns `null` for
- * notifications (no response body). Tool failures surface as an `isError` tool
- * result, not a JSON-RPC error, matching the stdio server's convention.
+ * Handle one JSON-RPC message. `principal` is the resolved caller (or null when
+ * unauthenticated — reads still work). Returns `null` for notifications (no
+ * response body). Tool failures surface as an `isError` tool result, not a
+ * JSON-RPC error, matching the stdio server's convention.
  */
 export async function dispatchMcp(
   msg: JsonRpcRequest,
-  owner: string | null,
+  principal: Principal | null,
 ): Promise<JsonRpcResponse | null> {
   const { id, method } = msg;
   switch (method) {
@@ -280,7 +301,7 @@ export async function dispatchMcp(
       if (!tool) {
         return ok(id, toolResult(`Unknown tool: ${params.name}`, true));
       }
-      if (tool.write && !owner) {
+      if (tool.write && !principal) {
         return ok(
           id,
           toolResult(
@@ -290,7 +311,7 @@ export async function dispatchMcp(
         );
       }
       try {
-        const result = await tool.run(params.arguments ?? {}, owner);
+        const result = await tool.run(params.arguments ?? {}, principal);
         return ok(id, toolResult(result));
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,11 +26,13 @@ const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 //   - /api/wiki                   — Clerk session OR the system service token
 //   - /api/wiki/<slug>            — Clerk session OR the system service token
 //   - /api/wiki/<slug>/revisions   — Clerk session OR the system service token
+//   - /api/mcp                    — remote MCP: Bearer agent/service token (reads need none)
 // This is not a hole.
-//
-// The MCP server is stdio-only and not exposed over HTTP, so it is unaffected.
 const IN_ROUTE_AUTH_PATHS = new Set([
   "/api/agents/seed",
+  // Remote (HTTP) MCP endpoint — authenticates in-route via a Bearer token
+  // (per-user agent token or the service token); reads work unauthenticated.
+  "/api/mcp",
   "/api/ingest",
   "/api/ingest/batch",
   "/api/ingest/image",


### PR DESCRIPTION
**Roadmap phase 2** — the agent-mediated growth unlock. External agents (Claude Desktop/Code, Cursor, OpenClaw) can now **read and ingest into a DEPLOYED yopedia over HTTP**; previously MCP was stdio-only (local process).

## What
- **`src/app/api/mcp/route.ts`** — stateless **Streamable-HTTP JSON-RPC** endpoint: `initialize` / `tools/list` / `tools/call` / `ping` (single + batch). No Durable Objects are configured, so the SDK's session-backed transport isn't viable — stateless POST-only is the right shape here and is enough for MCP clients.
- **`src/lib/mcp-http.ts`** — dispatch + a **curated** tool registry (read: `search_wiki`, `read_page`, `list_pages`, `query_wiki`; write: `ingest_url`, `ingest_text`, `create_page`, `save_query_answer`, `reingest`). Handlers are **reused from the stdio server (`@/mcp`)** — single source of truth, no parallel write-path to drift. Tool failures surface as `isError` results (matches stdio convention).
- **`src/middleware.ts`** — `/api/mcp` authenticates in-route via Bearer, exempt from the Clerk write-gate (regression-tested).
- **`skills/yopedia-mcp/SKILL.md`** — published connect-and-use skill (endpoint, token, Claude Code/Desktop/Cursor configs, tool table).

## Auth & attribution (the chosen model)
A Bearer token resolves a write `owner`:
- **per-user agent token** (minted via `/api/agents/[id]/token`) → the agent's **human owner**, so writes land in **that user's content**;
- **service token** → the service principal;
- **no token** → reads still work (public commons); write tools return an auth-required `isError`.

Reads run unauthenticated (null principal → public commons only).

## ⚠️ Policy note for review
The personal token grants **owner-space writes** here — deliberately **broader** than the per-agent `/api/agents/[id]/ingest` route (which scopes writes to `agent-knowledge`). Rationale: in remote MCP the human personally holds and configured the token in their own client, so their writes are their own pages. The token is documented as the user's personal write credential ("treat it like a password"). Flagging explicitly so reviewers can sanity-check this widening.

## Validation
- **Next build AND the OpenNext Cloudflare Workers bundle both build clean** — confirmed the `@/mcp` (MCP SDK) import bundles for Workers (the main technical risk).
- 3036 tests (12 new: dispatch envelope/auth-gating + middleware exemption); lint 0 errors.

## Follow-ups (not in this PR)
- Authenticated **private reads** (today reads are public-commons only even with a token).
- Per-user **token minting UI** (today it's the `/api/agents/[id]/token` API).
- Expose more of the 43 tools if needed (curated subset keeps the surface small).

🤖 Generated with [Claude Code](https://claude.com/claude-code)