### PR TITLE
yoyo: invite-only sign-up with a Clerk waitlist (gate registration only)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,18 @@
 # Both files are gitignored. Production sets these as Cloudflare Worker
 # secrets/vars and (for NEXT_PUBLIC_* values) in the deploy build step.
 
-# --- Clerk auth (X/Twitter SSO) ---
+# --- Clerk auth (email + optional X/Twitter SSO) ---
 # Both are required at runtime, even reads, or the app 500s.
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
 CLERK_SECRET_KEY=sk_test_...
+#
+# Invite-only / waitlist is configured in the CLERK DASHBOARD, not via env:
+#   1. Enable Email auth (needed for waitlist invitation emails).
+#   2. Require Username at sign-up (it's the basis for /u/<handle> URLs).
+#   3. Waitlist page → toggle "Enable waitlist" (gates new registration only;
+#      reading the commons stays public). Approve people via the row "…" → Invite.
+# The app side is just `waitlistUrl="/waitlist"` on <ClerkProvider> (layout.tsx)
+# + the /waitlist page — no extra env var.
 
 # --- Site owner ---
 # The X/Twitter handle of the site owner. Gates owner-only admin tools (Lint):

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,9 @@ CLERK_SECRET_KEY=sk_test_...
 #
 # Invite-only / waitlist is configured in the CLERK DASHBOARD, not via env:
 #   1. Enable Email auth (needed for waitlist invitation emails).
