### PR TITLE
Source images → bottom Figures gallery (re-hosted only); remove [[IMG]] machinery

### DIFF
--- a/src/lib/__tests__/ingest-image.test.ts
+++ b/src/lib/__tests__/ingest-image.test.ts
@@ -174,6 +174,25 @@ describe("source images → bottom Figures gallery (ingest, LLM path)", () => {
     // The only image was decorative → no gallery section at all.
     expect(page!.content).not.toContain("## Figures");
   });
+
+  it("no-LLM-key fallback: image appears once, in the gallery (not inline twice)", async () => {
+    // The fallback path is also fed image-free text, then the gallery is
+    // appended — so the image renders exactly once, under ## Figures.
+    mockedHasLLMKey.mockReturnValue(false);
+
+    const result = await ingest(
+      "Doc Fallback",
+      "Some prose.\n\n![a chart](assets/doc/chart.png)\n\nmore prose.",
+      { author: "alice", owner: "alice" },
+    );
+
+    const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    expect(page!.content).toContain("## Figures");
+    expect((page!.content.match(/!\[a chart\]\(assets\/doc\/chart\.png\)/g) ?? []).length).toBe(1);
+    expect(page!.content.indexOf("## Figures")).toBeGreaterThan(
+      page!.content.indexOf("Some prose."),
+    );
+  });
 });
 
 describe("source provenance — text-paste supersession", () => {

--- a/src/lib/__tests__/ingest-image.test.ts
+++ b/src/lib/__tests__/ingest-image.test.ts
@@ -129,12 +129,12 @@ describe("ingestImage", () => {
   });
 });
 
