### PR TITLE
Per-agent target vault for remote-MCP writes

### DIFF
--- a/skills/yopedia-mcp/SKILL.md
+++ b/skills/yopedia-mcp/SKILL.md
@@ -65,6 +65,17 @@ Omit the `Authorization` header for read-only access.
 | `save_query_answer` | Bearer | Persist a Q&A as your page |
 | `reingest` | Bearer | Re-fetch a page's source and refresh it |
 
+## Target vault (where your saves land)
+
+By default, writes land in your own content. You can optionally route an agent's
+ingests into a specific **vault** — set `defaultVault` on the agent
+(`PUT /api/agents/<your-agent-id>` with `{ "defaultVault": "<vault-id>" }`,
+owner-only; must be a vault you own). When set, the MCP server tells the
+connecting agent (via the `initialize` instructions and the write-tool
+descriptions) that saves are filed into that vault, and every ingest is
+auto-added to it by reference. A private target vault works as a staging area
+you review before sharing.
+
 ## Typical use
 
 - "Add this to my wiki: <url>" → `ingest_url`. The agent ingests directly; the user never copy-pastes.

--- a/skills/yopedia-mcp/SKILL.md
+++ b/skills/yopedia-mcp/SKILL.md
@@ -73,8 +73,10 @@ ingests into a specific **vault** — set `defaultVault` on the agent
 owner-only; must be a vault you own). When set, the MCP server tells the
 connecting agent (via the `initialize` instructions and the write-tool
 descriptions) that saves are filed into that vault, and every ingest is