-#   2. Require Username at sign-up (it's the basis for /u/<handle> URLs).
+#   2. Require Username at sign-up — the preferred /u/<handle> URL basis;
+#      resolveHandle() in src/lib/auth.ts falls back to the X handle / user id
+#      if it's unset, so the app still runs, just with less stable handles.
 #   3. Waitlist page → toggle "Enable waitlist" (gates new registration only;
 #      reading the commons stays public). Approve people via the row "…" → Invite.
 # The app side is just `waitlistUrl="/waitlist"` on <ClerkProvider> (layout.tsx)

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -7,7 +7,8 @@ import { AgentManager } from "@/components/AgentManager";
 /**
  * `/agents` — the signed-in user's agent management surface: list their agents
  * with inline edit / token / delete, plus a create form. A top-level page (moved
- * off `/vault`). Signed-out visitors see only a sign-in prompt — no data fetched.
+ * off `/vault`). Signed-out visitors see a sign-in prompt plus a waitlist link
+ * — no data fetched.
  */
 export default async function AgentsPage() {
   const principal = await getPrincipal();

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { SignInButton } from "@clerk/nextjs";
 import { getPrincipal } from "@/lib/auth";
 import { listAgentsForOwner } from "@/lib/agents";
@@ -42,6 +43,13 @@ export default async function AgentsPage() {
           <SignInButton mode="modal">
             <button className="btn primary">Sign in to view your agents</button>
           </SignInButton>
+          <p style={{ marginTop: 14, fontSize: 13, color: "var(--faint)" }}>
+            No account yet?{" "}
+            <Link href="/waitlist" className="underline">
+              Join the waitlist
+            </Link>
+            .
+          </p>
         </section>
       </div>
     );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -79,7 +79,10 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body className="min-h-screen antialiased flex flex-col">
-        <ClerkProvider>
+        {/* `waitlistUrl` makes Clerk's sign-in modal route new sign-ups to our
+            /waitlist page while the app is in waitlist (invite-only) sign-up
+            mode — gating registration only; reading the commons stays public. */}
+        <ClerkProvider waitlistUrl="/waitlist">
           <ClientProviders>
             <EnsureYoyo />
             <SiteChrome nav={<NavHeader />} footer={<Footer />}>

--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -7,8 +7,8 @@ import { VaultManager } from "@/components/VaultManager";
 /**
  * `/vault` — the signed-in user's vault management surface: a list of their
  * named vaults (each a curated reference lens over the commons) with create /
- * rename / delete / view. Agents live on the top-level `/agents`. Signed-out visitors
- * see only a sign-in prompt — no data is fetched or leaked.
+ * rename / delete / view. Agents live on the top-level `/agents`. Signed-out
+ * visitors see a sign-in prompt plus a waitlist link — no data is fetched or leaked.
  */
 export default async function VaultPage() {
   const principal = await getPrincipal();

--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -44,6 +44,13 @@ export default async function VaultPage() {
           <SignInButton mode="modal">
             <button className="btn primary">Sign in to view your vaults</button>
           </SignInButton>
+          <p style={{ marginTop: 14, fontSize: 13, color: "var(--faint)" }}>
+            No account yet?{" "}
+            <Link href="/waitlist" className="underline">
+              Join the waitlist
+            </Link>
+            .
+          </p>
         </section>
       </div>
     );

--- a/src/app/waitlist/[[...waitlist]]/page.tsx
+++ b/src/app/waitlist/[[...waitlist]]/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import { Waitlist } from "@clerk/nextjs";
+
+export const metadata: Metadata = {
+  // The layout title template appends " · yopedia".
+  title: "Join the waitlist",
+};
+
+/**
+ * `/waitlist` — the public landing for new visitors while yopedia is invite-only.
+ *
+ * Registration is gated in Clerk (waitlist sign-up mode, set in the Clerk
+ * dashboard), so a brand-new visitor can't create an account directly: they
+ * leave an email here, and the site owner approves them from the dashboard
+ * (which sends an invitation email to finish sign-up). Reading the commons
+ * stays fully public — this only gates *joining*.
+ *
+ * The optional catch-all segment (`[[...waitlist]]`) lets Clerk's `<Waitlist />`
+ * own any sub-routes of its flow without a 404 (per Clerk's Next.js setup).
+ */
+export default function WaitlistPage() {
+  return (
+    <div className="fade">
+      <section
+        className="shell"
+        style={{ paddingTop: 96, paddingBottom: 96, textAlign: "center" }}
+      >
+        <p className="fmark" style={{ justifyContent: "center" }}>
+          invite only
+        </p>
+        <h1
+          className="display"
+          style={{ fontSize: "clamp(34px,4.6vw,58px)", margin: "16px 0 12px" }}
+        >
+          Join the waitlist
+        </h1>
+        <p
+          style={{
+            color: "var(--ink-2)",
+            fontSize: 18,
+            maxWidth: "46ch",
+            margin: "0 auto 32px",
+            lineHeight: 1.55,
+          }}
+        >
+          yopedia is invite-only for now. Leave your email and we&rsquo;ll let
+          you in as we open up. Browsing the commons stays open to everyone.
+        </p>
+        <div className="flex justify-center">
+          <Waitlist />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/waitlist/[[...waitlist]]/page.tsx
+++ b/src/app/waitlist/[[...waitlist]]/page.tsx
@@ -11,9 +11,9 @@ export const metadata: Metadata = {
  *
  * Registration is gated in Clerk (waitlist sign-up mode, set in the Clerk
  * dashboard), so a brand-new visitor can't create an account directly: they
- * leave an email here, and the site owner approves them from the dashboard
- * (which sends an invitation email to finish sign-up). Reading the commons
- * stays fully public — this only gates *joining*.
+ * leave an email here, then get approved out-of-band in Clerk (the dashboard's
+ * waitlist, which emails an invite to finish sign-up). Reading the commons stays
+ * fully public — this only gates *joining*.
  *
  * The optional catch-all segment (`[[...waitlist]]`) lets Clerk's `<Waitlist />`
  * own any sub-routes of its flow without a 404 (per Clerk's Next.js setup).

--- a/src/components/HomeAsk.tsx
+++ b/src/components/HomeAsk.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useUser, useClerk, SignInButton } from "@clerk/nextjs";
 import { useStreamingQuery } from "@/hooks/useStreamingQuery";
@@ -238,7 +239,11 @@ export function HomeAsk() {
 
       {!isSignedIn && !demo && !demoLoading && !demoError && (
         <p className="mt-2 text-xs text-muted">
-          Try a sample question for a taste — sign in to ask your own.
+          Try a sample question for a taste —{" "}
+          <Link href="/waitlist" className="underline hover:text-foreground">
+            join the waitlist
+          </Link>{" "}
+          to ask your own.
         </p>
       )}
 
@@ -263,13 +268,14 @@ export function HomeAsk() {
             readOnly
           />
           {!demoStreaming && (
-            <button
-              type="button"
-              onClick={() => openSignIn()}
-              className="mt-4 rounded-lg bg-accent px-5 py-2 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-colors"
+            // The demo is the new-visitor funnel; invite-only means the next
+            // step is the waitlist, not a sign-in they can't complete yet.
+            <Link
+              href="/waitlist"
+              className="mt-4 inline-block rounded-lg bg-accent px-5 py-2 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-colors"
             >
-              Sign in to ask your own →
-            </button>
+              Join the waitlist to ask your own →
+            </Link>
           )}
         </div>
       )}

--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -122,14 +122,23 @@ export function NavHeader() {
           <ThemeToggle />
 
           <Show when="signed-out">
-            {/* SSO only: Clerk auto-creates the account on first "Continue with X".
-                Hidden below md — the hamburger menu carries auth on narrow widths. */}
+            {/* Invite-only: new visitors join the waitlist (the primary action);
+                approved/returning members sign in. Clerk's sign-in modal also
+                cross-links to /waitlist via `waitlistUrl`. Hidden below md — the
+                hamburger menu carries auth on narrow widths. */}
+            <Link
+              href="/waitlist"
+              className="btn primary hidden md:inline-flex"
+              style={{ marginLeft: 2 }}
+            >
+              Join waitlist
+            </Link>
             <SignInButton mode="modal">
               <button
-                className="btn primary hidden md:inline-flex"
+                className="btn ghost hidden md:inline-flex"
                 style={{ marginLeft: 2 }}
               >
-                Sign in with X
+                Sign in
               </button>
             </SignInButton>
           </Show>
@@ -245,9 +254,14 @@ export function NavHeader() {
             style={{ paddingInline: 24, paddingBlock: 6 }}
           >
             <Show when="signed-out">
-              <SignInButton mode="modal">
-                <button className="btn primary">Sign in with X</button>
-              </SignInButton>
+              <span className="inline-flex items-center gap-2">
+                <Link href="/waitlist" className="btn primary">
+                  Join waitlist
+                </Link>
+                <SignInButton mode="modal">
+                  <button className="btn ghost">Sign in</button>
+                </SignInButton>
+              </span>
             </Show>
             <Show when="signed-in">
               <span className="inline-flex items-center gap-2">

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -7,7 +7,11 @@ vi.mock("@clerk/nextjs/server", () => ({
   currentUser: vi.fn(),
 }));
 
-import { getServicePrincipal } from "../auth";
+import { getServicePrincipal, getPrincipal } from "../auth";
+import { auth, currentUser } from "@clerk/nextjs/server";
+
+const mockedAuth = vi.mocked(auth);
+const mockedCurrentUser = vi.mocked(currentUser);
 
 const TOKEN = "s3cr3t-service-token-abcdef";
 const HANDLE = "yoyo-bot";
@@ -77,5 +81,39 @@ describe("getServicePrincipal", () => {
   it("does not accept an empty bearer token even if env token is empty", () => {
     process.env.YOPEDIA_SERVICE_TOKEN = "";
     expect(getServicePrincipal(reqWith("Bearer "))).toBeNull();
+  });
+});
+
+describe("getPrincipal", () => {
+  it("returns null when signed out", async () => {
+    mockedAuth.mockResolvedValue({ userId: null } as never);
+    expect(await getPrincipal()).toBeNull();
+  });
+
+  it("uses the Clerk username as the handle (email/waitlist sign-ups)", async () => {
+    mockedAuth.mockResolvedValue({ userId: "user_1" } as never);
+    mockedCurrentUser.mockResolvedValue({
+      username: "jane",
+      externalAccounts: [],
+    } as never);
+    expect(await getPrincipal()).toEqual({ id: "user_1", handle: "jane" });
+  });
+
+  it("falls back to a connected X handle when no username is set (legacy)", async () => {
+    mockedAuth.mockResolvedValue({ userId: "user_2" } as never);
+    mockedCurrentUser.mockResolvedValue({
+      username: null,
+      externalAccounts: [{ provider: "oauth_x", username: "xjane" }],
+    } as never);
+    expect(await getPrincipal()).toEqual({ id: "user_2", handle: "xjane" });
+  });
+
+  it("falls back to the user id when neither a username nor X handle exists", async () => {
+    mockedAuth.mockResolvedValue({ userId: "user_3" } as never);
+    mockedCurrentUser.mockResolvedValue({
+      username: null,
+      externalAccounts: [],
+    } as never);
+    expect(await getPrincipal()).toEqual({ id: "user_3", handle: "user_3" });
   });
 });

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -116,4 +116,60 @@ describe("getPrincipal", () => {
     } as never);
     expect(await getPrincipal()).toEqual({ id: "user_3", handle: "user_3" });
   });
+
+  it("prefers the username even when an X account is also connected", async () => {
+    // The whole point of requiring a username: it's the stable /u/<handle>
+    // basis and must win over a connected X handle (guards a reordering).
+    mockedAuth.mockResolvedValue({ userId: "user_4" } as never);
+    mockedCurrentUser.mockResolvedValue({
+      username: "jane",
+      externalAccounts: [{ provider: "oauth_x", username: "xjane" }],
+    } as never);
+    expect(await getPrincipal()).toEqual({ id: "user_4", handle: "jane" });
+  });
+
+  it("matches an oauth_twitter provider, not just oauth_x", async () => {
+    mockedAuth.mockResolvedValue({ userId: "user_5" } as never);
+    mockedCurrentUser.mockResolvedValue({
+      username: null,
+      externalAccounts: [{ provider: "oauth_twitter", username: "tjane" }],
+    } as never);
+    expect(await getPrincipal()).toEqual({ id: "user_5", handle: "tjane" });
+  });
+
+  it("does not treat a non-X provider's handle as the user handle", async () => {
+    // The provider regex is anchored so e.g. Google never leaks its handle.
+    mockedAuth.mockResolvedValue({ userId: "user_6" } as never);
+    mockedCurrentUser.mockResolvedValue({
+      username: null,
+      externalAccounts: [{ provider: "oauth_google", username: "gjane" }],
+    } as never);
+    expect(await getPrincipal()).toEqual({ id: "user_6", handle: "user_6" });
+  });
+
+  it("picks the X account among several external accounts", async () => {
+    mockedAuth.mockResolvedValue({ userId: "user_7" } as never);
+    mockedCurrentUser.mockResolvedValue({
+      username: null,
+      externalAccounts: [
+        { provider: "oauth_google", username: "gjane" },
+        { provider: "oauth_x", username: "xjane" },
+      ],
+    } as never);
+    expect(await getPrincipal()).toEqual({ id: "user_7", handle: "xjane" });
+  });
+
+  it("falls back to the user id when a connected X account has no username", async () => {
+    mockedAuth.mockResolvedValue({ userId: "user_8" } as never);
+    mockedCurrentUser.mockResolvedValue({
+      username: null,
+      externalAccounts: [{ provider: "oauth_x", username: null }],
+    } as never);
+    expect(await getPrincipal()).toEqual({ id: "user_8", handle: "user_8" });
+  });
+
+  it("returns null (fails closed) when Clerk throws outside a request context", async () => {
+    mockedAuth.mockRejectedValue(new Error("no request context"));
+    expect(await getPrincipal()).toBeNull();
+  });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,6 +12,7 @@
 // requirement is relaxed).
 
 import { auth, currentUser } from "@clerk/nextjs/server";
+import { logger } from "./logger";
 
 export interface Principal {
   /** Stable Clerk user id (never changes). */
@@ -58,7 +59,19 @@ export async function getPrincipal(): Promise<Principal | null> {
     const { userId } = await auth();
     if (!userId) return null;
     const user = await currentUser();
-    return { id: userId, handle: resolveHandle(user) ?? userId };
+    const handle = resolveHandle(user);
+    if (!handle) {
+      // A signed-in user with NO username and NO linked X handle falls back to
+      // the raw Clerk id as their handle (ugly /u/<id> URLs + odd attribution).
+      // This should never happen under correct config — it signals the Clerk
+      // "require username at sign-up" setting is off (this flow depends on it).
+      // Don't fail silently: surface it so the misconfig is visible, not buried.
+      logger.warn(
+        "auth",
+        `user ${userId} resolved to no handle (no username, no linked X account) — using the user id; is Clerk's "require username" setting on?`,
+      );
+    }
+    return { id: userId, handle: handle ?? userId };
   } catch {
     // No Clerk request context (e.g. unit tests, non-request scope) → treat as
     // anonymous. Fail closed: callers get least privilege, never an exception.

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,7 +5,9 @@
 // The unauthenticated-write hole is closed in middleware (any /api write needs
 // a session). This module resolves *who* the signed-in user is, for write
 // attribution (`owner`/`authors`) — the route never trusts a client-supplied
-// author. SSO is Twitter/X, so the principal handle is the Twitter handle.
+// author. The principal handle is the Clerk username (required at sign-up, so
+// it's the stable basis for /u/<handle> URLs); for legacy X-only accounts that
+// never set a username it falls back to the connected Twitter/X handle.
 
 import { auth, currentUser } from "@clerk/nextjs/server";
 
@@ -22,7 +24,12 @@ interface ExternalAccountLike {
   username?: string | null;
 }
 
-/** Resolve the Twitter/X handle from a Clerk user, or null. */
+/**
+ * Resolve a user's handle, or null. Prefers the Clerk `username` (required at
+ * sign-up, so present for everyone who joined via the waitlist/email flow);
+ * falls back to a connected Twitter/X account's handle for legacy X-only
+ * accounts that predate the username requirement.
+ */
 function resolveHandle(user: {
   username?: string | null;
   externalAccounts?: ExternalAccountLike[];

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,16 +5,19 @@
 // The unauthenticated-write hole is closed in middleware (any /api write needs
 // a session). This module resolves *who* the signed-in user is, for write
 // attribution (`owner`/`authors`) — the route never trusts a client-supplied
-// author. The principal handle is the Clerk username (required at sign-up, so
-// it's the stable basis for /u/<handle> URLs); for legacy X-only accounts that
-// never set a username it falls back to the connected Twitter/X handle.
+// author. The principal handle is the Clerk username when set (the email/waitlist
+// sign-up flow is configured to require one, so it's the stable basis for
+// /u/<handle> URLs); it falls back to a connected Twitter/X handle, then the
+// user id, for accounts that lack one (legacy X-only, or if the dashboard
+// requirement is relaxed).
 
 import { auth, currentUser } from "@clerk/nextjs/server";
 
 export interface Principal {
   /** Stable Clerk user id (never changes). */
   id: string;
-  /** Twitter/X handle (falls back to Clerk username, then the user id). */
+  /** URL/display handle: the Clerk username when set, else a connected
+   *  Twitter/X handle, else the user id. */
   handle: string;
 }
 
@@ -25,10 +28,13 @@ interface ExternalAccountLike {
 }
 
 /**
- * Resolve a user's handle, or null. Prefers the Clerk `username` (required at
- * sign-up, so present for everyone who joined via the waitlist/email flow);
- * falls back to a connected Twitter/X account's handle for legacy X-only
- * accounts that predate the username requirement.
+ * Resolve a user's handle, or null. Prefers the Clerk `username` (the
+ * email/waitlist sign-up flow is configured to require one, so it's the stable
+ * `/u/<handle>` basis); falls back to a connected Twitter/X account's handle —
+ * e.g. for legacy X-only accounts that predate the username requirement, or if
+ * that dashboard requirement is ever relaxed — and ultimately to the user id in
+ * `getPrincipal`. The fallbacks are why this stays defensive rather than
+ * assuming a username is always present.
  */
 function resolveHandle(user: {
   username?: string | null;


### PR DESCRIPTION
## What

Makes new-user **registration invite-only** via Clerk's native **waitlist** sign-up mode, while keeping the commons **fully public to read**. You asked to limit who can register and add a waitlist — Clerk supports this natively, so the gating itself is a Clerk-dashboard toggle; this PR is the app-side wiring.

## Split of work

**Clerk Dashboard (yours — documented in `.env.example`):**
1. Enable **Email** auth (needed for waitlist invitation emails).
2. **Require Username** at sign-up (it's the basis for `/u/<handle>` URLs).
3. **Waitlist** page → toggle **Enable waitlist**. Approve people via the row "…" → **Invite**.

**Code (this PR):**
- `waitlistUrl="/waitlist"` on `<ClerkProvider>` → Clerk's sign-in modal routes new sign-ups to our waitlist.
- New `/waitlist` page (`app/waitlist/[[...waitlist]]/page.tsx`) rendering `<Waitlist />` in yopedia chrome.
- Funnel UI: **Join waitlist** (primary) + **Sign in** (ghost) in the nav; a waitlist link on the `/vault` and `/agents` signed-out gates; a waitlist CTA in the homepage demo. Old X-only "Sign in with X" buttons relabeled to "Sign in" (email is now primary).
- `auth.ts`: principal handle now prefers the Clerk **username** (required at sign-up), falling back to a connected **X handle** for legacy X-only accounts. Logic unchanged; docs + `getPrincipal` tests added.

## Scope / blast radius

**No middleware or read-path changes.** Existing signed-in users, the `/api` write-gate, and public `/wiki/<slug>` rendering are untouched — Clerk intercepts new registration before a user is ever created. The `@yoyoevolve` X-mention ingest loop keeps working for users who connect X (accepted tradeoff of going email-centric).

## Verification

- `pnpm lint` — 0 errors · `pnpm build` + `pnpm build:cloudflare` — clean · full `vitest` — **3131 passed** (`/waitlist` route confirmed in the build).
- Functional check (post-merge, needs the dashboard toggles): enable waitlist → a new visitor hits `/waitlist`, joins; owner Invites them → they finish sign-up; existing users still sign in normally; public pages still read without auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)