-describe("inline source images (via ingest, LLM path)", () => {
-  it("places a kept [[IMG:n]] token inline as the real image ref (no ## Images dump)", async () => {
+describe("source images → bottom Figures gallery (ingest, LLM path)", () => {
+  it("appends re-hosted source images as a ## Figures gallery; body stays image-free", async () => {
     mockedHasLLMKey.mockReturnValue(true);
-    // The LLM keeps the image by echoing its placeholder token inline.
+    // The synthesizer is fed image-free text and returns clean prose (no tokens).
     mockedCallLLM.mockResolvedValue(
-      "# Doc\n\n## Summary\n\nDistilled.\n\n[[IMG:1]]\n\n## Details\n\nMore.",
+      "# Doc\n\n## Summary\n\nDistilled.\n\n## Details\n\nMore.",
     );
 
     const result = await ingest(
@@ -144,37 +144,24 @@ describe("inline source images (via ingest, LLM path)", () => {
     );
 
     const page = await readWikiPageWithFrontmatter(result.primarySlug);
+    // The image lives in the trailing gallery, not inline in the prose body.
+    expect(page!.content).toContain("## Figures");
     expect(page!.content).toContain("![a chart](assets/doc/chart.png)");
-    expect(page!.content).not.toContain("## Images");
-    expect(page!.content).not.toContain("[[IMG:"); // token substituted, none left
+    expect(page!.content).not.toContain("[[IMG:");
+    expect(page!.content.indexOf("## Figures")).toBeGreaterThan(
+      page!.content.indexOf("## Details"),
+    );
 
-    // Invariant: the RAW source keeps the original refs untokenized — tokenizing
-    // only the LLM input, never `content` (which feeds saveRawSource + dedup hash).
+    // Invariant: the RAW source keeps the original refs — only the synthesis
+    // INPUT is image-stripped, never `content` (which feeds saveRawSource + hash).
     const rawId = parseSources(page!.frontmatter.sources as string)[0]?.raw_id;
     const raw = await readRawSourceById(result.primarySlug, rawId!);
     expect(raw.content).toContain("![a chart](assets/doc/chart.png)");
-    expect(raw.content).not.toContain("[[IMG:");
   });
 
-  it("drops an image whose token the LLM omitted (relevance filtering)", async () => {
+  it("drops decorative images (logo) — not added to the gallery", async () => {
     mockedHasLLMKey.mockReturnValue(true);
-    mockedCallLLM.mockResolvedValue("# Doc\n\n## Summary\n\nDistilled, image not kept.");
-
-    const result = await ingest(
-      "Doc No Pics",
-      "Some text.\n\n![a chart](assets/doc/chart.png)\n\nmore text.",
-      { author: "alice", owner: "alice" },
-    );
-
-    const page = await readWikiPageWithFrontmatter(result.primarySlug);
-    expect(page!.content).not.toContain("chart.png");
-    expect(page!.content).not.toContain("## Images");
-  });
-
-  it("strips decorative images (logo) before the LLM sees them", async () => {
-    mockedHasLLMKey.mockReturnValue(true);
-    // Even if the LLM emits IMG:1, the logo was never tokenized → nothing to restore.
-    mockedCallLLM.mockResolvedValue("# Doc\n\n## Summary\n\nText.\n\n[[IMG:1]]");
+    mockedCallLLM.mockResolvedValue("# Doc\n\n## Summary\n\nText.");
 
     const result = await ingest(
       "Doc Logo",
@@ -184,9 +171,8 @@ describe("inline source images (via ingest, LLM path)", () => {
 
     const page = await readWikiPageWithFrontmatter(result.primarySlug);
     expect(page!.content).not.toContain("logo.png");
-    // Distinguish "logo stripped" from "feature silently no-op": the token the
-    // LLM emitted had no ref to restore, so it must be dropped, not left raw.
-    expect(page!.content).not.toContain("[[IMG:");
+    // The only image was decorative → no gallery section at all.
+    expect(page!.content).not.toContain("## Figures");
   });
 });
 

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -15,8 +15,9 @@ import {
   deriveTitleFromContent,
   collectTagVocabulary,
   computeConfidence,
-  tokenizeSourceImages,
-  restoreImageTokens,
+  collectGalleryImages,
+  stripImageMarkdown,
+  appendFigures,
   mergeSourceEntry,
 } from "../ingest";
 import { slugify } from "../slugify";
@@ -3471,50 +3472,54 @@ describe("ingest attribution", () => {
   });
 });
 
-describe("tokenizeSourceImages / restoreImageTokens", () => {
-  it("round-trips content images through tokens", () => {
-    const src = "Intro.\n\n![a chart](assets/p/chart.png)\n\nbody.";
-    const { text, refs } = tokenizeSourceImages(src);
-    expect(text).toContain("[[IMG:1]]");
-    expect(text).not.toContain("chart.png");
-    expect(refs).toEqual([{ alt: "a chart", ref: "assets/p/chart.png" }]);
-    expect(restoreImageTokens(text, refs)).toContain(
-      "![a chart](assets/p/chart.png)",
-    );
+describe("collectGalleryImages / stripImageMarkdown / appendFigures", () => {
+  it("collects re-hosted (local) images only — never hotlinks", () => {
+    const src =
+      "Intro.\n\n![a chart](assets/p/chart.png)\n\n![remote](https://x.com/fig.png)\n\nbody.";
+    // The failed-download remote URL is excluded (no hotlink/tracking on view).
+    expect(collectGalleryImages(src)).toEqual([
+      { alt: "a chart", ref: "assets/p/chart.png" },
+    ]);
   });
 
-  it("strips decorative images (logo/icon) — never tokenized", () => {
-    const { text, refs } = tokenizeSourceImages(
-      "![site logo](assets/p/logo.png)\n\n![diagram](https://x.com/fig.png)",
-    );
-    expect(refs).toEqual([{ alt: "diagram", ref: "https://x.com/fig.png" }]);
-    expect(text).not.toContain("logo.png");
-    expect(text).toContain("[[IMG:1]]");
+  it("drops decorative images (logo/icon)", () => {
+    expect(
+      collectGalleryImages(
+        "![site logo](assets/p/logo.png)\n\n![diagram](assets/p/fig.png)",
+      ),
+    ).toEqual([{ alt: "diagram", ref: "assets/p/fig.png" }]);
   });
 
-  it("drops omitted and out-of-range tokens on restore", () => {
-    const refs = [{ alt: "a", ref: "assets/p/a.png" }];
-    // Token 1 kept inline, token 2 hallucinated → dropped; an unreferenced image filtered.
-    expect(restoreImageTokens("x [[IMG:1]] y [[IMG:2]] z", refs)).toBe(
-      "x ![a](assets/p/a.png) y  z",
-    );
-  });
-
-  it("dedups a repeated ref to one entry, reusing its token", () => {
-    const { text, refs } = tokenizeSourceImages(
-      "![x](assets/p/a.png)\n\nmid\n\n![x again](assets/p/a.png)",
-    );
-    expect(refs).toEqual([{ alt: "x", ref: "assets/p/a.png" }]); // one entry
-    expect((text.match(/\[\[IMG:1\]\]/g) ?? []).length).toBe(2); // both reuse token 1
-  });
-
-  it("caps the number of tokenized images", () => {
-    const imgs = Array.from(
+  it("dedups a repeated ref and caps at MAX_APPENDED_IMAGES", () => {
+    expect(
+      collectGalleryImages("![x](assets/p/a.png)\n\n![x again](assets/p/a.png)"),
+    ).toEqual([{ alt: "x", ref: "assets/p/a.png" }]);
+    const many = Array.from(
       { length: 20 },
       (_, i) => `![fig${i}](assets/p/f${i}.png)`,
     ).join("\n\n");
-    const { refs } = tokenizeSourceImages(imgs);
-    expect(refs.length).toBe(12); // MAX_APPENDED_IMAGES
+    expect(collectGalleryImages(many).length).toBe(12); // MAX_APPENDED_IMAGES
+  });
+
+  it("stripImageMarkdown removes all image syntax (body goes image-free to the LLM)", () => {
+    const out = stripImageMarkdown("a ![x](assets/p/a.png) b ![y](https://z/c.png) c");
+    expect(out).not.toMatch(/!\[/);
+    expect(out).toContain("a ");
+    expect(out).toContain(" c");
+  });
+
+  it("appendFigures adds a trailing ## Figures gallery (no-op when empty)", () => {
+    const body = "# Title\n\nProse.";
+    expect(appendFigures(body, [])).toBe(body);
+    const withFigs = appendFigures(body, [
+      { alt: "a", ref: "assets/p/a.png" },
+      { alt: "b", ref: "assets/p/b.png" },
+    ]);
+    expect(withFigs).toContain("## Figures");
+    expect(withFigs).toContain("![a](assets/p/a.png)");
+    expect(withFigs).toContain("![b](assets/p/b.png)");
+    // Gallery is at the END, after the prose body.
+    expect(withFigs.indexOf("## Figures")).toBeGreaterThan(withFigs.indexOf("Prose."));
   });
 });
 

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -548,65 +548,52 @@ function generateFallbackPage(title: string, content: string): string {
 // Image preservation
 // ---------------------------------------------------------------------------
 
-/**
-/** An image ref captured from the source for token-based inline placement. */
+/** A re-hosted source image captured for the trailing Figures gallery. */
 interface SourceImageRef {
   alt: string;
   ref: string;
 }
 
-/** Image refs we strip outright (decorative/branding/UI — never content). */
+/** Image refs we drop outright (decorative/branding/UI — never content). */
 const DECORATIVE_IMAGE_RE = /(logo|icon|avatar|sprite|favicon|emoji|banner)/i;
 
 /**
- * Replace the source's image refs with short `[[IMG:n]]` placeholder tokens at
- * their original positions, so the synthesis LLM can keep the genuine ones by
- * placing the same token inline where it now belongs (and omit the rest) — the
- * LLM reliably preserves a tiny token but mangles long `assets/<slug>/x.png`
- * paths. Decorative/branding images are removed outright (never tokenized).
- * Returns the tokenized text plus the ordered ref map for {@link restoreImageTokens}.
+ * Collect the RE-HOSTED source images for a trailing `## Figures` gallery. Only
+ * local `assets/…` refs are kept (never a hotlinked `http(s)` URL — a failed
+ * download that kept its original URL is excluded so a page never re-fetches a
+ * third-party image on view, which would be a tracking/exfil vector). Decorative
+ * images are dropped, duplicates collapsed, and the list capped at
+ * {@link MAX_APPENDED_IMAGES}. Run on the post-`downloadImages` content.
  */
-export function tokenizeSourceImages(content: string): {
-  text: string;
-  refs: SourceImageRef[];
-} {
-  const refs: SourceImageRef[] = [];
-  const tokenByRef = new Map<string, number>(); // dedup: same ref → same token
-  const re = /!\[([^\]]*)\]\(((?:assets\/|https?:\/\/)[^)\s]+)\)/g;
-  const text = content.replace(re, (_whole, alt: string, ref: string) => {
-    if (DECORATIVE_IMAGE_RE.test(ref) || DECORATIVE_IMAGE_RE.test(alt)) {
-      return ""; // strip decorative images so the LLM never sees them
-    }
-    const existing = tokenByRef.get(ref);
-    if (existing) return `\n\n[[IMG:${existing}]]\n\n`; // reuse — don't spend a cap slot
-    if (refs.length >= MAX_APPENDED_IMAGES) return ""; // past the cap → drop (don't leak a raw ref)
-    refs.push({ alt, ref });
-    tokenByRef.set(ref, refs.length);
-    return `\n\n[[IMG:${refs.length}]]\n\n`;
-  });
-  return { text, refs };
+export function collectGalleryImages(content: string): SourceImageRef[] {
+  const images: SourceImageRef[] = [];
+  const seen = new Set<string>();
+  for (const m of content.matchAll(/!\[([^\]]*)\]\(([^)\s]+)\)/g)) {
+    const alt = m[1];
+    const ref = m[2];
+    // Re-hosted only — exclude hotlinks (failed downloads keep their URL).
+    if (!ref.startsWith("assets/") && !ref.startsWith("raw/assets/")) continue;
+    if (DECORATIVE_IMAGE_RE.test(ref) || DECORATIVE_IMAGE_RE.test(alt)) continue;
+    if (seen.has(ref)) continue;
+    seen.add(ref);
+    if (images.length >= MAX_APPENDED_IMAGES) break;
+    images.push({ alt, ref });
+  }
+  return images;
 }
 
-/**
- * Substitute the real image refs back for the `[[IMG:n]]` tokens the LLM kept.
- * Tokens the LLM omitted are absent (those images are filtered out); tokens with
- * an out-of-range/invalid `n` (hallucinated) are dropped.
- */
-export function restoreImageTokens(body: string, refs: SourceImageRef[]): string {
-  const kept = new Set<number>();
-  const out = body.replace(/\[\[IMG:(\d+)\]\]/g, (_whole, n: string) => {
-    const idx = Number(n) - 1;
-    const img = refs[idx];
-    if (!img) return "";
-    kept.add(idx);
-    return `![${img.alt}](${img.ref})`;
-  });
-  // Observability: a sudden "kept 0/N" signals a prompt/truncation regression
-  // silently dropping real figures (which otherwise leaves no trace).
-  if (refs.length > 0) {
-    logger.debug("ingest", `inline images: kept ${kept.size}/${refs.length}`);
-  }
-  return out;
+/** Strip all markdown image syntax so the synthesis LLM gets image-free text
+ *  (images live in the trailing gallery, not inline in the body). */
+export function stripImageMarkdown(content: string): string {
+  return content.replace(/!\[[^\]]*\]\([^)]*\)/g, "");
+}
+
+/** Append a `## Figures` gallery of the re-hosted images to a synthesized body
+ *  (no-op when there are none). */
+export function appendFigures(body: string, images: SourceImageRef[]): string {
+  if (images.length === 0) return body;
+  const figs = images.map((i) => `![${i.alt}](${i.ref})`).join("\n\n");
+  return `${body.trimEnd()}\n\n## Figures\n\n${figs}\n`;
 }
 
 // ---------------------------------------------------------------------------
@@ -795,8 +782,6 @@ Then, on the following lines, the wiki article. Include:
   click away ("View raw"), so do NOT try to reproduce it. Invent nothing not
   supported by the source.
 
-Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. KEEP the ones that are genuine content — diagrams, figures, charts, screenshots that illustrate the topic — by writing the SAME token on its own line at the most relevant point in the article (next to the text it illustrates). Omit any token whose image is clearly decorative/branding/UI. Never invent tokens or change their numbers; output each kept token verbatim.
-
 Diagrams: when the concept has a clear STRUCTURE (a flow, pipeline, architecture, hierarchy, sequence, or relationship), you MAY include ONE concise Mermaid diagram in a fenced \`\`\`mermaid code block (e.g. flowchart LR, graph TD, sequenceDiagram); it renders as a diagram. Use it only where it genuinely clarifies, base it strictly on the source, and keep node labels short. Most pages need none.
 
 Write a focused, distilled page, not a transcript of the source. Output the CONCEPT, ALIASES, and TAGS lines, then pure markdown, and nothing else. Do not wrap in code fences.`;
@@ -814,8 +799,6 @@ const MAP_SYSTEM_PROMPT = `You are a wiki editor distilling ONE part of a long s
 From THIS part of the source, capture the substantive material a reader needs: the explanations, definitions, mechanisms, claims, examples, names, and numbers actually present. Be FAITHFUL — preserve concrete specifics exactly; do not generalize them away, and invent nothing not in this part.
 
 Write mostly in concise prose. Use a bullet only for genuinely list-like material — do not turn every sentence into a bullet. Omit boilerplate, marketing, repetition, and tangents. Do NOT add a title, a "Summary", or section headings — output only the distilled notes for this part.
-
-Images: the source may contain placeholder tokens like \`[[IMG:1]]\`. Keep genuine content images (diagrams, figures, charts, screenshots) by writing the SAME token on its own line where relevant; omit decorative/branding/UI ones. Never invent tokens or change their numbers.
 
 Output pure markdown and nothing else. Do not wrap in code fences.`;
 
@@ -836,8 +819,6 @@ ALIASES: <comma-separated alternative names / synonyms for the concept, or "none
 TAGS: <3-6 lowercase, hyphenated topic tags, comma-separated>
 
 Then the article: one \`# Title\` (the canonical concept), then EXACTLY ONE of each \`## Summary\`, \`## Key Points\`, \`## Concepts\`, \`## Details\`. Reorganise the merged notes into these sections — never emit a section twice or an "(additional)" variant. Prefer readable prose; use bullets only where the material is genuinely list-like. The \`## Details\` section should carry the substance in prose and lists, not a flat dump of every bullet.
-
-Images: the notes may contain placeholder tokens like \`[[IMG:1]]\`. Keep each genuine-content token on its own line at the most relevant point; never invent tokens or change their numbers; output each kept token verbatim.
 
 Diagrams: when the concept has a clear STRUCTURE (a flow, pipeline, architecture, hierarchy, sequence, or relationship), you MAY include ONE concise Mermaid diagram in a fenced \`\`\`mermaid code block (e.g. flowchart LR, graph TD, sequenceDiagram). Use it only where it genuinely clarifies, base it strictly on the notes, and keep node labels short. Most pages need none.
 
@@ -1293,6 +1274,71 @@ async function attachIngestTrigger(
 }
 
 /**
+ * Synthesize the wiki body from IMAGE-FREE source text: a single LLM call for
+ * short content, MAP/REDUCE for long content (parallel map in bounded-concurrency
+ * batches → merge), or a deterministic fallback page when there's no LLM key.
+ * Returns the raw synthesized body (still carrying the leading CONCEPT marker on
+ * the LLM path); the caller strips that and appends the Figures gallery.
+ */
+async function synthesizeBody(title: string, content: string): Promise<string> {
+  if (!hasLLMKey()) {
+    // Derived title so a title-less paste doesn't emit an empty `# ` H1.
+    return generateFallbackPage(title, content);
+  }
+  const systemPrompt = await buildIngestSystemPrompt();
+  const chunks = chunkText(content, MAX_LLM_INPUT_CHARS);
+  // Larger output budget so the ## Details section can preserve substantive
+  // source content instead of being truncated.
+  const llmOptions = { maxOutputTokens: INGEST_MAX_OUTPUT_TOKENS };
+
+  if (chunks.length === 1) {
+    return callLLM(systemPrompt, chunks[0], llmOptions);
+  }
+
+  // Long content — MAP/REDUCE. Distil each chunk straight from the SOURCE (in
+  // bounded-concurrency batches), then merge the partials into one article.
+  // Mapping from source keeps coverage faithful and stops cross-chunk drift;
+  // the parallel map keeps a long transcript well under the request budget.
+  const mapOptions = { maxOutputTokens: INGEST_MAP_MAX_OUTPUT_TOKENS };
+  const partials: string[] = [];
+  for (let i = 0; i < chunks.length; i += INGEST_MAP_CONCURRENCY) {
+    const batch = chunks.slice(i, i + INGEST_MAP_CONCURRENCY);
+    const mapped = await Promise.all(
+      batch.map(async (chunk, j) => {
+        const chunkIndex = i + j + 1;
+        try {
+          return await callLLM(
+            MAP_SYSTEM_PROMPT,
+            `Part ${chunkIndex} of ${chunks.length} of the source:\n\n${chunk}`,
+            mapOptions,
+          );
+        } catch (err) {
+          logger.warn(
+            "ingest",
+            `map chunk ${chunkIndex}/${chunks.length} failed, skipping:`,
+            err,
+          );
+          return "";
+        }
+      }),
+    );
+    partials.push(...mapped);
+  }
+
+  const notes = partials
+    .map((p, i) => ({ part: i + 1, text: p.trim() }))
+    .filter((p) => p.text)
+    .map((p) => `# Part ${p.part}\n\n${p.text}`)
+    .join("\n\n");
+  if (!notes) {
+    // Every map call came back blank — surface a real failure rather than
+    // reducing nothing into a hallucinated page.
+    throw new Error("synthesis produced no content from the source");
+  }
+  return callLLM(REDUCE_SYSTEM_PROMPT, notes, llmOptions);
+}
+
+/**
  * Ingest a source document into the wiki: synthesize the page (LLM) and write it
  * directly. There is no preview/commit two-step — every ingest runs synthesis
  * and writes.
@@ -1373,72 +1419,14 @@ export async function ingest(
   if (prebuiltContent) {
     // Image ingest: skip the LLM, write the already-final body as-is.
     wikiContent = prebuiltContent;
-  } else if (hasLLMKey()) {
-    const systemPrompt = await buildIngestSystemPrompt();
-    // Swap source images for [[IMG:n]] tokens so the LLM can place the relevant
-    // ones inline (and omit decorative ones); refs are restored after synthesis.
-    const { text: llmInput, refs: imageRefs } = tokenizeSourceImages(content);
-    const chunks = chunkText(llmInput, MAX_LLM_INPUT_CHARS);
-
-    // Larger output budget so the ## Details section can preserve substantive
-    // source content instead of being truncated.
-    const llmOptions = { maxOutputTokens: INGEST_MAX_OUTPUT_TOKENS };
-
-    if (chunks.length === 1) {
-      // Short content — single LLM call (no behaviour change)
-      wikiContent = await callLLM(systemPrompt, chunks[0], llmOptions);
-    } else {
-      // Long content — MAP/REDUCE. Distil each chunk straight from the SOURCE
-      // (in bounded-concurrency batches), then merge the partials into one
-      // article. Mapping from source keeps coverage faithful and stops the
-      // cross-chunk drift a sequential refine caused; merging collapses the
-      // parts into a single set of sections (no "(additional)" pileup); and the
-      // parallel map keeps a long transcript well under the request budget that
-      // sequential synthesis blew past.
-      const mapOptions = { maxOutputTokens: INGEST_MAP_MAX_OUTPUT_TOKENS };
-      const partials: string[] = [];
-      for (let i = 0; i < chunks.length; i += INGEST_MAP_CONCURRENCY) {
-        const batch = chunks.slice(i, i + INGEST_MAP_CONCURRENCY);
-        const mapped = await Promise.all(
-          batch.map(async (chunk, j) => {
-            const chunkIndex = i + j + 1;
-            try {
-              return await callLLM(
-                MAP_SYSTEM_PROMPT,
-                `Part ${chunkIndex} of ${chunks.length} of the source:\n\n${chunk}`,
-                mapOptions,
-              );
-            } catch (err) {
-              logger.warn(
-                "ingest",
-                `map chunk ${chunkIndex}/${chunks.length} failed, skipping:`,
-                err,
-              );
-              return "";
-            }
-          }),
-        );
-        partials.push(...mapped);
-      }
-
-      const notes = partials
-        .map((p, i) => ({ part: i + 1, text: p.trim() }))
-        .filter((p) => p.text)
-        .map((p) => `# Part ${p.part}\n\n${p.text}`)
-        .join("\n\n");
-      if (!notes) {
-        // Every map call came back blank — surface a real failure rather than
-        // reducing nothing into a hallucinated page.
-        throw new Error("synthesis produced no content from the source");
-      }
-      wikiContent = await callLLM(REDUCE_SYSTEM_PROMPT, notes, llmOptions);
-    }
-
-    // Restore the kept [[IMG:n]] tokens to real refs (omitted ones are dropped).
-    wikiContent = restoreImageTokens(wikiContent, imageRefs);
   } else {
-    // Use the derived title so a title-less paste doesn't emit an empty `# ` H1.
-    wikiContent = generateFallbackPage(effectiveTitle, content);
+    // Source images go in a trailing `## Figures` gallery, not inline: collect
+    // the re-hosted ones, then feed the synthesizer/fallback IMAGE-FREE text so
+    // the body stays clean prose (better for index/query) with no inline images.
+    const galleryImages = collectGalleryImages(content);
+    const cleanContent = stripImageMarkdown(content);
+    wikiContent = await synthesizeBody(effectiveTitle, cleanContent);
+    wikiContent = appendFigures(wikiContent, galleryImages);
   }
 
   // Pull the leading `CONCEPT:` / `ALIASES:` header lines the synthesis prompt
@@ -1480,8 +1468,9 @@ export async function ingest(
     }
   }
 
-  // Images are placed inline during synthesis via [[IMG:n]] tokens (see
-  // tokenizeSourceImages / restoreImageTokens) — no trailing dump.
+  // Re-hosted source images are collected into a trailing `## Figures` gallery
+  // (see collectGalleryImages / appendFigures) — the synthesized body is
+  // image-free prose.
 
   // A prebuilt body (image path) carries no CONCEPT marker, so the canonical
   // slug would otherwise stay the source-TITLE slug. Re-derive slug + title from

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -559,10 +559,10 @@ const DECORATIVE_IMAGE_RE = /(logo|icon|avatar|sprite|favicon|emoji|banner)/i;
 
 /**
  * Collect the RE-HOSTED source images for a trailing `## Figures` gallery. Only
- * local `assets/…` refs are kept (never a hotlinked `http(s)` URL — a failed
- * download that kept its original URL is excluded so a page never re-fetches a
- * third-party image on view, which would be a tracking/exfil vector). Decorative
- * images are dropped, duplicates collapsed, and the list capped at
+ * local `assets/…` (or `raw/assets/…`) refs are kept — never a hotlinked
+ * `http(s)` URL: a failed download that kept its original URL is excluded so a
+ * page never re-fetches a third-party image on view (a tracking/exfil vector).
+ * Decorative images are dropped, duplicates collapsed, and the list capped at
  * {@link MAX_APPENDED_IMAGES}. Run on the post-`downloadImages` content.
  */
 export function collectGalleryImages(content: string): SourceImageRef[] {
@@ -1278,7 +1278,8 @@ async function attachIngestTrigger(
  * short content, MAP/REDUCE for long content (parallel map in bounded-concurrency
  * batches → merge), or a deterministic fallback page when there's no LLM key.
  * Returns the raw synthesized body (still carrying the leading CONCEPT marker on
- * the LLM path); the caller strips that and appends the Figures gallery.
+ * the LLM path); the caller appends the Figures gallery and strips that marker
+ * (order-independent — the marker leads, the gallery trails).
  */
 async function synthesizeBody(title: string, content: string): Promise<string> {
   if (!hasLLMKey()) {
@@ -1424,6 +1425,16 @@ export async function ingest(
     // the re-hosted ones, then feed the synthesizer/fallback IMAGE-FREE text so
     // the body stays clean prose (better for index/query) with no inline images.
     const galleryImages = collectGalleryImages(content);
+    // Observability tripwire: a sudden "0 of N" signals a regression upstream
+    // (e.g. downloadImages stopped re-hosting → all refs stay hotlinks → the
+    // re-hosted-only filter drops everything) that would otherwise vanish silently.
+    const sourceImageCount = (content.match(/!\[[^\]]*\]\([^)]*\)/g) ?? []).length;
+    if (sourceImageCount > 0) {
+      logger.debug(
+        "ingest",
+        `figures: kept ${galleryImages.length} of ${sourceImageCount} source image(s)`,
+      );
+    }
     const cleanContent = stripImageMarkdown(content);
     wikiContent = await synthesizeBody(effectiveTitle, cleanContent);
     wikiContent = appendFigures(wikiContent, galleryImages);


### PR DESCRIPTION
**PR 2 of 2** of the ingestion refactor (PR 1 = async unification, merged #573). Stop placing source images inline; collect the re-hosted ones into a trailing **`## Figures`** gallery.

## Why
- **Cleaner body** — the synthesized prose is image-free, which is better for the BM25 index / query (inline image markdown is noise).
- **No hotlink/tracking vector** — only **re-hosted** (`assets/…`) images go in the gallery; a failed download that kept its original `http(s)` URL is **excluded** (a page never re-fetches a third-party image on view).
- Simpler — drops the `[[IMG:n]]` token round-trip (ask-the-LLM-to-place-images-inline) entirely.

## What
- Replaced `tokenizeSourceImages`/`restoreImageTokens` with:
  - **`collectGalleryImages(content)`** — re-hosted images only, decorative filtered (`DECORATIVE_IMAGE_RE`), deduped, capped at `MAX_APPENDED_IMAGES` (12).
  - **`stripImageMarkdown(content)`** — image-free text for the synthesizer.
  - **`appendFigures(body, images)`** — trailing `## Figures` section (no-op when empty).
- `ingest()`: feed image-free text to synthesis (LLM **and** fallback paths), then append the gallery. Extracted the LLM single/MAP-REDUCE/fallback logic into a **`synthesizeBody()`** helper so the image handling wraps it cleanly.
- Removed the `[[IMG:n]]` instructions from the INGEST/MAP/REDUCE prompts.
- **Unchanged**: the raw source + dedup hash (only the synthesis *input* is stripped, never `content`); the image-*upload* path (`prebuiltContent`) keeps its own inline embed (the image is the subject there).

Rendering already works: `resolveImageSrc` serves `assets/…` via `/api/assets`, and the index summary already strips images.

## Tests
- Unit: gallery helpers — re-hosted-only (hotlinks excluded), decorative dropped, dedup + cap, strip removes all image syntax, append ordering.
- Integration: an ingest with a source image produces a `## Figures` section with the body image-free and the raw source untouched; a decorative-only source produces no gallery.

Self-reviewed the full diff (only `ingest.ts` + 2 test files; no leftover token machinery). **Next + Workers builds clean · 3092 tests · lint 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)