-auto-added to it by reference. A private target vault works as a staging area
-you review before sharing.
+auto-added to it by reference. Note: the page itself still lands in the public
+commons (attributed to you) immediately — the vault holds a *reference* to it,
+so filing into a private vault curates a private reference list, it does not yet
+keep the page itself private (clone-to-private is not implemented).
 
 ## Typical use
 

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -117,6 +117,8 @@ export async function DELETE(_req: Request, { params }: RouteParams) {
  *   - `description?` — new description
  *   - `addPages?` — array of `{ slug, title, type, content }` to create and link
  *   - `removePages?` — array of slugs to unlink (does NOT delete wiki pages)
+ *   - `defaultVault?` — vault id to file this agent's remote-MCP ingests into
+ *     (must be a vault you own; `""`/`null` clears it)
  *
  * Only the owner may update (feed) the agent. Returns the updated profile.
  * 403 if not the owner, 404 if agent doesn't exist, 400 for validation.

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -184,8 +184,10 @@ export async function PUT(req: Request, { params }: RouteParams) {
     const message = getErrorMessage(err);
     if (
       message.includes("Invalid agent ID") ||
-      message.includes("must be a non-empty string")
+      message.includes("must be a non-empty string") ||
+      message.includes("must be a vault you own")
     ) {
+      // Caller-input validation failures (incl. a bad `defaultVault`) are 400s.
       return NextResponse.json({ error: message }, { status: 400 });
     }
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,7 +1,13 @@
 import { NextResponse } from "next/server";
 import { verifyAgentToken, getAgent } from "@/lib/agents";
 import { getServicePrincipal, type Principal } from "@/lib/auth";
-import { dispatchMcp, MCP_MAX_BATCH, type JsonRpcRequest } from "@/lib/mcp-http";
+import { getVault, vaultOwnedBy } from "@/lib/vault";
+import {
+  dispatchMcp,
+  MCP_MAX_BATCH,
+  type JsonRpcRequest,
+  type TargetVault,
+} from "@/lib/mcp-http";
 import { logger } from "@/lib/logger";
 
 /**
@@ -27,8 +33,20 @@ import { logger } from "@/lib/logger";
  *  means a token was presented but is invalid → 401. Literal discriminant so the
  *  three outcomes are compiler-checked, not a structural `in` probe. */
 type AuthResult =
-  | { kind: "ok"; principal: Principal | null }
+  | { kind: "ok"; principal: Principal | null; targetVault: TargetVault | null }
   | { kind: "unauthorized" };
+
+/** Resolve an agent's configured `defaultVault` to a usable target — only if it
+ *  still exists and is owned by `owner` (stale/foreign ids are ignored, not an
+ *  error). */
+async function resolveTargetVault(
+  vaultId: string | undefined,
+  owner: string,
+): Promise<TargetVault | null> {
+  if (!vaultId || !vaultOwnedBy(vaultId, owner)) return null;
+  const vault = await getVault(vaultId);
+  return vault ? { id: vault.id, name: vault.name } : null;
+}
 
 /** Resolve the calling principal from a Bearer token. A per-user agent token
  *  resolves to its human OWNER (handle), so writes attribute to and are
@@ -38,7 +56,7 @@ async function resolvePrincipal(req: Request): Promise<AuthResult> {
   const bearer = req.headers
     .get("authorization")
     ?.match(/^Bearer\s+(.+)$/i)?.[1];
-  if (!bearer) return { kind: "ok", principal: null };
+  if (!bearer) return { kind: "ok", principal: null, targetVault: null };
 
   const agentId = await verifyAgentToken(bearer);
   if (agentId) {
@@ -51,11 +69,15 @@ async function resolvePrincipal(req: Request): Promise<AuthResult> {
     // Act as the agent's human owner (handle-keyed ownership). The non-service
     // id means this is NOT a write-anything principal — it can only write the
     // owner's own pages + the public commons (canWriteFrontmatter).
-    return { kind: "ok", principal: { id: `agent:${agentId}`, handle: agent.owner } };
+    return {
+      kind: "ok",
+      principal: { id: `agent:${agentId}`, handle: agent.owner },
+      targetVault: await resolveTargetVault(agent.defaultVault, agent.owner),
+    };
   }
 
   const service = getServicePrincipal(req);
-  if (service) return { kind: "ok", principal: service };
+  if (service) return { kind: "ok", principal: service, targetVault: null };
 
   return { kind: "unauthorized" };
 }
@@ -71,7 +93,7 @@ export async function POST(req: Request) {
         { status: 401 },
       );
     }
-    const principal = auth.principal;
+    const { principal, targetVault } = auth;
 
     let body: unknown;
     try {
@@ -98,7 +120,9 @@ export async function POST(req: Request) {
       }
       const responses = (
         await Promise.all(
-          body.map((m) => dispatchMcp((m ?? PARSE_ERROR) as JsonRpcRequest, principal)),
+          body.map((m) =>
+            dispatchMcp((m ?? PARSE_ERROR) as JsonRpcRequest, principal, targetVault),
+          ),
         )
       ).filter((r) => r !== null);
       // All notifications → 202 with no body.
@@ -106,7 +130,11 @@ export async function POST(req: Request) {
       return NextResponse.json(responses);
     }
 
-    const res = await dispatchMcp((body ?? PARSE_ERROR) as JsonRpcRequest, principal);
+    const res = await dispatchMcp(
+      (body ?? PARSE_ERROR) as JsonRpcRequest,
+      principal,
+      targetVault,
+    );
     if (res === null) return new NextResponse(null, { status: 202 });
     return NextResponse.json(res);
   } catch (err) {

--- a/src/lib/__tests__/agents-id-route.test.ts
+++ b/src/lib/__tests__/agents-id-route.test.ts
@@ -93,6 +93,12 @@ describe("PUT /api/agents/[id] — ownership", () => {
     expect(mockedUpdate).not.toHaveBeenCalled();
   });
 
+  it("returns 400 (not 500) for an invalid defaultVault", async () => {
+    mockedUpdate.mockRejectedValue(new Error("defaultVault must be a vault you own"));
+    const res = await PUT(putReq({ defaultVault: "bob--x" }), { params });
+    expect(res.status).toBe(400);
+  });
+
   it("returns 404 when the agent does not exist", async () => {
     mockedAssert.mockResolvedValue(null);
     const res = await PUT(putReq({ name: "x" }), { params });

--- a/src/lib/__tests__/agents.test.ts
+++ b/src/lib/__tests__/agents.test.ts
@@ -27,6 +27,7 @@ import {
 import type { UpdateAgentPage } from "../agents";
 import { readWikiPage, readWikiPageWithFrontmatter } from "../wiki";
 import type { AgentProfile } from "../types";
+import { createVault } from "../vault";
 import { _resetStorage, getStorage } from "../storage";
 
 // ---------------------------------------------------------------------------
@@ -174,6 +175,46 @@ describe("getAgent", () => {
     await expect(getAgent("INVALID")).rejects.toThrow(/Invalid agent ID/);
     await expect(getAgent("")).rejects.toThrow(/Invalid agent ID/);
     await expect(getAgent("-bad")).rejects.toThrow(/Invalid agent ID/);
+  });
+});
+
+describe("updateAgent — defaultVault", () => {
+  async function aliceAgent(): Promise<AgentProfile> {
+    const profile = makeProfile({ id: "alice--yoyo", owner: "alice" });
+    await registerAgent(profile);
+    return profile;
+  }
+
+  it("sets a target vault the owner owns", async () => {
+    await aliceAgent();
+    const vault = await createVault("alice", "Inbox", "public");
+    const updated = await updateAgent("alice--yoyo", { defaultVault: vault.id });
+    expect(updated!.defaultVault).toBe(vault.id);
+    // Persisted.
+    expect((await getAgent("alice--yoyo"))!.defaultVault).toBe(vault.id);
+  });
+
+  it("rejects a vault the owner does not own", async () => {
+    await aliceAgent();
+    const foreign = await createVault("bob", "Stuff", "public");
+    await expect(
+      updateAgent("alice--yoyo", { defaultVault: foreign.id }),
+    ).rejects.toThrow(/vault you own/i);
+  });
+
+  it("rejects a non-existent vault (even with the owner's prefix)", async () => {
+    await aliceAgent();
+    await expect(
+      updateAgent("alice--yoyo", { defaultVault: "alice--ghost" }),
+    ).rejects.toThrow(/vault you own/i);
+  });
+
+  it("clears the target vault with an empty string", async () => {
+    await aliceAgent();
+    const vault = await createVault("alice", "Inbox", "public");
+    await updateAgent("alice--yoyo", { defaultVault: vault.id });
+    const cleared = await updateAgent("alice--yoyo", { defaultVault: "" });
+    expect(cleared!.defaultVault).toBeUndefined();
   });
 });
 

--- a/src/lib/__tests__/mcp-http.test.ts
+++ b/src/lib/__tests__/mcp-http.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../mcp-http";
 import { ensureDirectories } from "../wiki";
 import { _resetStorage } from "../storage";
+import { createVault, vaultSlugs } from "../vault";
 import type { Principal } from "../auth";
 
 const ALICE: Principal = { id: "agent:a--yoyo", handle: "alice" };
@@ -135,5 +136,61 @@ describe("dispatchMcp — tools/call auth gating", () => {
 
   it("exposes a batch cap constant", () => {
     expect(MCP_MAX_BATCH).toBeGreaterThan(0);
+  });
+});
+
+describe("dispatchMcp — per-agent target vault", () => {
+  const VAULT = { id: "alice--inbox", name: "Inbox" };
+
+  it("initialize surfaces the target vault in instructions (and omits it without one)", async () => {
+    const withVault = await dispatchMcp({ id: 1, method: "initialize" }, ALICE, VAULT);
+    expect((withVault!.result as { instructions?: string }).instructions).toMatch(/Inbox/);
+    const without = await dispatchMcp({ id: 1, method: "initialize" }, ALICE, null);
+    expect((without!.result as { instructions?: string }).instructions).toBeUndefined();
+  });
+
+  it("tools/list appends the vault destination to WRITE tool descriptions only", async () => {
+    const res = await dispatchMcp({ id: 1, method: "tools/list" }, ALICE, VAULT);
+    const tools = (res!.result as { tools: { name: string; description: string }[] }).tools;
+    const ingest = tools.find((t) => t.name === "ingest_url")!;
+    const search = tools.find((t) => t.name === "search_wiki")!;
+    expect(ingest.description).toMatch(/Inbox/);
+    expect(search.description).not.toMatch(/Inbox/);
+  });
+
+  it("files a created page into the target vault and notes it in the result", async () => {
+    const vault = await createVault("alice", "Inbox", "public");
+    const res = await dispatchMcp(
+      {
+        id: 1,
+        method: "tools/call",
+        params: { name: "create_page", arguments: { slug: "from-agent", content: "# From Agent\n\nbody." } },
+      },
+      ALICE,
+      { id: vault.id, name: vault.name },
+    );
+    const r = res!.result as { isError?: boolean; content: { text: string }[] };
+    expect(r.isError).toBeFalsy();
+    // The new page is referenced into the vault, and the result records it.
+    expect(await vaultSlugs(vault.id)).toContain("from-agent");
+    expect(r.content[0].text).toContain("filedIntoVault");
+  });
+
+  it("a vault-filing failure does not fail the write (fail-soft)", async () => {
+    // No such vault → addToVault's mutate is a no-op/throws internally; the page
+    // is still created and the call succeeds.
+    const res = await dispatchMcp(
+      {
+        id: 1,
+        method: "tools/call",
+        params: { name: "create_page", arguments: { slug: "still-created", content: "# X\n\nbody." } },
+      },
+      ALICE,
+      { id: "alice--ghost", name: "Ghost" },
+    );
+    const r = res!.result as { isError?: boolean };
+    expect(r.isError).toBeFalsy();
+    const { readWikiPage } = await import("../wiki");
+    expect(await readWikiPage("still-created")).not.toBeNull();
   });
 });

--- a/src/lib/__tests__/mcp-http.test.ts
+++ b/src/lib/__tests__/mcp-http.test.ts
@@ -8,6 +8,7 @@ import {
   MCP_MAX_BATCH,
   MCP_PROTOCOL_VERSION,
   MCP_SERVER_INFO,
+  _internal,
 } from "../mcp-http";
 import { ensureDirectories } from "../wiki";
 import { _resetStorage } from "../storage";
@@ -174,6 +175,16 @@ describe("dispatchMcp — per-agent target vault", () => {
     // The new page is referenced into the vault, and the result records it.
     expect(await vaultSlugs(vault.id)).toContain("from-agent");
     expect(r.content[0].text).toContain("filedIntoVault");
+  });
+
+  it("resultSlug reads `slug` (most write tools) and `primarySlug` (reingest)", () => {
+    // Guards the reingest filing path: reingest returns IngestResult with
+    // primarySlug and no top-level slug.
+    expect(_internal.resultSlug({ slug: "a" })).toBe("a");
+    expect(_internal.resultSlug({ primarySlug: "b" })).toBe("b");
+    expect(_internal.resultSlug({ slug: "a", primarySlug: "b" })).toBe("a");
+    expect(_internal.resultSlug({})).toBeNull();
+    expect(_internal.resultSlug("nope")).toBeNull();
   });
 
   it("a vault-filing failure does not fail the write (fail-soft)", async () => {

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -16,6 +16,7 @@ import { serializeFrontmatter } from "./frontmatter";
 import { slugify } from "./slugify";
 import { writeWikiPageWithSideEffects } from "./lifecycle";
 import { readWikiPageWithFrontmatter } from "./wiki";
+import { getVault, vaultOwnedBy } from "./vault";
 import { logger } from "./logger";
 import type { AgentProfile } from "./types";
 
@@ -560,6 +561,9 @@ export interface UpdateAgentOptions {
   addPages?: UpdateAgentPage[];
   /** Slugs to remove from the profile's page lists (does NOT delete wiki pages). */
   removePages?: string[];
+  /** Vault id to file this agent's remote-MCP ingests into (must be a vault the
+   *  agent's owner owns). Pass `""`/`null` to clear. */
+  defaultVault?: string | null;
 }
 
 /**
@@ -599,6 +603,24 @@ export async function updateAgent(
       throw new Error("Agent description must be a non-empty string");
     }
     existing.description = options.description;
+  }
+  if (options.defaultVault !== undefined) {
+    if (!options.defaultVault) {
+      // "" / null clears the target vault.
+      delete existing.defaultVault;
+    } else {
+      // Must be a vault the agent's OWNER owns AND that exists — so a target
+      // can't point at someone else's (or a phantom) vault.
+      const vault = await getVault(options.defaultVault);
+      if (
+        !vault ||
+        !existing.owner ||
+        !vaultOwnedBy(options.defaultVault, existing.owner)
+      ) {
+        throw new Error("defaultVault must be a vault you own");
+      }
+      existing.defaultVault = options.defaultVault;
+    }
   }
 
   // Remove pages from lists (before adding, so add-then-remove of same slug

--- a/src/lib/mcp-http.ts
+++ b/src/lib/mcp-http.ts
@@ -274,8 +274,9 @@ function toolDescriptor(t: ToolDef) {
  *  network fetch + LLM call). */
 export const MCP_MAX_BATCH = 20;
 
-/** A new page's slug from a write-tool result (handlers vary: ingest →
- *  `primarySlug`, create/save → `slug`). */
+/** A new page's slug from a write-tool result. Most handlers return a top-level
+ *  `slug` (ingest_url/ingest_text/create_page/save_query_answer); `reingest`
+ *  returns the raw IngestResult with `primarySlug`. Probe both. */
 function resultSlug(result: unknown): string | null {
   if (result && typeof result === "object") {
     const r = result as { slug?: unknown; primarySlug?: unknown };

--- a/src/lib/mcp-http.ts
+++ b/src/lib/mcp-http.ts
@@ -32,7 +32,15 @@ import {
 } from "@/mcp";
 import { readWikiPageWithFrontmatter } from "@/lib/wiki";
 import { canWriteFrontmatter } from "@/lib/authz";
+import { addToVault } from "@/lib/vault";
+import { logger } from "@/lib/logger";
 import type { Principal } from "@/lib/auth";
+
+/** The resolved vault that an authenticated caller's ingests are filed into. */
+export interface TargetVault {
+  id: string;
+  name: string;
+}
 
 /** Protocol version we advertise in `initialize`. */
 export const MCP_PROTOCOL_VERSION = "2025-06-18";
@@ -266,31 +274,83 @@ function toolDescriptor(t: ToolDef) {
  *  network fetch + LLM call). */
 export const MCP_MAX_BATCH = 20;
 
+/** A new page's slug from a write-tool result (handlers vary: ingest →
+ *  `primarySlug`, create/save → `slug`). */
+function resultSlug(result: unknown): string | null {
+  if (result && typeof result === "object") {
+    const r = result as { slug?: unknown; primarySlug?: unknown };
+    if (typeof r.slug === "string") return r.slug;
+    if (typeof r.primarySlug === "string") return r.primarySlug;
+  }
+  return null;
+}
+
+/**
+ * After a successful write, file the new page into the caller's per-agent target
+ * vault (by reference). Fail-soft: the page is already written, so a vault hiccup
+ * must never fail the call — log and return the result unchanged.
+ */
+async function fileIntoVault(
+  result: unknown,
+  targetVault: TargetVault | null,
+): Promise<unknown> {
+  if (!targetVault) return result;
+  const slug = resultSlug(result);
+  if (!slug) return result;
+  try {
+    await addToVault(targetVault.id, slug);
+    return result && typeof result === "object"
+      ? { ...result, filedIntoVault: targetVault.id }
+      : result;
+  } catch (err) {
+    logger.warn("mcp", `vault filing failed for ${slug} → ${targetVault.id}`, err);
+    return result;
+  }
+}
+
 /**
  * Handle one JSON-RPC message. `principal` is the resolved caller (or null when
- * unauthenticated — reads still work). Returns `null` for notifications (no
- * response body). Tool failures surface as an `isError` tool result, not a
+ * unauthenticated — reads still work); `targetVault` is the caller's per-agent
+ * vault that successful ingests are filed into. Returns `null` for notifications
+ * (no response body). Tool failures surface as an `isError` tool result, not a
  * JSON-RPC error, matching the stdio server's convention.
  */
 export async function dispatchMcp(
   msg: JsonRpcRequest,
   principal: Principal | null,
+  targetVault: TargetVault | null = null,
 ): Promise<JsonRpcResponse | null> {
   const { id, method } = msg;
   switch (method) {
-    case "initialize":
+    case "initialize": {
+      // Tell the connecting agent where its saves land (the user configured a
+      // target vault for this agent) — prompt-level transparency; the server
+      // still enforces attribution + vault filing.
+      const instructions = targetVault
+        ? `Pages you save (ingest_url/ingest_text/create_page/save_query_answer) are filed into the user's "${targetVault.name}" vault, attributed to the user.`
+        : undefined;
       return ok(id, {
         protocolVersion: MCP_PROTOCOL_VERSION,
         capabilities: { tools: {} },
         serverInfo: MCP_SERVER_INFO,
+        ...(instructions ? { instructions } : {}),
       });
+    }
     case "notifications/initialized":
     case "notifications/cancelled":
       return null; // notifications get no response
     case "ping":
       return ok(id, {});
-    case "tools/list":
-      return ok(id, { tools: MCP_TOOLS.map(toolDescriptor) });
+    case "tools/list": {
+      // Append the vault destination to write-tool descriptions so the agent
+      // sees it in the schema, not just the initialize instructions.
+      const suffix = targetVault ? ` Filed into the "${targetVault.name}" vault.` : "";
+      const tools = MCP_TOOLS.map((t) => {
+        const d = toolDescriptor(t);
+        return t.write && suffix ? { ...d, description: d.description + suffix } : d;
+      });
+      return ok(id, { tools });
+    }
     case "tools/call": {
       const params = (msg.params ?? {}) as {
         name?: string;
@@ -311,7 +371,8 @@ export async function dispatchMcp(
       }
       try {
         const result = await tool.run(params.arguments ?? {}, principal);
-        return ok(id, toolResult(result));
+        const filed = tool.write ? await fileIntoVault(result, targetVault) : result;
+        return ok(id, toolResult(filed));
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return ok(id, toolResult(`Error: ${message}`, true));

--- a/src/lib/mcp-http.ts
+++ b/src/lib/mcp-http.ts
@@ -266,6 +266,9 @@ function toolDescriptor(t: ToolDef) {
   return { name: t.name, description: t.description, inputSchema: t.inputSchema };
 }
 
+/** Exposed for tests (the reingest→primarySlug filing contract). */
+export const _internal = { resultSlug };
+
 // ---------------------------------------------------------------------------
 // Dispatch
 // ---------------------------------------------------------------------------

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -239,6 +239,10 @@ export interface AgentProfile {
   learningPages: string[];
   /** Wiki page slugs containing social wisdom */
   socialPages: string[];
+  /** Optional vault id this agent's remote-MCP ingests are filed into (by
+   *  reference). Set by the owner; must be a vault they own. Surfaced to the
+   *  connecting agent via the MCP `initialize` instructions. */
+  defaultVault?: string;
   /** ISO date of when the agent was registered */
   registered: string;
   /** ISO date of last context update */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -241,7 +241,8 @@ export interface AgentProfile {
   socialPages: string[];
   /** Optional vault id this agent's remote-MCP ingests are filed into (by
    *  reference). Set by the owner; must be a vault they own. Surfaced to the
-   *  connecting agent via the MCP `initialize` instructions. */
+   *  connecting agent via the MCP `initialize` instructions and the write-tool
+   *  descriptions in `tools/list`. */
   defaultVault?: string;
   /** ISO date of when the agent was registered */
   registered: string;


### PR DESCRIPTION
**Roadmap phase 2b** (the slice we agreed after #569). Optionally route an agent's remote-MCP ingests into a designated **vault** — so writes land in a named bucket (organization + blast-radius containment + a private **staging** area) instead of straight into the user's owner-space.

## Design: server enforces, prompt informs
Per the agreed split — the destination is configured per-agent server-side; the agent is *told* but can't pick freely.

- **`AgentProfile.defaultVault`** (optional vault id) — set **owner-only** via `PUT /api/agents/[id]` (`UpdateAgentOptions.defaultVault`). `updateAgent` validates it's a vault the agent's **owner** owns and that **exists** (`""`/`null` clears). Reuses `vaultOwnedBy` + `getVault`.
- **`/api/mcp`** resolves the agent's `defaultVault` → a `TargetVault` (re-checking ownership + existence; stale/foreign ids are ignored, not an error) and threads it into dispatch.
- **`dispatchMcp`**: after a successful **write**, files the new page into the target vault **by reference** (`addToVault`) — **fail-soft** (a vault hiccup never fails the write; the page is already saved). The destination is surfaced to the agent via both the **`initialize` instructions** and the **write-tool descriptions** (prompt-level transparency). **No per-call override arg** — strictly the per-agent configured vault.

No vault set → unchanged owner-space behavior.

## Notes
- Commons-first: the page still lands in the commons (public, owner-attributed); the vault holds a **reference**. True private *clone*-to-vault staging is a separate future flow — a private target vault here references the page (appears in your private vault lens), it doesn't yet seal a copy.

## Tests
- `updateAgent` defaultVault: set (own vault), reject a vault you don't own, reject a phantom vault, clear with `""`.
- `dispatchMcp` target vault: files the created page into the vault + records `filedIntoVault`; **fail-soft** on a bad vault (page still created, call succeeds); `initialize` instructions + write-tool descriptions surface the vault, reads don't.

3058 tests · Next build + lint clean (Workers/SDK bundle validated in #569; this adds only internal-lib imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)