### PR TITLE
yoyo: fix HTML artifacts misclassified app-style by inlined illustrations (+ wider column)

### DIFF
--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -154,7 +154,7 @@ describe("composeSrcDoc", () => {
     // The shared measure token is defined, and the body is capped + centered to
     // it — so even un-wrapped content (no <main>/.doc) sits in a column whose
     // edges match the full-width yoyo illustrations.
-    expect(out).toContain("--measure:46rem");
+    expect(out).toContain("--measure:50rem");
     expect(out).toContain("body{max-width:var(--measure);margin-inline:auto}");
     // All three consumers share the token: the body column, the wrapper, and
     // the illustration figure — so they align whether or not content is wrapped.
@@ -181,7 +181,17 @@ describe("composeSrcDoc", () => {
     expect(out).not.toContain("body{max-width:var(--measure)");
     // The shared token + illustration cap still ship (harmless, and bound any
     // illustration an app-style doc happens to use).
-    expect(out).toContain("--measure:46rem");
+    expect(out).toContain("--measure:50rem");
+  });
+
+  it("still centers a document that inlines base64 illustrations (data: URI isn't app-style)", () => {
+    // Regression: a baked illustration's base64 payload contains vh-like runs
+    // that must NOT flip the doc to app-style and skip the centered column.
+    const out = composeSrcDoc(
+      '<main><p>article</p><figure class="yoyo-illustration">' +
+        '<img src="data:image/jpeg;base64,/9j/4AAQ/100vh/SkZJRg=="></figure></main>',
+    );
+    expect(out).toContain("body{max-width:var(--measure);margin-inline:auto}");
   });
 });
 
