### PR TITLE
yoyo: drop the Figures gallery from ingested pages (no re-hosting, less storage)

### DIFF
--- a/src/app/api/assets/[...path]/route.ts
+++ b/src/app/api/assets/[...path]/route.ts
@@ -6,11 +6,11 @@ import { logger } from "@/lib/logger";
 /**
  * GET /api/assets/[...path]
  *
- * Serves a binary asset (image) that was stored during ingest. Ingested images
- * live at the storage key `raw/assets/{slug}/{file}` and are referenced in
- * markdown by the relative path `assets/{slug}/{file}` (see `downloadImages` in
- * `lib/fetch.ts`). This route maps a request path back to that storage key and
- * streams the bytes with the right Content-Type.
+ * Serves a binary asset (image) that was stored during ingest. Stored images
+ * (e.g. single-image ingests via `storeImageBytes` / `ingestImage`, and baked
+ * yoyo illustrations) live at the storage key `raw/assets/{slug}/{file}` and are
+ * referenced in markdown by the relative path `assets/{slug}/{file}`. This route
+ * maps a request path back to that storage key and streams the bytes.
  *
  * Public + read-only: the middleware only gates write methods on `/api`.
  */

--- a/src/lib/__tests__/ingest-image.test.ts
+++ b/src/lib/__tests__/ingest-image.test.ts
@@ -129,10 +129,10 @@ describe("ingestImage", () => {
   });
 });
 
