### PR TITLE
yoyo: wire the dispute→reconcile loop (open thread on dispute, clear on resolve, honest banner)

### DIFF
--- a/src/app/u/[handle]/[slug]/page.tsx
+++ b/src/app/u/[handle]/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { getPrincipal } from "@/lib/auth";
 import { canReadFrontmatter } from "@/lib/authz";
 import { belongsInCommons } from "@/lib/commons";
 import { ArticleView } from "@/components/ArticleView";
+import { listThreads } from "@/lib/talk";
 
 interface WikiPageProps {
   params: Promise<{ handle: string; slug: string }>;
@@ -141,12 +142,17 @@ export default async function WikiPageView({ params }: WikiPageProps) {
 
   // Private, readable page → render with the real principal (so its backlinks
   // include the viewer's own private pages).
+  // Only let the `disputed` banner claim "a reconciliation is open" when one is.
+  const hasOpenReconciliation =
+    page.frontmatter.disputed === true &&
+    (await listThreads(slug)).some((t) => t.status === "open");
   return (
     <ArticleView
       page={page}
       slug={slug}
       pageTenant={pageTenant}
       principal={principal}
+      hasOpenReconciliation={hasOpenReconciliation}
     />
   );
 }

--- a/src/app/u/[handle]/[slug]/page.tsx
+++ b/src/app/u/[handle]/[slug]/page.tsx
@@ -11,7 +11,7 @@ import { getPrincipal } from "@/lib/auth";
 import { canReadFrontmatter } from "@/lib/authz";
 import { belongsInCommons } from "@/lib/commons";
 import { ArticleView } from "@/components/ArticleView";
-import { listThreads } from "@/lib/talk";
+import { hasOpenThread } from "@/lib/talk";
 
 interface WikiPageProps {
   params: Promise<{ handle: string; slug: string }>;
@@ -143,9 +143,9 @@ export default async function WikiPageView({ params }: WikiPageProps) {
   // Private, readable page → render with the real principal (so its backlinks
   // include the viewer's own private pages).
   // Only let the `disputed` banner claim "a reconciliation is open" when one is.
+  // (hasOpenThread is fail-soft — a discuss-read error can't break the render.)
   const hasOpenReconciliation =
-    page.frontmatter.disputed === true &&
-    (await listThreads(slug)).some((t) => t.status === "open");
+    page.frontmatter.disputed === true && (await hasOpenThread(slug));
   return (
     <ArticleView
       page={page}

--- a/src/app/wiki/[slug]/page.tsx
+++ b/src/app/wiki/[slug]/page.tsx
@@ -10,7 +10,7 @@ import {
 import { commonsPath } from "@/lib/links";
 import { belongsInCommons } from "@/lib/commons";
 import { commonsRedirectForMissing } from "@/lib/page-redirect";
-import { listThreads } from "@/lib/talk";
+import { hasOpenThread } from "@/lib/talk";
 import { ArticleView } from "@/components/ArticleView";
 
 interface PublicWikiPageProps {
@@ -129,9 +129,9 @@ export default async function PublicWikiPage({
       : undefined,
   );
   // Only let the `disputed` banner claim "a reconciliation is open" when one is.
+  // (hasOpenThread is fail-soft — a discuss-read error can't break the render.)
   const hasOpenReconciliation =
-    page.frontmatter.disputed === true &&
-    (await listThreads(slug)).some((t) => t.status === "open");
+    page.frontmatter.disputed === true && (await hasOpenThread(slug));
   return (
     <ArticleView
       page={page}

--- a/src/app/wiki/[slug]/page.tsx
+++ b/src/app/wiki/[slug]/page.tsx
@@ -10,6 +10,7 @@ import {
 import { commonsPath } from "@/lib/links";
 import { belongsInCommons } from "@/lib/commons";
 import { commonsRedirectForMissing } from "@/lib/page-redirect";
+import { listThreads } from "@/lib/talk";
 import { ArticleView } from "@/components/ArticleView";
 
 interface PublicWikiPageProps {
@@ -127,7 +128,17 @@ export default async function PublicWikiPage({
       ? page.frontmatter.owner
       : undefined,
   );
+  // Only let the `disputed` banner claim "a reconciliation is open" when one is.
+  const hasOpenReconciliation =
+    page.frontmatter.disputed === true &&
+    (await listThreads(slug)).some((t) => t.status === "open");
   return (
-    <ArticleView page={page} slug={slug} pageTenant={pageTenant} principal={null} />
+    <ArticleView
+      page={page}
+      slug={slug}
+      pageTenant={pageTenant}
+      principal={null}
+      hasOpenReconciliation={hasOpenReconciliation}
+    />
   );
 }

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -117,9 +117,10 @@ interface ArticleViewProps {
    */
   principal: Principal | null;
   /**
-   * Whether an open reconciliation thread actually exists — so the `disputed`
-   * banner only claims one when true. Computed in the route (the share view
-   * omits it → defaults false). Optional/defaults false.
+   * Whether an open discussion thread actually exists — so the `disputed` banner
+   * only claims "a reconciliation is open" when true. Computed by both read
+   * routes (`/wiki/<slug>`, `/u/<handle>/<slug>`); optional with a safe `false`
+   * default so a caller that hasn't computed it can't make the banner over-claim.
    */
   hasOpenReconciliation?: boolean;
 }

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -116,6 +116,12 @@ interface ArticleViewProps {
    * real principal from the auth-gated private route.
    */
   principal: Principal | null;
+  /**
+   * Whether an open reconciliation thread actually exists — so the `disputed`
+   * banner only claims one when true. Computed in the route (the share view
+   * omits it → defaults false). Optional/defaults false.
+   */
+  hasOpenReconciliation?: boolean;
 }
 
 /**
@@ -130,6 +136,7 @@ export async function ArticleView({
   slug,
   pageTenant,
   principal,
+  hasOpenReconciliation = false,
 }: ArticleViewProps) {
   // Slug→tenant map + commons slug set so in-content links and backlinks resolve
   // to each target's canonical URL: PUBLIC targets to the global `/wiki/<slug>`,
@@ -375,8 +382,12 @@ export async function ArticleView({
           >
             <span className="fresh warn" style={{ marginTop: 6 }} />
             <span>
-              This page is <strong>disputed</strong> and low-confidence. A
-              reconciliation is open on the discussion. Read with care.
+              This page is <strong>disputed</strong> and low-confidence — its
+              sources disagree.
+              {hasOpenReconciliation
+                ? " A reconciliation is open on the discussion."
+                : ""}{" "}
+              Read with care.
             </span>
           </div>
         )}

--- a/src/lib/__tests__/ingest.test.ts
+++ b/src/lib/__tests__/ingest.test.ts
@@ -588,6 +588,16 @@ describe("ingest — Phase 1 frontmatter fields", () => {
     // the preserved disputed=true flag caps it at 0.5.
     expect(page!.frontmatter.confidence).toBe(0.5);
 
+    // (A) The disputed page got an OPEN reconciliation thread so the dispute is
+    // actionable (human / ask-yoyo / maintenance scan).
+    const { listThreads, RECONCILE_THREAD_TITLE } = await import("../talk");
+    const threads = await listThreads("phase1-reingest");
+    expect(
+      threads.some(
+        (t) => t.status === "open" && t.title === RECONCILE_THREAD_TITLE,
+      ),
+    ).toBe(true);
+
     // expiry reset to ~90 days from now (not the old 2024-09-01)
     const expiry = page!.frontmatter.expiry as string;
     const expiryDate = new Date(expiry);

--- a/src/lib/__tests__/merge.test.ts
+++ b/src/lib/__tests__/merge.test.ts
@@ -24,6 +24,7 @@ import { commonsPath } from "../links";
 import { resetSourceIndex } from "../source-index";
 import { resetAliasIndex, resolveAlias } from "../alias-index";
 import { rebuildBacklinkIndex } from "../backlink-index";
+import { listThreads, RECONCILE_THREAD_TITLE } from "../talk";
 import { _resetStorage } from "../storage";
 import { hasLLMKey, callLLM } from "../llm";
 import type { SourceEntry } from "../types";
@@ -218,6 +219,17 @@ describe("mergePages", () => {
     const into = await readWikiPageWithFrontmatter("agent-harness");
     expect(into!.frontmatter.disputed).toBe(true);
     expect(into!.frontmatter.confidence as number).toBeLessThanOrEqual(0.5);
+
+    // A disputed fold must open a reconciliation thread on the survivor so the
+    // contradiction is actionable (same loop as a disputed ingest).
+    const threads = await listThreads("agent-harness");
+    const recon = threads.find((t) => t.title === RECONCILE_THREAD_TITLE);
+    expect(recon).toBeDefined();
+    expect(recon!.status).toBe("open");
+    // Authored by the human actor (not the agent) → scan-actionable; references
+    // the absorbed slug.
+    expect(recon!.comments[0].author).toBe("alice");
+    expect(recon!.comments[0].body).toContain('merged in "harness-ai-agents"');
   });
 
   it("appends both bodies (no reconcile) when there's no LLM key", async () => {

--- a/src/lib/__tests__/reconcile.test.ts
+++ b/src/lib/__tests__/reconcile.test.ts
@@ -142,9 +142,9 @@ describe("reconcileFromTalk", () => {
       disputed: true,
     });
     await createThread("settled", "Sources disagree", "frank", "please reconcile");
-    // A clean revision with NO DISPUTED marker → contradiction resolved.
+    // An explicit "DISPUTED: no" verdict → contradiction resolved, flag cleared.
     mockedCallLLM.mockResolvedValue(
-      "# settled\n\nReconciled: the dates agree once normalized.",
+      "DISPUTED: no\n\n# settled\n\nReconciled: the dates agree once normalized.",
     );
 
     const result = await reconcileFromTalk("settled", 0, { author: "frank--yoyo" });
@@ -152,6 +152,7 @@ describe("reconcileFromTalk", () => {
     expect(result.disputed).toBe(false);
     const page = await readWikiPageWithFrontmatter("settled");
     expect(page!.frontmatter.disputed).toBe(false); // CLEARED (was true)
+    expect(page!.body).not.toContain("DISPUTED:"); // verdict line stripped
     const thread = await getThread("settled", 0);
     expect(thread!.status).toBe("resolved");
     expect(
@@ -163,9 +164,9 @@ describe("reconcileFromTalk", () => {
     const body = "Already consistent prose, nothing to edit.";
     await seedPage("flagonly", body, { disputed: true });
     await createThread("flagonly", "Sources disagree", "gina", "reconcile pls");
-    // The LLM returns the SAME body, no DISPUTED marker → no content change,
-    // verdict resolved → the flag must still flip to false.
-    mockedCallLLM.mockResolvedValue(`# flagonly\n\n${body}`);
+    // The LLM returns the SAME body with an explicit "DISPUTED: no" → no content
+    // change, verdict resolved → the flag must still flip to false.
+    mockedCallLLM.mockResolvedValue(`DISPUTED: no\n\n# flagonly\n\n${body}`);
 
     const result = await reconcileFromTalk("flagonly", 0, { author: "gina--yoyo" });
 
@@ -173,6 +174,46 @@ describe("reconcileFromTalk", () => {
     expect(result.disputed).toBe(false);
     const page = await readWikiPageWithFrontmatter("flagonly");
     expect(page!.frontmatter.disputed).toBe(false); // cleared despite no body change
+  });
+
+  it("PRESERVES disputed when the LLM omits the verdict line (no silent downgrade)", async () => {
+    // Tri-state safety: a malformed/forgotten marker must NOT clear a genuine
+    // dispute — only an explicit "DISPUTED: no" does.
+    await seedPage("kept", "Contested prose with a real contradiction.", {
+      disputed: true,
+    });
+    await createThread("kept", "Sources disagree", "hank", "reconcile pls");
+    // A revision with NO DISPUTED line at all → leave the flag unchanged.
+    mockedCallLLM.mockResolvedValue(
+      "# kept\n\nReworded prose, but the verdict line was forgotten.",
+    );
+
+    const result = await reconcileFromTalk("kept", 0, { author: "hank--yoyo" });
+
+    expect(result.changed).toBe(true); // body did change…
+    expect(result.disputed).toBe(true); // …but the dispute is preserved
+    const page = await readWikiPageWithFrontmatter("kept");
+    expect(page!.frontmatter.disputed).toBe(true);
+    // Still unresolved → thread stays open for a human.
+    expect((await getThread("kept", 0))!.status).toBe("open");
+  });
+
+  it("KEEPS disputed on an already-disputed page when the verdict is still 'yes'", async () => {
+    await seedPage("stuck", "1956 (McCarthy) vs 1955 (others).", {
+      disputed: true,
+    });
+    await createThread("stuck", "Sources disagree", "ivy", "reconcile pls");
+    mockedCallLLM.mockResolvedValue(
+      "DISPUTED: yes\n\n# stuck\n\nStill unresolved: 1956 vs 1955, both attributed.",
+    );
+
+    const result = await reconcileFromTalk("stuck", 0, { author: "ivy--yoyo" });
+
+    expect(result.disputed).toBe(true);
+    expect(
+      (await readWikiPageWithFrontmatter("stuck"))!.frontmatter.disputed,
+    ).toBe(true);
+    expect((await getThread("stuck", 0))!.status).toBe("open");
   });
 
   it("throws on a missing page (→ poison/422 at the route)", async () => {

--- a/src/lib/__tests__/reconcile.test.ts
+++ b/src/lib/__tests__/reconcile.test.ts
@@ -137,6 +137,44 @@ describe("reconcileFromTalk", () => {
     expect(mockedCallLLM).not.toHaveBeenCalled();
   });
 
+  it("CLEARS disputed when the reconcile resolves the contradiction (closes the loop)", async () => {
+    await seedPage("settled", "Older text with a contradiction.", {
+      disputed: true,
+    });
+    await createThread("settled", "Sources disagree", "frank", "please reconcile");
+    // A clean revision with NO DISPUTED marker → contradiction resolved.
+    mockedCallLLM.mockResolvedValue(
+      "# settled\n\nReconciled: the dates agree once normalized.",
+    );
+
+    const result = await reconcileFromTalk("settled", 0, { author: "frank--yoyo" });
+
+    expect(result.disputed).toBe(false);
+    const page = await readWikiPageWithFrontmatter("settled");
+    expect(page!.frontmatter.disputed).toBe(false); // CLEARED (was true)
+    const thread = await getThread("settled", 0);
+    expect(thread!.status).toBe("resolved");
+    expect(
+      thread!.comments[thread!.comments.length - 1].body.toLowerCase(),
+    ).toContain("cleared");
+  });
+
+  it("clears disputed even when the body needs no change (write-gate covers the flag flip)", async () => {
+    const body = "Already consistent prose, nothing to edit.";
+    await seedPage("flagonly", body, { disputed: true });
+    await createThread("flagonly", "Sources disagree", "gina", "reconcile pls");
+    // The LLM returns the SAME body, no DISPUTED marker → no content change,
+    // verdict resolved → the flag must still flip to false.
+    mockedCallLLM.mockResolvedValue(`# flagonly\n\n${body}`);
+
+    const result = await reconcileFromTalk("flagonly", 0, { author: "gina--yoyo" });
+
+    expect(result.changed).toBe(false);
+    expect(result.disputed).toBe(false);
+    const page = await readWikiPageWithFrontmatter("flagonly");
+    expect(page!.frontmatter.disputed).toBe(false); // cleared despite no body change
+  });
+
   it("throws on a missing page (→ poison/422 at the route)", async () => {
     await expect(reconcileFromTalk("nope", 0)).rejects.toThrow(/not found/i);
   });

--- a/src/lib/__tests__/talk.test.ts
+++ b/src/lib/__tests__/talk.test.ts
@@ -9,6 +9,7 @@ import {
   getThread,
   createThread,
   ensureReconciliationThread,
+  hasOpenThread,
   RECONCILE_THREAD_TITLE,
   addComment,
   resolveThread,
@@ -472,5 +473,26 @@ describe("ensureReconciliationThread", () => {
   it("defaults a blank author to 'system' (still non-agent → scan-actionable)", async () => {
     await ensureReconciliationThread("p", "");
     expect((await listThreads("p"))[0].comments[0].author).toBe("system");
+  });
+
+  it("coerces an agent-handle actor to 'system' so the scan can act on it", async () => {
+    // An agent self-ingest (author === the agent's own handle) or an autonomous
+    // `yoyo` staleness re-ingest must NOT leave the thread's latest comment
+    // agent-side — the maintenance scan only acts on human-side latest comments.
+    await ensureReconciliationThread("p", "alice--yoyo");
+    expect((await listThreads("p"))[0].comments[0].author).toBe("system");
+
+    await ensureReconciliationThread("q", "yoyo");
+    expect((await listThreads("q"))[0].comments[0].author).toBe("system");
+  });
+});
+
+describe("hasOpenThread", () => {
+  it("returns true only while an open thread exists", async () => {
+    expect(await hasOpenThread("p")).toBe(false); // no discuss file yet
+    await createThread("p", "An issue", "bob", "something is off");
+    expect(await hasOpenThread("p")).toBe(true);
+    await resolveThread("p", 0, "resolved");
+    expect(await hasOpenThread("p")).toBe(false); // all threads closed
   });
 });

--- a/src/lib/__tests__/talk.test.ts
+++ b/src/lib/__tests__/talk.test.ts
@@ -8,6 +8,8 @@ import {
   listThreads,
   getThread,
   createThread,
+  ensureReconciliationThread,
+  RECONCILE_THREAD_TITLE,
   addComment,
   resolveThread,
   deleteDiscussions,
@@ -434,5 +436,41 @@ describe("talk page data layer", () => {
       expect(stats.has("excluded")).toBe(false);
       expect(stats.get("included")).toEqual({ total: 1, open: 1 });
     });
+  });
+});
+
+describe("ensureReconciliationThread", () => {
+  it("opens a reconciliation thread authored by the human/system actor", async () => {
+    await ensureReconciliationThread("p", "alice", "merged in q");
+    const threads = await listThreads("p");
+    expect(threads).toHaveLength(1);
+    expect(threads[0].title).toBe(RECONCILE_THREAD_TITLE);
+    expect(threads[0].status).toBe("open");
+    // Authored by the actor (NOT the agent) so the maintenance scan acts on it.
+    expect(threads[0].comments[0].author).toBe("alice");
+    expect(threads[0].comments[0].body).toContain("merged in q");
+  });
+
+  it("is idempotent — no second thread while one is already open", async () => {
+    await ensureReconciliationThread("p", "alice");
+    await ensureReconciliationThread("p", "alice");
+    expect(
+      (await listThreads("p")).filter((t) => t.title === RECONCILE_THREAD_TITLE),
+    ).toHaveLength(1);
+  });
+
+  it("opens a fresh one once the prior reconciliation thread is resolved", async () => {
+    await ensureReconciliationThread("p", "alice");
+    await resolveThread("p", 0, "resolved");
+    await ensureReconciliationThread("p", "alice");
+    const open = (await listThreads("p")).filter(
+      (t) => t.title === RECONCILE_THREAD_TITLE && t.status === "open",
+    );
+    expect(open).toHaveLength(1);
+  });
+
+  it("defaults a blank author to 'system' (still non-agent → scan-actionable)", async () => {
+    await ensureReconciliationThread("p", "");
+    expect((await listThreads("p"))[0].comments[0].author).toBe("system");
   });
 });

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -10,6 +10,7 @@ import {
   type Frontmatter,
 } from "./wiki";
 import { buildCorpusStats, bm25Score, tokenize } from "./bm25";
+import { ensureReconciliationThread } from "./talk";
 import { callLLM, hasLLMKey } from "./llm";
 import { fetchUrlContent, fetchImageBytes, storeImageBytes, pdfToText } from "./fetch";
 import { describeImage } from "./vision";
@@ -1824,6 +1825,15 @@ export async function ingest(
     typeof frontmatter.source_url === "string" ? frontmatter.source_url : undefined,
     hash,
   );
+
+  // When this ingest left the page disputed (a source contradicts it), open a
+  // reconciliation discussion thread so the dispute is actionable — by a human,
+  // by "ask yoyo", or by the maintenance scan. Idempotent (skips if one's open)
+  // + fail-soft. Authored by the (human/system) actor so the scan, which only
+  // acts on threads whose latest comment is human-side, will pick it up.
+  if (frontmatter.disputed === true) {
+    await ensureReconciliationThread(slug, actor);
+  }
 
   const result: IngestResult = {
     rawPath,

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -1829,8 +1829,8 @@ export async function ingest(
   // When this ingest left the page disputed (a source contradicts it), open a
   // reconciliation discussion thread so the dispute is actionable — by a human,
   // by "ask yoyo", or by the maintenance scan. Idempotent (skips if one's open)
-  // + fail-soft. Authored by the (human/system) actor so the scan, which only
-  // acts on threads whose latest comment is human-side, will pick it up.
+  // + fail-soft; `ensureReconciliationThread` keeps the thread's author non-agent
+  // (coercing an agent actor to "system") so the scan can pick it up.
   if (frontmatter.disputed === true) {
     await ensureReconciliationThread(slug, actor);
   }

--- a/src/lib/merge.ts
+++ b/src/lib/merge.ts
@@ -21,6 +21,7 @@ import { logger } from "./logger";
 import { hasLLMKey } from "./llm";
 import { listWikiPages, readWikiPageWithFrontmatter } from "./wiki";
 import { isArtifactType } from "./page-types";
+import { ensureReconciliationThread } from "./talk";
 import {
   reconcilePage,
   sameHumanOwner,
@@ -271,6 +272,12 @@ export async function mergePages({
     crossRefSource: null,
     author: actor,
   });
+
+  // If the fold left the survivor disputed, open a reconciliation thread so the
+  // dispute is actionable (same loop as ingest). Idempotent + fail-soft.
+  if (disputed) {
+    await ensureReconciliationThread(intoSlug, actor ?? "system", `merged in "${fromSlug}"`);
+  }
 
   // 5. Delete the absorbed page (hard delete — its revisions + discussions go
   // with it; see the module note).

--- a/src/lib/reconcile.ts
+++ b/src/lib/reconcile.ts
@@ -3,13 +3,16 @@
  * "agents maintain, humans discuss" loop (B2b). A reader opens a talk thread
  * ("this claim is wrong", "these two pages are the same"), an agent (yoyo) reads
  * the page + the thread and revises the page to address the valid points,
- * flagging `disputed` when it can't resolve a contradiction. Triggered async via
+ * flagging `disputed` when it can't resolve a contradiction (and clearing it
+ * when it does). Triggered async via
  * the task queue (`/api/tasks/run` → here), never blocking the human's request.
  *
- * Reuses the ingest reconcile primitives (`parseDisputedMarker`,
- * `parseConceptMarker`, `extractSummary`) and the unified write path
+ * Reuses the ingest reconcile primitives (`parseConceptMarker`,
+ * `extractSummary`) and the unified write path
  * (`writeWikiPageWithSideEffects`), so this stays consistent with how pages are
- * synthesized and how `disputed`/revisions/log all behave.
+ * synthesized and how `disputed`/revisions/log all behave. The `DISPUTED:`
+ * verdict is parsed by the local tri-state `parseDisputedVerdict` (omit →
+ * leave the flag unchanged) rather than ingest's binary `parseDisputedMarker`.
  */
 
 import {
@@ -18,7 +21,7 @@ import {
   serializeFrontmatter,
   type Frontmatter,
 } from "./wiki";
-import { extractSummary, parseDisputedMarker, parseConceptMarker } from "./ingest";
+import { extractSummary, parseConceptMarker } from "./ingest";
 import { callLLM, hasLLMKey } from "./llm";
 import { INGEST_MAX_OUTPUT_TOKENS } from "./constants";
 import { getThread, addComment, resolveThread } from "./talk";
@@ -33,9 +36,10 @@ Rules:
 - Apply corrections and incorporate well-supported additions; keep the existing section structure (## Summary, ## Key Points, ## Concepts, ## Details) and any image markdown.
 - Only change what the discussion justifies. Do NOT invent facts not supported by the page or the discussion, and do NOT remove substantive existing content unless the discussion shows it is wrong.
 - Ignore off-topic chatter, opinions without support, and questions that don't imply a change.
-- The page may ALREADY be flagged disputed from an earlier unresolved contradiction. Judge the WHOLE revised page: if it STILL contains an unresolved contradiction (raised in this discussion, or already present), do not silently pick a side — keep both positions (attributing each) and begin your ENTIRE output with a single line, exactly:
-DISPUTED: yes
-  If NO unresolved contradiction remains, omit the DISPUTED line (this clears the disputed flag).
+- The page may ALREADY be flagged disputed from an earlier unresolved contradiction. Judge the WHOLE revised page and begin your ENTIRE output with ONE verdict line:
+    DISPUTED: yes   — an unresolved contradiction remains (raised here, or already present); keep both positions, attributing each.
+    DISPUTED: no    — none remains / you resolved it (this clears the flag).
+  Only if you are genuinely unsure, omit the line entirely — the current flag is then left unchanged.
 
 Output the optional DISPUTED line, then the full revised page as pure markdown, and nothing else. Do not wrap in code fences.`;
 
@@ -43,15 +47,39 @@ export interface ReconcileFromTalkResult {
   slug: string;
   /** True when the page body actually changed. */
   changed: boolean;
-  /** True when the reconcile surfaced an unresolved contradiction. */
+  /** The page's `disputed` flag AFTER reconciling (set / cleared / preserved). */
   disputed: boolean;
+}
+
+/**
+ * Parse the leading `DISPUTED: yes|no` verdict line (trailing rationale on the
+ * line is tolerated, so "DISPUTED: yes — still conflicts" still reads as `yes`).
+ * Returns the verdict — `true` (keep/flag), `false` (resolved/clear), or `null`
+ * when no verdict line is present (→ leave the existing flag unchanged) — plus
+ * the body with that line stripped. Requiring an explicit `no` to clear keeps a
+ * malformed/forgotten marker from silently downgrading a genuine dispute.
+ */
+function parseDisputedVerdict(raw: string): {
+  verdict: boolean | null;
+  body: string;
+} {
+  const m = raw.match(
+    /^﻿?\s*DISPUTED:[ \t]*(yes|true|no|false)\b[^\n]*(?:\r?\n|$)/i,
+  );
+  if (!m) return { verdict: null, body: raw };
+  return {
+    verdict: /^(yes|true)$/i.test(m[1]),
+    body: raw.slice(m[0].length).replace(/^\s+/, ""),
+  };
 }
 
 /**
  * Reconcile `slug` against discussion thread `threadIndex`: read both, LLM-revise
  * the page to address the readers' valid points, write via the unified pipeline
- * (escalating `disputed`), then post a yoyo reply summarizing what changed and
- * resolve the thread (left open + `disputed` when unresolved).
+ * (setting `disputed` to the page-wide verdict — flag when a contradiction
+ * remains, CLEAR when resolved, leave unchanged when the LLM gives no verdict),
+ * then post a yoyo reply summarizing what changed and resolve the thread (left
+ * open + `disputed` when a contradiction remains).
  *
  * Idempotent and fail-soft: a missing page/thread or an empty LLM response makes
  * no change (the page is never blanked). Safe to re-run (queue redelivery).
@@ -91,17 +119,20 @@ export async function reconcileFromTalk(
     return { slug, changed: false, disputed: false };
   }
 
-  const { disputed, body: afterDisputed } = parseDisputedMarker(out);
+  const { verdict, body: afterDisputed } = parseDisputedVerdict(out);
   // Strip any echoed CONCEPT:/ALIASES: synthesis headers.
   const { body: newBody } = parseConceptMarker(afterDisputed);
   const changed = newBody.trim() !== page.body.trim();
   const wasDisputed = page.frontmatter.disputed === true;
+  // Tri-state: an explicit verdict sets the flag; a SILENT response leaves it
+  // unchanged. Requiring an explicit "no" to clear means a malformed/forgotten
+  // marker can't silently downgrade a genuine dispute.
+  const disputed = verdict ?? wasDisputed;
 
-  // Write when the body changed OR the disputed flag must flip. Reflecting the
-  // LLM's page-wide verdict means a reconcile that RESOLVES the contradiction
-  // CLEARS `disputed` — even with no body change — closing the dispute loop
+  // Write when the body changed OR the disputed flag must flip — so a reconcile
+  // that RESOLVES the contradiction clears the banner even with no body change
   // (the old code only escalated, so the banner stuck forever).
-  if (changed || wasDisputed !== disputed) {
+  if (changed || disputed !== wasDisputed) {
     const fm: Frontmatter = { ...page.frontmatter };
     fm.updated = new Date().toISOString().slice(0, 10);
     fm.disputed = disputed;
@@ -121,6 +152,15 @@ export async function reconcileFromTalk(
           disputed ? " (disputed)" : wasDisputed ? " (dispute resolved)" : ""
         }`,
     });
+
+    // Clearing a human-visible dispute is a high-consequence downgrade — log it
+    // so a wrong-clear (an LLM mis-verdict) is auditable, not silent.
+    if (wasDisputed && !disputed) {
+      logger.info(
+        "reconcile",
+        `cleared disputed on "${slug}" (thread ${threadIndex}) — reconcile reports no remaining contradiction`,
+      );
+    }
   }
 
   // Reply in the thread (must precede resolve — resolved threads reject comments),

--- a/src/lib/reconcile.ts
+++ b/src/lib/reconcile.ts
@@ -33,9 +33,9 @@ Rules:
 - Apply corrections and incorporate well-supported additions; keep the existing section structure (## Summary, ## Key Points, ## Concepts, ## Details) and any image markdown.
 - Only change what the discussion justifies. Do NOT invent facts not supported by the page or the discussion, and do NOT remove substantive existing content unless the discussion shows it is wrong.
 - Ignore off-topic chatter, opinions without support, and questions that don't imply a change.
-- If the discussion raises a CONTRADICTION you cannot resolve from the available information, do not silently pick a side: keep both positions (attributing each) and begin your ENTIRE output with a single line, exactly:
+- The page may ALREADY be flagged disputed from an earlier unresolved contradiction. Judge the WHOLE revised page: if it STILL contains an unresolved contradiction (raised in this discussion, or already present), do not silently pick a side — keep both positions (attributing each) and begin your ENTIRE output with a single line, exactly:
 DISPUTED: yes
-  Otherwise do not emit a DISPUTED line.
+  If NO unresolved contradiction remains, omit the DISPUTED line (this clears the disputed flag).
 
 Output the optional DISPUTED line, then the full revised page as pure markdown, and nothing else. Do not wrap in code fences.`;
 
@@ -95,23 +95,31 @@ export async function reconcileFromTalk(
   // Strip any echoed CONCEPT:/ALIASES: synthesis headers.
   const { body: newBody } = parseConceptMarker(afterDisputed);
   const changed = newBody.trim() !== page.body.trim();
+  const wasDisputed = page.frontmatter.disputed === true;
 
-  if (changed || disputed) {
+  // Write when the body changed OR the disputed flag must flip. Reflecting the
+  // LLM's page-wide verdict means a reconcile that RESOLVES the contradiction
+  // CLEARS `disputed` — even with no body change — closing the dispute loop
+  // (the old code only escalated, so the banner stuck forever).
+  if (changed || wasDisputed !== disputed) {
     const fm: Frontmatter = { ...page.frontmatter };
     fm.updated = new Date().toISOString().slice(0, 10);
-    if (disputed) fm.disputed = true; // escalate only
-    const summary = extractSummary(newBody.replace(/^#\s+.+$/m, "").trim());
+    fm.disputed = disputed;
+    const finalBody = changed ? newBody : page.body;
+    const summary = extractSummary(finalBody.replace(/^#\s+.+$/m, "").trim());
 
     await writeWikiPageWithSideEffects({
       slug,
       title: page.title,
-      content: serializeFrontmatter(fm, changed ? newBody : page.body),
+      content: serializeFrontmatter(fm, finalBody),
       summary,
       logOp: "edit",
       crossRefSource: null, // a reconcile isn't a new source for cross-ref
       author,
       logDetails: () =>
-        `reconciled from discussion thread ${threadIndex}${disputed ? " (disputed)" : ""}`,
+        `reconciled from discussion thread ${threadIndex}${
+          disputed ? " (disputed)" : wasDisputed ? " (dispute resolved)" : ""
+        }`,
     });
   }
 
@@ -119,9 +127,11 @@ export async function reconcileFromTalk(
   // then resolve unless it ended disputed (leave it open for a human to weigh in).
   const reply = disputed
     ? "I reviewed this but found an unresolved contradiction — I've flagged the page as **disputed** and kept both views. Leaving this open for a human to settle."
-    : changed
-      ? "I've updated the page to address this. Thanks for flagging it."
-      : "I reviewed this but didn't find a change the page needed. Reopen with more detail if you disagree.";
+    : wasDisputed
+      ? "I reconciled the contradiction — the page reads consistently now, so I've cleared the **disputed** flag."
+      : changed
+        ? "I've updated the page to address this. Thanks for flagging it."
+        : "I reviewed this but didn't find a change the page needed. Reopen with more detail if you disagree.";
   try {
     await addComment(slug, threadIndex, author, reply);
     await resolveThread(slug, threadIndex, disputed ? "open" : "resolved");

--- a/src/lib/talk.ts
+++ b/src/lib/talk.ts
@@ -185,6 +185,45 @@ export async function createThread(
   });
 }
 
+/** Title of the auto-opened reconciliation thread — also its idempotency key. */
+export const RECONCILE_THREAD_TITLE = "Sources disagree — reconciliation needed";
+
+/**
+ * Open a reconciliation discussion thread for a page just flagged `disputed`
+ * (a source contradicts it), UNLESS an open one already exists — idempotent
+ * across re-ingests, keyed on {@link RECONCILE_THREAD_TITLE}. Authored by
+ * `author` (the ingest actor — a human or "system", never the agent) so the
+ * thread's latest comment is human-side and the maintenance scan + "ask yoyo"
+ * will act on it. Fail-soft: a thread-open failure never breaks the caller.
+ */
+export async function ensureReconciliationThread(
+  pageSlug: string,
+  author: string,
+  detail?: string,
+): Promise<void> {
+  try {
+    const threads = await listThreads(pageSlug);
+    if (
+      threads.some(
+        (t) => t.status === "open" && t.title === RECONCILE_THREAD_TITLE,
+      )
+    ) {
+      return; // a reconciliation is already open — don't duplicate
+    }
+    const body =
+      `An ingested source contradicts this page${detail ? ` (${detail})` : ""}, ` +
+      `so it's flagged **disputed** with both views kept. Please reconcile the ` +
+      `contradiction — edit the page, or ask yoyo to take a pass.`;
+    await createThread(pageSlug, RECONCILE_THREAD_TITLE, author || "system", body);
+  } catch (err) {
+    logger.warn(
+      "talk",
+      `failed to open reconciliation thread for "${pageSlug}"`,
+      err,
+    );
+  }
+}
+
 /**
  * Add a comment to an existing thread.
  * Returns the newly created TalkComment.

--- a/src/lib/talk.ts
+++ b/src/lib/talk.ts
@@ -12,6 +12,7 @@ import { getStorage } from "./storage";
 import { getDataDir } from "./paths";
 import { withFileLock } from "./lock";
 import { isEnoent } from "./errors";
+import { isAgentHandle } from "./agent-handle";
 import { logger } from "./logger";
 import type { TalkThread, TalkComment } from "./types";
 
@@ -191,10 +192,12 @@ export const RECONCILE_THREAD_TITLE = "Sources disagree — reconciliation neede
 /**
  * Open a reconciliation discussion thread for a page just flagged `disputed`
  * (a source contradicts it), UNLESS an open one already exists — idempotent
- * across re-ingests, keyed on {@link RECONCILE_THREAD_TITLE}. Authored by
- * `author` (the ingest actor — a human or "system", never the agent) so the
- * thread's latest comment is human-side and the maintenance scan + "ask yoyo"
- * will act on it. Fail-soft: a thread-open failure never breaks the caller.
+ * across re-ingests, keyed on {@link RECONCILE_THREAD_TITLE}. The first comment
+ * is authored by a NON-agent: `author` if it's a human/system handle, else
+ * coerced to "system" (an agent-handle actor — e.g. a `yoyo` staleness
+ * re-ingest — would otherwise make the thread invisible to the maintenance scan,
+ * which only acts on threads whose latest comment is human-side). Fail-soft: a
+ * thread-open failure never breaks the caller.
  */
 export async function ensureReconciliationThread(
   pageSlug: string,
@@ -210,17 +213,33 @@ export async function ensureReconciliationThread(
     ) {
       return; // a reconciliation is already open — don't duplicate
     }
+    // Keep the latest comment human-side so the scan + "ask yoyo" can act on it.
+    const safeAuthor = !author || isAgentHandle(author) ? "system" : author;
     const body =
       `An ingested source contradicts this page${detail ? ` (${detail})` : ""}, ` +
       `so it's flagged **disputed** with both views kept. Please reconcile the ` +
       `contradiction — edit the page, or ask yoyo to take a pass.`;
-    await createThread(pageSlug, RECONCILE_THREAD_TITLE, author || "system", body);
+    await createThread(pageSlug, RECONCILE_THREAD_TITLE, safeAuthor, body);
   } catch (err) {
     logger.warn(
       "talk",
       `failed to open reconciliation thread for "${pageSlug}"`,
       err,
     );
+  }
+}
+
+/**
+ * True iff `pageSlug` has at least one OPEN discussion thread. Fail-soft: a
+ * discuss-read error (corrupt file, storage hiccup) logs and returns `false`,
+ * so a page render that calls this only to word a banner never crashes.
+ */
+export async function hasOpenThread(pageSlug: string): Promise<boolean> {
+  try {
+    return (await listThreads(pageSlug)).some((t) => t.status === "open");
+  } catch (err) {
+    logger.warn("talk", `open-thread check failed for "${pageSlug}"`, err);
+    return false;
   }
 }
 


### PR DESCRIPTION
## Why

A `disputed` page was a **dead end** (you hit this on `agent-harness`): ingest/merge flagged `disputed` but opened **no thread**; the maintenance scan only reconciles a disputed page that *already* has an open human thread; and `reconcileFromTalk` was **escalate-only** — so the flag (and the warning banner) stuck forever, even after a reconcile. This closes the loop.

## What

**(A) Open a reconciliation thread on dispute.** New `ensureReconciliationThread` (`src/lib/talk.ts`):
- **idempotent** — keyed on the thread title, so re-ingesting a still-disputed page won't spawn duplicate threads;
- **fail-soft** — a thread-open failure never breaks the ingest;
- **authored by the human/system ingest actor (never the agent)** — critical, because the maintenance scan *skips* threads whose latest comment is an agent. Called from `ingest()` and `mergePages()` whenever the result is `disputed`.

**(B) Clear `disputed` when a reconcile resolves it.** `reconcileFromTalk` now reflects the LLM's **page-wide verdict** (`fm.disputed = disputed`) instead of escalate-only, and the **write-gate widened** so a no-content-change resolve still flips the flag and resolves the thread. The prompt now defines `DISPUTED: yes` as "the page **still** contains an unresolved contradiction" (omitting it clears). Scoped to the talk reconcile; the on-merge reconcile stays escalate-only (conservative — a new source shouldn't silently clear a dispute from elsewhere).

**(C) Honest banner.** `ArticleView` takes an optional `hasOpenReconciliation`; the `/wiki/[slug]` and `/u/[handle]/[slug]` routes compute it (`disputed && an open thread exists`), so the banner only claims "a reconciliation is open on the discussion" when one actually is. The share view omits the prop → defaults false.

## The loop, end to end
ingest/merge contradicts → `disputed` + an **open reconciliation thread** (banner now truthful) → a human comments / clicks "ask yoyo", or the maintenance scan picks it up → `reconcileFromTalk` revises the page → **resolved → `disputed` cleared + thread resolved**, or **still contradictory → flag kept, thread left open** for a human.

## Verification
- `pnpm build` + `pnpm build:cloudflare` clean · `pnpm lint` 0 errors · **3121 tests pass**.
- New/updated tests: `ensureReconciliationThread` (opens / idempotent / reopens after resolve / `system`-author default); `reconcileFromTalk` **clears** disputed on resolve (incl. the no-body-change flag-flip) and still keeps it on a real contradiction; a disputed re-ingest opens a reconciliation thread.

## Note on your existing page
`agent-harness` was disputed *before* this shipped, so it has no thread yet — with (C), its banner will now read without the false "reconciliation is open" claim. Re-ingesting it (or opening a discussion + asking yoyo) will engage the new loop; and once reconciled, (B) will clear the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)