@@ -190,6 +200,22 @@ describe("Chart.js injection", () => {
     expect(usesViewportUnits("<div style='height:100vh'></div>")).toBe(true);
     expect(usesViewportUnits("<style>.h{min-height:100dvh}</style>")).toBe(true);
     expect(usesViewportUnits("<p>just prose, padding: 12px</p>")).toBe(false);
+  });
+
+  it("usesViewportUnits ignores vh-like runs inside inlined data: URIs", () => {
+    // A baked illustration's base64 contains vh-like substrings at /,+ bounds
+    // (e.g. real payloads like "+C7vh7U/Gn"); these must NOT read as app-style.
+    expect(
+      usesViewportUnits(
+        '<img src="data:image/jpeg;base64,/9j/4AAQ/100vh/SkZJRg==">',
+      ),
+    ).toBe(false);
+    // …but a genuine viewport unit in CSS still counts, even alongside an image.
+    expect(
+      usesViewportUnits(
+        '<style>.hero{height:100vh}</style><img src="data:image/png;base64,iVBOR100vh">',
+      ),
+    ).toBe(true);
   });
 
   it("drops cross-reference markdown leaked after </html>", () => {

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -203,11 +203,17 @@ describe("Chart.js injection", () => {
   });
 
   it("usesViewportUnits ignores vh-like runs inside inlined data: URIs", () => {
-    // A baked illustration's base64 contains vh-like substrings at /,+ bounds
-    // (e.g. real payloads like "+C7vh7U/Gn"); these must NOT read as app-style.
+    // A baked illustration's base64 contains digit-led vh runs at /,+ bounds
+    // (e.g. the real payload fragment "/7VH/"); those must NOT read as app-style.
     expect(
       usesViewportUnits(
         '<img src="data:image/jpeg;base64,/9j/4AAQ/100vh/SkZJRg==">',
+      ),
+    ).toBe(false);
+    // The url(data:…) background form is stripped at its ")" terminator too.
+    expect(
+      usesViewportUnits(
+        '<div style="background:url(data:image/svg+xml;base64,Zm9v/100vh)"></div>',
       ),
     ).toBe(false);
     // …but a genuine viewport unit in CSS still counts, even alongside an image.

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -67,7 +67,7 @@ const SANDBOX_CSP =
  * their own width.
  */
 const BASE_STYLE = `<style>
-:root{color-scheme:light dark;--paper:#fbfaf6;--paper-2:#f4f1e9;--ink:#1b1a16;--ink-2:#423f38;--muted:#756f62;--rule:#e2ddd0;--accent:#4d6bfe;--accent-soft:#e7ebff;--radius:12px;--measure:46rem;--head:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,ui-serif,serif}
+:root{color-scheme:light dark;--paper:#fbfaf6;--paper-2:#f4f1e9;--ink:#1b1a16;--ink-2:#423f38;--muted:#756f62;--rule:#e2ddd0;--accent:#4d6bfe;--accent-soft:#e7ebff;--radius:12px;--measure:50rem;--head:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,ui-serif,serif}
 @media (prefers-color-scheme:dark){:root{--paper:#14130f;--paper-2:#1c1b16;--ink:#efebdf;--ink-2:#c7c2b4;--muted:#948e7f;--rule:#2b281f;--accent:#90a4ff;--accent-soft:#20233a}}
 *{box-sizing:border-box}
 html{-webkit-text-size-adjust:100%}
@@ -156,10 +156,18 @@ export function usesChartLib(html: string): boolean {
  * Does the artifact lay itself out against the viewport (`100vh`/`100dvh`/etc.)?
  * Such "app-style" documents define their own full-screen scroll viewport, so an
  * auto-sizing iframe feedback-loops them to absurd heights. We instead give them
- * a fixed-height frame and let them scroll inside it (see `HtmlPreview`).
+ * a fixed-height frame and let them scroll inside it (see `HtmlPreview`), and we
+ * skip the centered content column (see `sandboxHead`).
+ *
+ * Inlined `data:` URIs are stripped FIRST: a baked yoyo illustration is a large
+ * base64 image (`<img src="data:image/jpeg;base64,…">`) whose payload
+ * coincidentally contains `<digits>vh`-style runs at `/`/`+` boundaries, which
+ * would false-positive this check and wrongly flag a normal document as
+ * app-style. Real viewport units live in CSS/inline styles, never in image data.
  */
 export function usesViewportUnits(html: string): boolean {
-  return /\b\d+(?:\.\d+)?(?:vh|dvh|svh|lvh)\b/i.test(html ?? "");
+  const code = (html ?? "").replace(/\bdata:[^"')\s]+/gi, "");
+  return /\b\d+(?:\.\d+)?(?:vh|dvh|svh|lvh)\b/i.test(code);
 }
 
 /**


### PR DESCRIPTION
## The real bug behind "not changed"

PR #623 added a centered column for `type:html` artifacts but gated it on `usesViewportUnits()` (app-style docs stay full-bleed). That gate **false-positives on inlined illustrations**: a baked yoyo illustration is a large `<img src="data:image/jpeg;base64,…">`, and the base64 payload coincidentally contains `\d+vh`-style runs at `/`/`+` boundaries (real example from the page: `/7VH/`). So **any illustration-bearing document** was misclassified app-style → the centered column was skipped.

Verified live on `…/share/yuanhao/about-startup-billionaire-math-…`: the model's own CSS has **zero** viewport units; the only `vh` matches in `page.body` are inside the 3 base64 illustrations. That's why prose/stats/chart ran browser-wide while the (correctly capped) illustration sat alone in a narrow column.

Same false positive also affects the **inline** view: such a doc was wrongly given a fixed 80vh frame instead of natural auto-height.

## Fix

- **`usesViewportUnits` strips `data:` URIs** before the viewport-unit test, so only real CSS/inline-style units count. General correctness fix for every illustrated artifact.
- **Design:** bump the shared `--measure` **46rem → 50rem (800px)** — a deliberate, generous centered column for a *visual* blog post (illustration + 3-up stat grid + chart + prose), where the tight prose measure felt cramped. One token still drives the body column, the `.doc/main/article` wrappers, and the `.yoyo-illustration` figure, so everything stays aligned by construction.

Both are render-time (`composeSrcDoc`), so existing shared pages pick this up **without regeneration**.

## Verification

- New tests: `usesViewportUnits` ignores vh-runs inside `data:` URIs but still detects a genuine `100vh` in CSS; and an illustration-bearing doc now gets the `body{max-width:var(--measure)}` column.
- `pnpm lint` 0 errors · `pnpm build` + `pnpm build:cloudflare` clean · full suite **3151 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)