### PR TITLE
yoyo: auto-merge same-concept ingests at /query (LLM adjudication + BM25 fallback)

### DIFF
--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -2112,17 +2112,14 @@ describe("ingest — concept-slug convergence", () => {
 });
 
 // ---------------------------------------------------------------------------
-// ingest — semantic concept resolver (layer 3: embedding nearest-page merge)
+// ingest — concept resolver (layer 3: retrieve candidates + LLM-adjudicate merge)
 // ---------------------------------------------------------------------------
 
-describe("ingest — semantic concept resolver", () => {
+describe("ingest — concept resolver (adjudicated merge)", () => {
   beforeEach(() => {
     resetSourceIndex();
     resetAliasIndex();
     mockedHasLLMKey.mockReturnValue(true);
-    // Each ingest's synthesis reports a concept derived from the source body, so
-    // two differently-worded sources get DIFFERENT concept slugs — only the
-    // embedding step can merge them.
     mockedCallLLM.mockImplementation(async (system: string, user: string) => {
       // The adjudicator (distinct system prompt) decides merges; by default it
       // confirms a merge into "alpha-thing" whenever that candidate is offered.
@@ -2186,6 +2183,34 @@ describe("ingest — semantic concept resolver", () => {
 
     const slugs = (await listWikiPages()).map((p) => p.slug).sort();
     expect(slugs).toEqual(["alpha-thing", "beta-thing"]);
+    // Cost invariant: nothing cleared the floor → the adjudicator never ran.
+    expect(
+      mockedCallLLM.mock.calls.filter((c) => c[0].includes("decide whether")),
+    ).toHaveLength(0);
+  });
+
+  it("never folds into an artifact / agent-scoped candidate even at the same scope", async () => {
+    mockedHasEmbeddingSupport.mockReturnValue(true);
+    mockedSearchByVector.mockResolvedValue([{ slug: "alpha-thing", score: 0.95 }]);
+
+    // Both pages are agent-knowledge + same owner, so the scope-EQUALITY check
+    // passes; only the artifact/agent-scoped guard can prevent the fold here.
+    await ingest("Alpha Source", "First source, alpha topic. Details here.", {
+      pageType: "agent-knowledge",
+      owner: "alice",
+      author: "alice",
+    });
+    const result = await ingest("Beta Source", "Second source, beta wording. More.", {
+      pageType: "agent-knowledge",
+      owner: "alice",
+      author: "alice",
+    });
+
+    expect(result.primarySlug).toBe("beta-thing"); // forked, not merged
+    // The guard drops the candidate BEFORE adjudication — so it never even ran.
+    expect(
+      mockedCallLLM.mock.calls.filter((c) => c[0].includes("decide whether")),
+    ).toHaveLength(0);
   });
 
   it("forks when the adjudicator judges the candidate a DIFFERENT concept", async () => {

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -2123,11 +2123,18 @@ describe("ingest — semantic concept resolver", () => {
     // Each ingest's synthesis reports a concept derived from the source body, so
     // two differently-worded sources get DIFFERENT concept slugs — only the
     // embedding step can merge them.
-    mockedCallLLM.mockImplementation(async (_system: string, user: string) =>
-      user.includes("alpha")
+    mockedCallLLM.mockImplementation(async (system: string, user: string) => {
+      // The adjudicator (distinct system prompt) decides merges; by default it
+      // confirms a merge into "alpha-thing" whenever that candidate is offered.
+      if (system.includes("decide whether")) {
+        return user.includes("alpha-thing") ? "alpha-thing" : "none";
+      }
+      // Otherwise it's the synthesis call — two differently-worded sources get
+      // DIFFERENT concept slugs, so only the adjudicator can merge them.
+      return user.includes("alpha")
         ? "CONCEPT: Alpha Thing\nALIASES: none\n\n# Alpha Thing\n\n## Summary\n\nAbout alpha."
-        : "CONCEPT: Beta Thing\nALIASES: none\n\n# Beta Thing\n\n## Summary\n\nAbout beta.",
-    );
+        : "CONCEPT: Beta Thing\nALIASES: none\n\n# Beta Thing\n\n## Summary\n\nAbout beta.";
+    });
   });
   afterEach(() => {
     mockedHasLLMKey.mockReturnValue(false);
@@ -2136,9 +2143,10 @@ describe("ingest — semantic concept resolver", () => {
     mockedSearchByVector.mockResolvedValue([]);
   });
 
-  it("merges a differently-worded source into the nearest page above threshold", async () => {
+  it("merges a differently-worded source into the candidate the adjudicator confirms", async () => {
     mockedHasEmbeddingSupport.mockReturnValue(true);
-    // The nearest existing page is "alpha-thing" with a confident score.
+    // The retrieval surfaces "alpha-thing" as a near candidate; the adjudicator
+    // (mock) confirms it's the same concept.
     mockedSearchByVector.mockResolvedValue([
       { slug: "alpha-thing", score: 0.95 },
     ]);
@@ -2149,8 +2157,8 @@ describe("ingest — semantic concept resolver", () => {
     await ingest("Alpha Source", "First source, alpha topic. Details here.");
     expect((await listWikiPages()).map((p) => p.slug)).toEqual(["alpha-thing"]);
 
-    // Second source's concept slug would be "beta-thing", but the embedding
-    // search points at "alpha-thing" ≥ threshold (same owner) → merge.
+    // Second source's concept slug would be "beta-thing", but retrieval points
+    // at "alpha-thing" (same owner/scope) and the adjudicator confirms → merge.
     const result = await ingest("Beta Source", "Second source, beta wording. More.");
 
     expect(result.primarySlug).toBe("alpha-thing");
@@ -2165,9 +2173,10 @@ describe("ingest — semantic concept resolver", () => {
     ).toBe(2);
   });
 
-  it("forks a new page when the nearest hit is below threshold", async () => {
+  it("forks when no candidate clears the retrieval floor (no adjudication call)", async () => {
     mockedHasEmbeddingSupport.mockReturnValue(true);
-    // Nearest page exists but is NOT similar enough — err toward a new page.
+    // Nearest page exists but is below CONCEPT_ADJUDICATE_FLOOR (0.6) → it isn't
+    // even offered to the adjudicator → fork.
     mockedSearchByVector.mockResolvedValue([
       { slug: "alpha-thing", score: 0.5 },
     ]);
@@ -2177,6 +2186,67 @@ describe("ingest — semantic concept resolver", () => {
 
     const slugs = (await listWikiPages()).map((p) => p.slug).sort();
     expect(slugs).toEqual(["alpha-thing", "beta-thing"]);
+  });
+
+  it("forks when the adjudicator judges the candidate a DIFFERENT concept", async () => {
+    mockedHasEmbeddingSupport.mockReturnValue(true);
+    mockedSearchByVector.mockResolvedValue([{ slug: "alpha-thing", score: 0.95 }]);
+    // Override: adjudicator always says "none".
+    mockedCallLLM.mockImplementation(async (system: string, user: string) =>
+      system.includes("decide whether")
+        ? "none"
+        : user.includes("alpha")
+          ? "CONCEPT: Alpha Thing\nALIASES: none\n\n# Alpha Thing\n\n## Summary\n\nA."
+          : "CONCEPT: Beta Thing\nALIASES: none\n\n# Beta Thing\n\n## Summary\n\nB.",
+    );
+
+    await ingest("Alpha Source", "First source, alpha topic. Details here.");
+    const result = await ingest("Beta Source", "Second source, beta wording. More.");
+
+    expect(result.primarySlug).toBe("beta-thing");
+    expect((await listWikiPages()).map((p) => p.slug).sort()).toEqual([
+      "alpha-thing",
+      "beta-thing",
+    ]);
+  });
+
+  it("forks when the adjudicator returns a slug that wasn't offered (hallucination guard)", async () => {
+    mockedHasEmbeddingSupport.mockReturnValue(true);
+    mockedSearchByVector.mockResolvedValue([{ slug: "alpha-thing", score: 0.95 }]);
+    mockedCallLLM.mockImplementation(async (system: string, user: string) =>
+      system.includes("decide whether")
+        ? "some-other-slug" // not one of the candidates
+        : user.includes("alpha")
+          ? "CONCEPT: Alpha Thing\nALIASES: none\n\n# Alpha Thing\n\n## Summary\n\nA."
+          : "CONCEPT: Beta Thing\nALIASES: none\n\n# Beta Thing\n\n## Summary\n\nB.",
+    );
+
+    await ingest("Alpha Source", "First source, alpha topic. Details here.");
+    const result = await ingest("Beta Source", "Second source, beta wording. More.");
+
+    expect(result.primarySlug).toBe("beta-thing");
+  });
+
+  it("merges via the BM25 fallback when embeddings are unavailable (the pre-backfill prod path)", async () => {
+    // Vectorize not backfilled → searchByVector unused; candidates come from a
+    // title+summary BM25 pass. The two sources share tokens ("widget protocol").
+    mockedHasEmbeddingSupport.mockReturnValue(false);
+    mockedCallLLM.mockImplementation(async (system: string, user: string) => {
+      if (system.includes("decide whether")) {
+        return user.includes("widget-protocol") ? "widget-protocol" : "none";
+      }
+      return user.toLowerCase().includes("specification")
+        ? "CONCEPT: Widget Protocol\nALIASES: none\n\n# Widget Protocol\n\n## Summary\n\nThe widget protocol specification."
+        : "CONCEPT: Widget Spec\nALIASES: none\n\n# Widget Spec\n\n## Summary\n\nThe widget protocol, explained.";
+    });
+
+    await ingest("First", "First note on the widget protocol specification details.");
+    expect((await listWikiPages()).map((p) => p.slug)).toContain("widget-protocol");
+
+    const result = await ingest("Second", "Second note, widget protocol explained anew.");
+
+    expect(result.primarySlug).toBe("widget-protocol");
+    expect(await listWikiPages()).toHaveLength(1);
   });
 
   it("does NOT semantic-merge an agent-knowledge ingest into a public page (scope guard)", async () => {

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -5,8 +5,11 @@ import {
   readWikiPageWithFrontmatter,
   serializeFrontmatter,
   listWikiPages,
+  isArtifactType,
+  isAgentScopedType,
   type Frontmatter,
 } from "./wiki";
+import { buildCorpusStats, bm25Score, tokenize } from "./bm25";
 import { callLLM, hasLLMKey } from "./llm";
 import { fetchUrlContent, downloadImages, fetchImageBytes, storeImageBytes, pdfToText } from "./fetch";
 import { describeImage } from "./vision";
@@ -930,10 +933,87 @@ export function normalizeTags(raw: string[], max: number = MAX_AUTO_TAGS): strin
   return out;
 }
 
-/** Cosine-similarity floor for treating the nearest existing page as the SAME
- *  concept on a semantic match. Deliberately conservative — a wrong merge is
- *  harder to undo than a fork, so we err toward a new page when unsure. */
-export const CONCEPT_MERGE_THRESHOLD = 0.86;
+/** Recall floor for RETRIEVING merge candidates by embedding similarity — low on
+ *  purpose. It only gates which existing pages the LLM gets to judge; the LLM is
+ *  the accept arbiter. (Replaces the old conservative cosine-only 0.86 accept
+ *  gate, which forked whenever two sources worded the same concept apart.) */
+export const CONCEPT_ADJUDICATE_FLOOR = 0.6;
+
+/** Most existing pages shown to the merge adjudicator per ingest (prompt/cost guard). */
+const MAX_MERGE_CANDIDATES = 5;
+
+const MERGE_ADJUDICATION_SYSTEM_PROMPT = `You decide whether a newly written wiki page describes the SAME underlying concept as one of a few existing pages — so they are merged into ONE page instead of creating a duplicate.
+
+Merge ONLY when the new page and an existing page are about the SAME concept / topic / entity (the same thing — possibly worded differently or drawn from a different source). Do NOT merge pages that are merely related, adjacent, complementary, or in the same broad domain.
+
+Reply with ONLY the slug of the matching existing page, copied exactly from the list — or the single word "none" if no existing page is the same concept. When unsure, answer "none".`;
+
+/**
+ * Find existing pages that might be the SAME concept as a freshly-synthesized
+ * one, for {@link adjudicateMerge}. Uses embedding similarity when available (a
+ * wide recall net at {@link CONCEPT_ADJUDICATE_FLOOR}); otherwise a title+summary
+ * BM25 pass over the index (`fullBody:false` → no disk reads, no LLM) so merge
+ * still works before the vector store is backfilled. Returns candidate slugs,
+ * best-first.
+ */
+async function findMergeCandidates(
+  concept: string,
+  embedBody: string,
+): Promise<string[]> {
+  const query = `${concept}\n\n${embedBody}`;
+  if (hasEmbeddingSupport()) {
+    const hits = await searchByVector(query, MAX_MERGE_CANDIDATES + 3);
+    return hits
+      .filter((h) => h.score >= CONCEPT_ADJUDICATE_FLOOR)
+      .map((h) => h.slug);
+  }
+  const entries = await listWikiPages();
+  if (entries.length === 0) return [];
+  const stats = await buildCorpusStats(entries, { fullBody: false });
+  const qTokens = tokenize(query);
+  return entries
+    .map((e) => ({ slug: e.slug, score: bm25Score(e, qTokens, stats) }))
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_MERGE_CANDIDATES + 3)
+    .map((s) => s.slug);
+}
+
+/**
+ * Ask the LLM which (if any) candidate page is the SAME concept as the new page.
+ * Returns the chosen slug — validated to be one we actually offered (a
+ * hallucination guard; longest match wins so a slug that's a substring of
+ * another can't shadow it) — or `null` (→ fork). Conservative: no LLM key, an
+ * empty / "none" answer, an unrecognized slug, or an LLM error all yield `null`.
+ */
+async function adjudicateMerge(
+  concept: string,
+  embedBody: string,
+  candidates: { slug: string; title: string; snippet: string }[],
+): Promise<string | null> {
+  if (!hasLLMKey()) return null;
+  const list = candidates
+    .map((c) => `- slug: ${c.slug}\n  title: ${c.title}\n  snippet: ${c.snippet}`)
+    .join("\n");
+  const user = `NEW page concept: "${concept}"\n\nNEW page (excerpt):\n${embedBody.slice(
+    0,
+    800,
+  )}\n\nEXISTING pages that might be the same concept:\n${list}\n\nWhich existing page is the SAME concept as the NEW page? Reply with its slug, or "none".`;
+  let out: string;
+  try {
+    out = await callLLM(MERGE_ADJUDICATION_SYSTEM_PROMPT, user, {
+      maxOutputTokens: 24,
+    });
+  } catch (err) {
+    logger.warn("ingest", "merge adjudication failed; forking to a new page", err);
+    return null;
+  }
+  const answer = out.trim().toLowerCase();
+  const matches = candidates
+    .filter((c) => answer.includes(c.slug.toLowerCase()))
+    .sort((a, b) => b.slug.length - a.slug.length);
+  return matches[0]?.slug ?? null;
+}
 
 /**
  * Resolve the slug an ingest should land on, given a content-derived concept.
@@ -943,13 +1023,15 @@ export const CONCEPT_MERGE_THRESHOLD = 0.86;
  *   1. Exact — the candidate concept slug is already a page.
  *   2. Alias — the concept or one of its synonyms resolves (via the alias
  *      index) to an existing page.
- *   3. Semantic — the nearest existing page by embedding similarity is at or
- *      above {@link CONCEPT_MERGE_THRESHOLD}. Scoped to the SAME owner's silo so
- *      a fuzzy match never attaches a source to another tenant's page.
+ *   3. Adjudicated merge — retrieve nearby existing pages (embedding similarity,
+ *      or a title+summary BM25 fallback) and let the LLM decide which, if any,
+ *      is the SAME concept. Scoped to the SAME owner + scope, never an artifact /
+ *      agent-knowledge page, so a fuzzy match can't cross silos or corrupt an
+ *      artifact's markup.
  *
- * `embedBody` is the synthesized page body used for the semantic query. Returns
- * the candidate concept slug unchanged when no confident existing match is
- * found. Embedding-unavailable environments (e.g. tests) cleanly skip step 3.
+ * `embedBody` is the synthesized page body used for retrieval + adjudication.
+ * Returns the candidate concept slug unchanged when no confident match is found
+ * (and whenever there's no LLM key — adjudication is conservative by default).
  */
 async function resolveConceptSlug(
   candidateSlug: string,
@@ -974,21 +1056,33 @@ async function resolveConceptSlug(
     }
   }
 
-  // 3. Semantic nearest-page (the robust catch for LLM wording drift).
-  if (hasEmbeddingSupport()) {
-    const hits = await searchByVector(`${concept}\n\n${embedBody}`, 3);
-    for (const { slug: hitSlug, score } of hits) {
-      if (score < CONCEPT_MERGE_THRESHOLD) break; // sorted desc — none closer
-      if (hitSlug === candidateSlug) continue;
-      const page = await readWikiPageWithFrontmatter(hitSlug);
-      if (!page) continue;
-      // Same-silo guard: only merge into a page this owner owns, AND only when
-      // the page scope matches — so a fuzzy match can't fold agent-knowledge
-      // into a public feed page (or vice versa). Conservative: err toward fork.
-      const sameOwner = (page.frontmatter.owner ?? "system") === owner;
-      const sameScope = (page.frontmatter.type ?? "") === (pageType ?? "");
-      if (sameOwner && sameScope) return hitSlug;
-    }
+  // 3. Adjudicated merge (the robust catch for LLM concept-wording drift across
+  //    sources). Retrieve nearby existing pages, keep only same-owner/same-scope
+  //    non-artifact candidates, then let the LLM decide which — if any — is the
+  //    same concept.
+  const candidates: { slug: string; title: string; snippet: string }[] = [];
+  for (const hitSlug of await findMergeCandidates(concept, embedBody)) {
+    if (candidates.length >= MAX_MERGE_CANDIDATES) break;
+    if (hitSlug === candidateSlug) continue;
+    const page = await readWikiPageWithFrontmatter(hitSlug);
+    if (!page) continue;
+    const hitType =
+      typeof page.frontmatter.type === "string" ? page.frontmatter.type : "";
+    // Never fold into an artifact (slides/html) or an agent-knowledge page; only
+    // within the same owner's silo + same scope. Conservative: err toward fork.
+    if (isArtifactType(hitType) || isAgentScopedType(hitType)) continue;
+    if ((page.frontmatter.owner ?? "system") !== owner) continue;
+    if (hitType !== (pageType ?? "")) continue;
+    candidates.push({
+      slug: hitSlug,
+      title: page.title,
+      snippet: page.body.replace(/\s+/g, " ").trim().slice(0, 240),
+    });
+  }
+  if (candidates.length > 0) {
+    const chosen = await adjudicateMerge(concept, embedBody, candidates);
+    // Re-read post-adjudication (defensive: fork if it vanished concurrently).
+    if (chosen && (await readWikiPageWithFrontmatter(chosen))) return chosen;
   }
 
   // 4. No confident match — fork onto the candidate concept slug.

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -982,9 +982,10 @@ async function findMergeCandidates(
 /**
  * Ask the LLM which (if any) candidate page is the SAME concept as the new page.
  * Returns the chosen slug — validated to be one we actually offered (a
- * hallucination guard; longest match wins so a slug that's a substring of
- * another can't shadow it) — or `null` (→ fork). Conservative: no LLM key, an
- * empty / "none" answer, an unrecognized slug, or an LLM error all yield `null`.
+ * hallucination guard), matched as a whole TOKEN, never a loose substring, so
+ * the "none" sentinel or a short slug inside a word can't trigger a merge; if
+ * the answer names several candidates, the longest wins. Returns `null` (→ fork)
+ * on no LLM key, an empty / "none" / unrecognized answer, or an LLM error.
  */
 async function adjudicateMerge(
   concept: string,
@@ -1008,9 +1009,14 @@ async function adjudicateMerge(
     logger.warn("ingest", "merge adjudication failed; forking to a new page", err);
     return null;
   }
-  const answer = out.trim().toLowerCase();
+  // Match whole tokens (slugs keep hyphens, so "transformer" and
+  // "transformer-architecture" are distinct tokens) — never a loose substring,
+  // which could match the "none" sentinel or a short slug inside a word.
+  const answerTokens = new Set(
+    out.trim().toLowerCase().split(/[^a-z0-9-]+/).filter(Boolean),
+  );
   const matches = candidates
-    .filter((c) => answer.includes(c.slug.toLowerCase()))
+    .filter((c) => answerTokens.has(c.slug.toLowerCase()))
     .sort((a, b) => b.slug.length - a.slug.length);
   return matches[0]?.slug ?? null;
 }
@@ -1026,8 +1032,8 @@ async function adjudicateMerge(
  *   3. Adjudicated merge — retrieve nearby existing pages (embedding similarity,
  *      or a title+summary BM25 fallback) and let the LLM decide which, if any,
  *      is the SAME concept. Scoped to the SAME owner + scope, never an artifact /
- *      agent-knowledge page, so a fuzzy match can't cross silos or corrupt an
- *      artifact's markup.
+ *      agent-scoped (`agent-*`) page, so a fuzzy match can't cross silos or
+ *      corrupt an artifact's markup.
  *
  * `embedBody` is the synthesized page body used for retrieval + adjudication.
  * Returns the candidate concept slug unchanged when no confident match is found
@@ -1059,30 +1065,40 @@ async function resolveConceptSlug(
   // 3. Adjudicated merge (the robust catch for LLM concept-wording drift across
   //    sources). Retrieve nearby existing pages, keep only same-owner/same-scope
   //    non-artifact candidates, then let the LLM decide which — if any — is the
-  //    same concept.
-  const candidates: { slug: string; title: string; snippet: string }[] = [];
-  for (const hitSlug of await findMergeCandidates(concept, embedBody)) {
-    if (candidates.length >= MAX_MERGE_CANDIDATES) break;
-    if (hitSlug === candidateSlug) continue;
-    const page = await readWikiPageWithFrontmatter(hitSlug);
-    if (!page) continue;
-    const hitType =
-      typeof page.frontmatter.type === "string" ? page.frontmatter.type : "";
-    // Never fold into an artifact (slides/html) or an agent-knowledge page; only
-    // within the same owner's silo + same scope. Conservative: err toward fork.
-    if (isArtifactType(hitType) || isAgentScopedType(hitType)) continue;
-    if ((page.frontmatter.owner ?? "system") !== owner) continue;
-    if (hitType !== (pageType ?? "")) continue;
-    candidates.push({
-      slug: hitSlug,
-      title: page.title,
-      snippet: page.body.replace(/\s+/g, " ").trim().slice(0, 240),
-    });
-  }
-  if (candidates.length > 0) {
-    const chosen = await adjudicateMerge(concept, embedBody, candidates);
-    // Re-read post-adjudication (defensive: fork if it vanished concurrently).
-    if (chosen && (await readWikiPageWithFrontmatter(chosen))) return chosen;
+  //    same concept. Wrapped fail-soft: dedup is advisory, so ANY retrieval /
+  //    read / adjudication error forks a new page rather than breaking the ingest
+  //    (this path now runs on every ingest, incl. the embeddings-off BM25 case).
+  try {
+    const candidates: { slug: string; title: string; snippet: string }[] = [];
+    for (const hitSlug of await findMergeCandidates(concept, embedBody)) {
+      if (candidates.length >= MAX_MERGE_CANDIDATES) break;
+      if (hitSlug === candidateSlug) continue;
+      const page = await readWikiPageWithFrontmatter(hitSlug);
+      if (!page) continue;
+      const hitType =
+        typeof page.frontmatter.type === "string" ? page.frontmatter.type : "";
+      // Never fold into an artifact (slides/html) or an agent-scoped (`agent-*`)
+      // page; only within the same owner's silo + same scope. Err toward fork.
+      if (isArtifactType(hitType) || isAgentScopedType(hitType)) continue;
+      if ((page.frontmatter.owner ?? "system") !== owner) continue;
+      if (hitType !== (pageType ?? "")) continue;
+      candidates.push({
+        slug: hitSlug,
+        title: page.title,
+        snippet: page.body.replace(/\s+/g, " ").trim().slice(0, 240),
+      });
+    }
+    if (candidates.length > 0) {
+      const chosen = await adjudicateMerge(concept, embedBody, candidates);
+      // Re-read post-adjudication (defensive: fork if it vanished concurrently).
+      if (chosen && (await readWikiPageWithFrontmatter(chosen))) return chosen;
+    }
+  } catch (err) {
+    logger.warn(
+      "ingest",
+      "concept-merge resolution failed; forking to a new page",
+      err,
+    );
   }
 
   // 4. No confident match — fork onto the candidate concept slug.


### PR DESCRIPTION
## What

The **prevention** half of the duplicate-page fix (PR2 #589 shipped the *cure*, `merge_pages`). Same-concept-different-source ingests — e.g. an X post "Agent Harness" and the article "Harness (AI agents)" — currently fork into two pages because all four ingest dedup layers are identity-based, and the one semantic layer (`resolveConceptSlug` step 3) was a **cosine-only ≥0.86 gate**: it forks on any wording drift *and* is embedding-only, so with Vectorize not backfilled in prod it never fired at all.

## How

Upgrades **step 3 of `resolveConceptSlug`** (no new write path — returning an existing slug flows into the existing reconcile-on-merge machinery: body fold + `disputed` escalation + source union):

1. **Retrieve candidates** — embedding similarity with a *low recall floor* (`CONCEPT_ADJUDICATE_FLOOR = 0.6`, gating only *which pages the LLM judges*) when embeddings are available; otherwise a **title+summary BM25 pass** over the index (`fullBody:false` → no disk reads, no rerank LLM) — so it works **before Vectorize is backfilled** (the current prod reality).
2. **Pre-filter** — same owner + same scope, never an artifact (slides/html) or agent-knowledge page, never the candidate itself.
3. **One LLM adjudication call** — "which of these existing pages is the SAME concept, or `none`?" The answer is **validated against the offered candidates** (hallucination guard; longest match wins so a substring slug can't shadow) and **re-read** before use. Any miss → fork.

This replaces a brittle number with an LLM judgment: high recall (catches reworded concepts) **and** high precision (won't merge merely-related pages).

## Safety
- **Monotonic** — folds into the older page; a re-ingest of the *same* source hits the URL/content-hash dedup first, so no churn/flip-flop; `reconcilePage` never re-enters `ingest`.
- **No extra cost on the common path** — empty wiki / no candidate over floor / no LLM key → fork, zero extra LLM calls.
- **Conservative by default** — no LLM key, `"none"`, or an unrecognized slug all fork.
- **Bounded blast radius** — a wrong merge escalates `disputed` (caps confidence, flags for review) and is curable via `merge_pages`.

## Verification
- `pnpm build` + `pnpm build:cloudflare` clean · `pnpm lint` 0 errors · **3114 tests pass**.
- New `resolveConceptSlug` tests: differently-worded same-concept → merge via adjudication; below-floor → no candidate/no adjudication call; adjudicator `"none"` → fork; hallucinated slug → fork; **BM25 fallback (embeddings off) surfaces + merges** a candidate (the pre-backfill prod path). Existing owner/scope guard tests still pass (candidates dropped before adjudication).
- Post-deploy: this is what makes your **delete-the-dupes-and-re-ingest** workflow converge — re-ingesting the X post + the article lands them on one page (the second flagged `disputed` only if it contradicts). Let it deploy before re-ingesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)