-describe("source images → bottom Figures gallery (ingest, LLM path)", () => {
-  it("appends re-hosted source images as a ## Figures gallery; body stays image-free", async () => {
+describe("source images → dropped (ingest, LLM path)", () => {
+  it("drops source images: body is image-free with no ## Figures; raw keeps the original refs", async () => {
     mockedHasLLMKey.mockReturnValue(true);
-    // The synthesizer is fed image-free text and returns clean prose (no tokens).
+    // The synthesizer is fed image-free text and returns clean prose.
     mockedCallLLM.mockResolvedValue(
       "# Doc\n\n## Summary\n\nDistilled.\n\n## Details\n\nMore.",
     );
@@ -144,40 +144,17 @@ describe("source images → bottom Figures gallery (ingest, LLM path)", () => {
     );
 
     const page = await readWikiPageWithFrontmatter(result.primarySlug);
-    // The image lives in the trailing gallery, not inline in the prose body.
-    expect(page!.content).toContain("## Figures");
-    expect(page!.content).toContain("![a chart](assets/doc/chart.png)");
-    expect(page!.content).not.toContain("[[IMG:");
-    expect(page!.content.indexOf("## Figures")).toBeGreaterThan(
-      page!.content.indexOf("## Details"),
-    );
+    // No gallery, and no image anywhere in the page body.
+    expect(page!.content).not.toContain("## Figures");
+    expect(page!.content).not.toContain("chart.png");
 
-    // Invariant: the RAW source keeps the original refs — only the synthesis
-    // INPUT is image-stripped, never `content` (which feeds saveRawSource + hash).
+    // Invariant: the RAW source is untouched — it keeps the original image ref.
     const rawId = parseSources(page!.frontmatter.sources as string)[0]?.raw_id;
     const raw = await readRawSourceById(result.primarySlug, rawId!);
     expect(raw.content).toContain("![a chart](assets/doc/chart.png)");
   });
 
-  it("drops decorative images (logo) — not added to the gallery", async () => {
-    mockedHasLLMKey.mockReturnValue(true);
-    mockedCallLLM.mockResolvedValue("# Doc\n\n## Summary\n\nText.");
-
-    const result = await ingest(
-      "Doc Logo",
-      "Intro.\n\n![site logo](assets/doc/logo.png)\n\nbody.",
-      { author: "alice", owner: "alice" },
-    );
-
-    const page = await readWikiPageWithFrontmatter(result.primarySlug);
-    expect(page!.content).not.toContain("logo.png");
-    // The only image was decorative → no gallery section at all.
-    expect(page!.content).not.toContain("## Figures");
-  });
-
-  it("no-LLM-key fallback: image appears once, in the gallery (not inline twice)", async () => {
-    // The fallback path is also fed image-free text, then the gallery is
-    // appended — so the image renders exactly once, under ## Figures.
+  it("no-LLM-key fallback also drops images (no gallery, body image-free)", async () => {
     mockedHasLLMKey.mockReturnValue(false);
 
     const result = await ingest(
@@ -187,11 +164,9 @@ describe("source images → bottom Figures gallery (ingest, LLM path)", () => {
     );
 
     const page = await readWikiPageWithFrontmatter(result.primarySlug);
-    expect(page!.content).toContain("## Figures");
-    expect((page!.content.match(/!\[a chart\]\(assets\/doc\/chart\.png\)/g) ?? []).length).toBe(1);
-    expect(page!.content.indexOf("## Figures")).toBeGreaterThan(
-      page!.content.indexOf("Some prose."),
-    );
+    expect(page!.content).not.toContain("## Figures");
+    expect(page!.content).not.toContain("chart.png");
+    expect(page!.content).toContain("Some prose.");
   });
 });
 

--- a/src/lib/__tests__/ingest-image.test.ts
+++ b/src/lib/__tests__/ingest-image.test.ts
@@ -147,6 +147,9 @@ describe("source images → dropped (ingest, LLM path)", () => {
     // No gallery, and no image anywhere in the page body.
     expect(page!.content).not.toContain("## Figures");
     expect(page!.content).not.toContain("chart.png");
+    // No re-hosting: source images are never fetched or stored to R2.
+    expect(mockedFetchBytes).not.toHaveBeenCalled();
+    expect(mockedStoreBytes).not.toHaveBeenCalled();
 
     // Invariant: the RAW source is untouched — it keeps the original image ref.
     const rawId = parseSources(page!.frontmatter.sources as string)[0]?.raw_id;

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -15,9 +15,7 @@ import {
   deriveTitleFromContent,
   collectTagVocabulary,
   computeConfidence,
-  collectGalleryImages,
   stripImageMarkdown,
-  appendFigures,
   mergeSourceEntry,
 } from "../ingest";
 import { slugify } from "../slugify";
@@ -3567,54 +3565,14 @@ describe("ingest attribution", () => {
   });
 });
 
-describe("collectGalleryImages / stripImageMarkdown / appendFigures", () => {
-  it("collects re-hosted (local) images only — never hotlinks", () => {
-    const src =
-      "Intro.\n\n![a chart](assets/p/chart.png)\n\n![remote](https://x.com/fig.png)\n\nbody.";
-    // The failed-download remote URL is excluded (no hotlink/tracking on view).
-    expect(collectGalleryImages(src)).toEqual([
-      { alt: "a chart", ref: "assets/p/chart.png" },
-    ]);
-  });
-
-  it("drops decorative images (logo/icon)", () => {
-    expect(
-      collectGalleryImages(
-        "![site logo](assets/p/logo.png)\n\n![diagram](assets/p/fig.png)",
-      ),
-    ).toEqual([{ alt: "diagram", ref: "assets/p/fig.png" }]);
-  });
-
-  it("dedups a repeated ref and caps at MAX_APPENDED_IMAGES", () => {
-    expect(
-      collectGalleryImages("![x](assets/p/a.png)\n\n![x again](assets/p/a.png)"),
-    ).toEqual([{ alt: "x", ref: "assets/p/a.png" }]);
-    const many = Array.from(
-      { length: 20 },
-      (_, i) => `![fig${i}](assets/p/f${i}.png)`,
-    ).join("\n\n");
-    expect(collectGalleryImages(many).length).toBe(12); // MAX_APPENDED_IMAGES
-  });
-
-  it("stripImageMarkdown removes all image syntax (body goes image-free to the LLM)", () => {
-    const out = stripImageMarkdown("a ![x](assets/p/a.png) b ![y](https://z/c.png) c");
+describe("stripImageMarkdown", () => {
+  it("removes all image syntax (ingested bodies go image-free — no gallery)", () => {
+    const out = stripImageMarkdown(
+      "a ![x](assets/p/a.png) b ![y](https://z/c.png) c",
+    );
     expect(out).not.toMatch(/!\[/);
     expect(out).toContain("a ");
     expect(out).toContain(" c");
-  });
-
-  it("appendFigures adds a trailing ## Figures gallery (no-op when empty)", () => {
-    const body = "# Title\n\nProse.";
-    expect(appendFigures(body, [])).toBe(body);
-    const withFigs = appendFigures(body, [
-      { alt: "a", ref: "assets/p/a.png" },
-      { alt: "b", ref: "assets/p/b.png" },
-    ]);
-    expect(withFigs).toContain("## Figures");
-    expect(withFigs).toContain("![a](assets/p/a.png)");
-    expect(withFigs).toContain("![b](assets/p/b.png)");
-    // Gallery is at the END, after the prose body.
-    expect(withFigs.indexOf("## Figures")).toBeGreaterThan(withFigs.indexOf("Prose."));
   });
 });
 

--- a/src/lib/__tests__/mcp.test.ts
+++ b/src/lib/__tests__/mcp.test.ts
@@ -53,9 +53,9 @@ import { parseFrontmatter } from "../frontmatter";
 import { registerAgent } from "../agents";
 
 // ---------------------------------------------------------------------------
-// Mock fetchUrlContent, downloadImages, fetchImageBytes, and storeImageBytes
-// so no test makes real HTTP calls.
-// All other exports from ../fetch (isUrl, validateUrlSafety, etc.) are kept.
+// Mock fetchUrlContent, fetchImageBytes, and storeImageBytes so no test makes
+// real HTTP calls. All other exports from ../fetch (isUrl, validateUrlSafety,
+// etc.) are kept.
 // ---------------------------------------------------------------------------
 vi.mock("../fetch", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../fetch")>();
@@ -65,7 +65,6 @@ vi.mock("../fetch", async (importOriginal) => {
       title: `Mocked page for ${url}`,
       content: `Mocked content fetched from ${url}`,
     })),
-    downloadImages: vi.fn(async (markdown: string) => markdown),
     fetchImageBytes: vi.fn(async (url: string) => ({
       bytes: new ArrayBuffer(8),
       filename: url.split("/").pop() || "image.png",
@@ -107,11 +106,10 @@ vi.mock("../llm", async (importOriginal) => {
   };
 });
 
-import { fetchUrlContent, downloadImages } from "../fetch";
+import { fetchUrlContent } from "../fetch";
 import { fetchXPostContent } from "../x-post";
 const mockedFetchUrlContent = vi.mocked(fetchUrlContent);
 const mockedFetchXPostContent = vi.mocked(fetchXPostContent);
-const mockedDownloadImages = vi.mocked(downloadImages);
 
 let tmpDir: string;
 let originalWikiDir: string | undefined;
@@ -134,7 +132,6 @@ beforeEach(async () => {
     title: `Mocked page for ${url}`,
     content: `Mocked content fetched from ${url}`,
   }));
-  mockedDownloadImages.mockImplementation(async (markdown: string) => markdown);
 });
 
 afterEach(async () => {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -310,7 +310,9 @@ export async function fetchUrlContent(
   // Readability prunes figures that look decorative (lazy-loaded, empty alt, SVG
   // diagrams), so technical posts often lose their diagrams. Salvage image URLs
   // straight from the source DOM and reference any the extracted content is
-  // missing — downloadImages() then localizes them (or keeps the URL). Appended
+  // missing, so the immutable RAW source snapshot still captures the article's
+  // figures. (Ingest strips all images from the synthesized wiki page — see
+  // `stripImageMarkdown` — so these never appear in the page body.) Appended
   // AFTER truncation so a long article never drops its figures. HTML path only.
   if (mimeType !== "text/plain" && mimeType !== "text/markdown") {
     const salvaged = extractImageUrls(body, url).filter(

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -11,7 +11,7 @@ import {
 } from "./wiki";
 import { buildCorpusStats, bm25Score, tokenize } from "./bm25";
 import { callLLM, hasLLMKey } from "./llm";
-import { fetchUrlContent, downloadImages, fetchImageBytes, storeImageBytes, pdfToText } from "./fetch";
+import { fetchUrlContent, fetchImageBytes, storeImageBytes, pdfToText } from "./fetch";
 import { describeImage } from "./vision";
 import { isYouTubeUrl, fetchYouTubeContent } from "./youtube";
 import { isXPostUrl, fetchXPostContent } from "./x-post";
@@ -104,7 +104,6 @@ import {
   INGEST_MAX_OUTPUT_TOKENS,
   INGEST_MAP_MAX_OUTPUT_TOKENS,
   INGEST_MAP_CONCURRENCY,
-  MAX_APPENDED_IMAGES,
   MAX_CONTENT_LENGTH,
   MAX_PDF_SIZE,
   MAX_AUTO_TAGS,
@@ -113,7 +112,6 @@ import {
 import { ClientInputError } from "./errors";
 import { slugify } from "./slugify";
 import { loadPageConventions } from "./schema";
-import { getRawDir } from "./config";
 import { resolveAlias } from "./alias-index";
 import {
   resolveSourceUrl,
@@ -244,8 +242,6 @@ export async function ingestUrl(
   }
 
   const { title, content } = await fetchUrlContent(url);
-  // Image downloading is centralized in ingest() so every path (url, text,
-  // agent, X) captures embedded images uniformly.
   return ingest(title, content, { ...options, sourceUrl: url });
 }
 
@@ -493,8 +489,7 @@ export async function reingest(
     });
   }
 
-  const { title, content: rawContent } = await fetchUrlContent(sourceUrl);
-  const content = await downloadImages(rawContent, slug, getRawDir());
+  const { title, content } = await fetchUrlContent(sourceUrl);
   return ingest(title, content, { sourceUrl, pinSlug: slug, ...opts });
 }
 
@@ -548,55 +543,15 @@ function generateFallbackPage(title: string, content: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Image preservation
+// Image handling
 // ---------------------------------------------------------------------------
 
-/** A re-hosted source image captured for the trailing Figures gallery. */
-interface SourceImageRef {
-  alt: string;
-  ref: string;
-}
-
-/** Image refs we drop outright (decorative/branding/UI — never content). */
-const DECORATIVE_IMAGE_RE = /(logo|icon|avatar|sprite|favicon|emoji|banner)/i;
-
-/**
- * Collect the RE-HOSTED source images for a trailing `## Figures` gallery. Only
- * local `assets/…` (or `raw/assets/…`) refs are kept — never a hotlinked
- * `http(s)` URL: a failed download that kept its original URL is excluded so a
- * page never re-fetches a third-party image on view (a tracking/exfil vector).
- * Decorative images are dropped, duplicates collapsed, and the list capped at
- * {@link MAX_APPENDED_IMAGES}. Run on the post-`downloadImages` content.
- */
-export function collectGalleryImages(content: string): SourceImageRef[] {
-  const images: SourceImageRef[] = [];
-  const seen = new Set<string>();
-  for (const m of content.matchAll(/!\[([^\]]*)\]\(([^)\s]+)\)/g)) {
-    const alt = m[1];
-    const ref = m[2];
-    // Re-hosted only — exclude hotlinks (failed downloads keep their URL).
-    if (!ref.startsWith("assets/") && !ref.startsWith("raw/assets/")) continue;
-    if (DECORATIVE_IMAGE_RE.test(ref) || DECORATIVE_IMAGE_RE.test(alt)) continue;
-    if (seen.has(ref)) continue;
-    seen.add(ref);
-    if (images.length >= MAX_APPENDED_IMAGES) break;
-    images.push({ alt, ref });
-  }
-  return images;
-}
-
-/** Strip all markdown image syntax so the synthesis LLM gets image-free text
- *  (images live in the trailing gallery, not inline in the body). */
+/** Strip all markdown image syntax so the synthesis LLM gets image-free text.
+ *  Source images are DROPPED from ingested pages — no inline images, no
+ *  `## Figures` gallery, and no re-hosting to R2 (clean prose for index/query,
+ *  and less storage). Single-image ingests (`ingestImage`) are unaffected. */
 export function stripImageMarkdown(content: string): string {
   return content.replace(/!\[[^\]]*\]\([^)]*\)/g, "");
-}
-
-/** Append a `## Figures` gallery of the re-hosted images to a synthesized body
- *  (no-op when there are none). */
-export function appendFigures(body: string, images: SourceImageRef[]): string {
-  if (images.length === 0) return body;
-  const figs = images.map((i) => `![${i.alt}](${i.ref})`).join("\n\n");
-  return `${body.trimEnd()}\n\n## Figures\n\n${figs}\n`;
 }
 
 // ---------------------------------------------------------------------------
@@ -1388,8 +1343,7 @@ async function attachIngestTrigger(
  * short content, MAP/REDUCE for long content (parallel map in bounded-concurrency
  * batches → merge), or a deterministic fallback page when there's no LLM key.
  * Returns the raw synthesized body (still carrying the leading CONCEPT marker on
- * the LLM path); the caller appends the Figures gallery and strips that marker
- * (order-independent — the marker leads, the gallery trails).
+ * the LLM path); the caller strips that marker.
  */
 async function synthesizeBody(title: string, content: string): Promise<string> {
   if (!hasLLMKey()) {
@@ -1500,15 +1454,6 @@ export async function ingest(
   const actor = options?.author?.trim() || "system";
   const owner = options?.owner?.trim() || actor;
 
-  // Download any images referenced in the source to local storage and rewrite
-  // their markdown refs to `assets/<slug>/...`. Centralized here (not in
-  // ingestUrl) so URL, pasted-text, agent, and X ingests all capture images.
-  // Skipped for a prebuilt body (the image-ingest path): it already ran image
-  // capture / carries local refs, so re-downloading would refetch needlessly.
-  if (!prebuiltContent) {
-    content = await downloadImages(content, slug, getRawDir());
-  }
-
   // Dedup by content: if identical content was already ingested (any slug),
   // attach the triggerer and skip the LLM + embedding.
   const hash = contentHash(content);
@@ -1531,23 +1476,11 @@ export async function ingest(
     // Image ingest: skip the LLM, write the already-final body as-is.
     wikiContent = prebuiltContent;
   } else {
-    // Source images go in a trailing `## Figures` gallery, not inline: collect
-    // the re-hosted ones, then feed the synthesizer/fallback IMAGE-FREE text so
-    // the body stays clean prose (better for index/query) with no inline images.
-    const galleryImages = collectGalleryImages(content);
-    // Observability tripwire: a sudden "0 of N" signals a regression upstream
-    // (e.g. downloadImages stopped re-hosting → all refs stay hotlinks → the
-    // re-hosted-only filter drops everything) that would otherwise vanish silently.
-    const sourceImageCount = (content.match(/!\[[^\]]*\]\([^)]*\)/g) ?? []).length;
-    if (sourceImageCount > 0) {
-      logger.debug(
-        "ingest",
-        `figures: kept ${galleryImages.length} of ${sourceImageCount} source image(s)`,
-      );
-    }
+    // Source images are dropped — strip them so the synthesizer gets image-free
+    // text and the body is clean prose (no inline images, no `## Figures`
+    // gallery, no re-hosting).
     const cleanContent = stripImageMarkdown(content);
     wikiContent = await synthesizeBody(effectiveTitle, cleanContent);
-    wikiContent = appendFigures(wikiContent, galleryImages);
   }
 
   // Pull the leading `CONCEPT:` / `ALIASES:` header lines the synthesis prompt
@@ -1588,10 +1521,6 @@ export async function ingest(
       }
     }
   }
-
-  // Re-hosted source images are collected into a trailing `## Figures` gallery
-  // (see collectGalleryImages / appendFigures) — the synthesized body is
-  // image-free prose.
 
   // A prebuilt body (image path) carries no CONCEPT marker, so the canonical
   // slug would otherwise stay the source-TITLE slug. Re-derive slug + title from


### PR DESCRIPTION
## What

Ingested article/text pages appended a trailing **`## Figures`** gallery of re-hosted source images. On merged pages that stacked up redundant/overlapping diagrams (the `agent-harness` merge ended up with two "harness overview" images from two sources), and re-hosting every source image to R2 cost storage for figures that mostly cluttered the page. Per your call: **drop the gallery entirely** — less storage, no confusing images.

## How

- **Source images are dropped.** `stripImageMarkdown` still feeds the synthesizer image-free text (clean prose for index/query). We **no longer call `downloadImages`** (no re-hosting → no new R2 image storage) and **no longer build a `## Figures` gallery**.
- **Unchanged:** the generated Mermaid diagram; single-image ingests (`ingestImage`, where the image *is* the page); and raw sources keep their original image refs (the raw layer is immutable).
- `ingest.ts`: removed `collectGalleryImages`, `appendFigures`, `SourceImageRef`, `DECORATIVE_IMAGE_RE`, both `downloadImages` calls, and the now-unused `MAX_APPENDED_IMAGES` / `getRawDir` imports. Kept `stripImageMarkdown`.
- `downloadImages` is **retained in `fetch.ts`** as a utility (still unit-tested in `fetch.test`, mocked in `mcp.test`) but no longer called by ingest. (Can be removed in a follow-up if we're sure nothing will reuse it — left it to keep this PR focused.)

## Scope notes
- **Existing pages keep their galleries until re-ingested** (no migration). The `agent-harness` pair gets cleaned by your planned delete+reingest.
- **Orphaned R2 gallery assets** from past ingests still occupy storage; they can be garbage-collected in a separate cleanup pass if you want to reclaim it (this PR only stops *new* storage).

## Verification
- `pnpm build` + `pnpm build:cloudflare` clean · `pnpm lint` 0 errors · **3113 tests pass**.
- Updated tests: source images are dropped (body image-free, no `## Figures`), raw source keeps the original refs, and the no-LLM-key fallback also drops images. Kept the `stripImageMarkdown` unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)