### PR TITLE
yoyo: center HTML artifacts in a shared-measure column (align prose + illustrations)

### DIFF
--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -156,8 +156,23 @@ describe("composeSrcDoc", () => {
     // edges match the full-width yoyo illustrations.
     expect(out).toContain("--measure:46rem");
     expect(out).toContain("body{max-width:var(--measure);margin-inline:auto}");
-    // The illustration figure is bound to the SAME measure and centered.
+    // All three consumers share the token: the body column, the wrapper, and
+    // the illustration figure — so they align whether or not content is wrapped.
+    expect(out).toContain(".doc,main,article{max-width:var(--measure)");
     expect(out).toContain("figure.yoyo-illustration{max-width:var(--measure)");
+  });
+
+  it("injects the body-column cap BEFORE the model's own <style> so the model can override it", () => {
+    const out = composeSrcDoc(
+      "<html><head><style>body{max-width:1200px}</style></head><body><p>x</p></body></html>",
+    );
+    // CSS is last-wins on source order (both are bare `body{}` selectors, no
+    // !important), so our injected cap MUST precede the model's style for the
+    // model to win. Guards against a refactor that appends head bits after the
+    // model markup and silently overrides every model/app layout.
+    expect(
+      out.indexOf("body{max-width:var(--measure);margin-inline:auto}"),
+    ).toBeLessThan(out.indexOf("body{max-width:1200px}"));
   });
 
   it("leaves app-style (viewport-unit) layouts full-bleed — no body column cap", () => {

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -148,6 +148,26 @@ describe("composeSrcDoc", () => {
     // The delegated tab controller ships so `.tabs` markup works.
     expect(out).toContain("data-tab");
   });
+
+  it("centers document-style content in a column of the shared --measure", () => {
+    const out = composeSrcDoc("<p>a blog-post style answer</p>");
+    // The shared measure token is defined, and the body is capped + centered to
+    // it — so even un-wrapped content (no <main>/.doc) sits in a column whose
+    // edges match the full-width yoyo illustrations.
+    expect(out).toContain("--measure:46rem");
+    expect(out).toContain("body{max-width:var(--measure);margin-inline:auto}");
+    // The illustration figure is bound to the SAME measure and centered.
+    expect(out).toContain("figure.yoyo-illustration{max-width:var(--measure)");
+  });
+
+  it("leaves app-style (viewport-unit) layouts full-bleed — no body column cap", () => {
+    const out = composeSrcDoc("<div style='height:100vh'>full-screen app</div>");
+    // App-style docs define their own full-screen width; don't impose a column.
+    expect(out).not.toContain("body{max-width:var(--measure)");
+    // The shared token + illustration cap still ship (harmless, and bound any
+    // illustration an app-style doc happens to use).
+    expect(out).toContain("--measure:46rem");
+  });
 });
 
 describe("Chart.js injection", () => {

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -57,14 +57,20 @@ const SANDBOX_CSP =
  * injected after this and overrides it freely; the predefined component classes
  * (`.lead`, `.callout`, `.grid`/`.card`, `.stat`, `.badge`, `.tabs`, `figure`)
  * are documented in the HTML format prompt so answers can opt into them.
+ *
+ * Content width is one shared token, `--measure`: the `.doc`/`main`/`article`
+ * wrappers AND the body column (centered for document-style docs in
+ * `sandboxHead`) AND the `.yoyo-illustration` figure all use it, so prose and the
+ * full-width hand-drawn illustrations land on the SAME centered edges regardless
+ * of whether the model wrapped its content.
  */
 const BASE_STYLE = `<style>
-:root{color-scheme:light dark;--paper:#fbfaf6;--paper-2:#f4f1e9;--ink:#1b1a16;--ink-2:#423f38;--muted:#756f62;--rule:#e2ddd0;--accent:#4d6bfe;--accent-soft:#e7ebff;--radius:12px;--head:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,ui-serif,serif}
+:root{color-scheme:light dark;--paper:#fbfaf6;--paper-2:#f4f1e9;--ink:#1b1a16;--ink-2:#423f38;--muted:#756f62;--rule:#e2ddd0;--accent:#4d6bfe;--accent-soft:#e7ebff;--radius:12px;--measure:46rem;--head:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,ui-serif,serif}
 @media (prefers-color-scheme:dark){:root{--paper:#14130f;--paper-2:#1c1b16;--ink:#efebdf;--ink-2:#c7c2b4;--muted:#948e7f;--rule:#2b281f;--accent:#90a4ff;--accent-soft:#20233a}}
 *{box-sizing:border-box}
 html{-webkit-text-size-adjust:100%}
 body{margin:0;background:var(--paper);color:var(--ink);font:17px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;padding:clamp(20px,5vw,56px) clamp(18px,5vw,28px)}
-.doc,main,article{max-width:46rem;margin:0 auto}
+.doc,main,article{max-width:var(--measure);margin:0 auto}
 h1,h2,h3,h4{font-family:var(--head);line-height:1.2;font-weight:600;margin:1.8em 0 .5em}
 h1{font-size:clamp(2rem,5vw,2.7rem);margin-top:0;letter-spacing:-.01em}
 h2{font-size:1.6rem;padding-top:.5em;border-top:1px solid var(--rule)}
@@ -92,7 +98,7 @@ tr:hover td{background:var(--paper-2)}
 .stat .num{font-family:var(--head);font-size:2.1rem;font-weight:700;color:var(--ink);line-height:1}
 .stat .label{font-size:.8rem;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)}
 .badge{display:inline-block;font-size:.78rem;font-weight:600;padding:2px 9px;border-radius:999px;background:var(--accent-soft);color:var(--accent);border:1px solid var(--rule)}
-figure{margin:1.6em 0}figure>figcaption{font-size:.85rem;color:var(--muted);margin-top:.5em;text-align:center}
+figure{margin:1.6em 0}figure.yoyo-illustration{max-width:var(--measure);margin-left:auto;margin-right:auto;text-align:center}figure>figcaption{font-size:.85rem;color:var(--muted);margin-top:.5em;text-align:center}
 .chart{position:relative;height:340px}
 details{border:1px solid var(--rule);border-radius:var(--radius);padding:0 16px;margin:1em 0;background:var(--paper-2)}
 details[open]{padding-bottom:8px}
@@ -177,10 +183,20 @@ function sandboxHead(
     ? `<style>html{scrollbar-width:none;-ms-overflow-style:none}` +
       `html::-webkit-scrollbar,body::-webkit-scrollbar{width:0;height:0;display:none}</style>`
     : "";
+  // Document-style artifacts (blog-post HTML, no viewport/app layout) are
+  // centered in a column of the shared `--measure`, so prose and the full-width
+  // yoyo illustrations land on the SAME aligned edges instead of sprawling
+  // edge-to-edge on a wide viewport (the iframe is full-bleed). This applies
+  // even when the model didn't wrap its content in `<main>`/`.doc`. App-style
+  // (100vh) layouts manage their own full-bleed width, so they're left alone.
+  const centerColumn = usesViewportUnits(html)
+    ? ""
+    : `<style>html{background:var(--paper)}body{max-width:var(--measure);margin-inline:auto}</style>`;
   return (
     `<meta http-equiv="Content-Security-Policy" content="${SANDBOX_CSP}">` +
     `<base target="_blank">` +
     BASE_STYLE +
+    centerColumn +
     hideBar +
     chartLib +
     BASE_SCRIPT

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -59,10 +59,12 @@ const SANDBOX_CSP =
  * are documented in the HTML format prompt so answers can opt into them.
  *
  * Content width is one shared token, `--measure`: the `.doc`/`main`/`article`
- * wrappers AND the body column (centered for document-style docs in
- * `sandboxHead`) AND the `.yoyo-illustration` figure all use it, so prose and the
- * full-width hand-drawn illustrations land on the SAME centered edges regardless
- * of whether the model wrapped its content.
+ * wrappers, the body column (centered for document-style docs in `sandboxHead`),
+ * and the `.yoyo-illustration` figure all use it, so prose and the measure-width
+ * hand-drawn illustrations land on the SAME centered edges. For document-style
+ * docs the body column supplies that alignment even when the model didn't wrap
+ * its content; app-style (viewport-unit) layouts are left full-bleed and manage
+ * their own width.
  */
 const BASE_STYLE = `<style>
 :root{color-scheme:light dark;--paper:#fbfaf6;--paper-2:#f4f1e9;--ink:#1b1a16;--ink-2:#423f38;--muted:#756f62;--rule:#e2ddd0;--accent:#4d6bfe;--accent-soft:#e7ebff;--radius:12px;--measure:46rem;--head:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,ui-serif,serif}
@@ -184,11 +186,13 @@ function sandboxHead(
       `html::-webkit-scrollbar,body::-webkit-scrollbar{width:0;height:0;display:none}</style>`
     : "";
   // Document-style artifacts (blog-post HTML, no viewport/app layout) are
-  // centered in a column of the shared `--measure`, so prose and the full-width
-  // yoyo illustrations land on the SAME aligned edges instead of sprawling
-  // edge-to-edge on a wide viewport (the iframe is full-bleed). This applies
-  // even when the model didn't wrap its content in `<main>`/`.doc`. App-style
-  // (100vh) layouts manage their own full-bleed width, so they're left alone.
+  // centered in a column of the shared `--measure`, so prose and the
+  // measure-width yoyo illustrations land on the SAME aligned edges instead of
+  // sprawling edge-to-edge on a wide viewport (the iframe is full-bleed). This
+  // applies even when the model didn't wrap its content in `<main>`/`.doc`. We
+  // also paint `html` with `--paper` so the gutters beside the narrowed body
+  // column show the page background, not the bare iframe. App-style (100vh)
+  // layouts manage their own full-bleed width, so they're left alone.
   const centerColumn = usesViewportUnits(html)
     ? ""
     : `<style>html{background:var(--paper)}body{max-width:var(--measure);margin-inline:auto}</style>`;


### PR DESCRIPTION
## What

On the share view, a `type:html` artifact renders **full-bleed** in the sandboxed iframe with **no content max-width** — so on a wide viewport the prose runs edge-to-edge while the 16:9 yoyo illustrations (`max-width:100%`) render at a different width, leaving them misaligned and the page off-center.

Reported on `…/share/yuanhao/about-startup-billionaire-math-解释给五岁小朋友听`.

## How

Give document-style artifacts one **centered content column** sized by a single token, `--measure` (**46rem** — the exact width the `.doc`/`main`/`article` wrappers already use). Since the baked illustration is `<img style="max-width:100%">`, capping the body to `--measure` makes prose and illustration share **identical width + centered edges by construction** — the requested "content ≤ illustration" becomes equality (aligned edges).

Using the *existing* wrapper measure (not a new number) is deliberate: a different width would re-misalign a doc that mixes a wrapped `<main>` (46rem) with a body-level `<figure>`.

- `--measure:46rem` on `:root`; `.doc/main/article` and the `.yoyo-illustration` figure are both bound to it (figure also centered, so even a stray full-bleed illustration aligns).
- `sandboxHead` centers the body at `--measure` for **document-style** docs only; **app-style** (100vh, via the existing `usesViewportUnits` heuristic) keeps its full-bleed width. The model's own `<style>` is injected *after*, so it can still override.

## Why it fixes the existing page

`BASE_STYLE`/`sandboxHead` are recomposed by `composeSrcDoc` on **every render**, so this CSS-only change applies to already-shared pages **without regenerating** them. Well-structured docs don't regress (their `<main>` was already 46rem).

## Assumption to sanity-check on deploy

The "document vs app-style" split reuses the existing `usesViewportUnits` heuristic. If a doc happens to use a viewport unit (e.g. `min-height:100dvh` for footer-pinning) it's treated as app-style and stays full-bleed — consistent with how the iframe height already behaves.

## Verification

- New tests: document-style gets the `body{max-width:var(--measure)}` column; app-style does not (token + illustration cap still ship).
- `pnpm lint` 0 errors · `pnpm build` + `pnpm build:cloudflare` clean · full suite **3148 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)