### PR TITLE
yoyo: feature personal artifacts on the homepage (below trail + contributors)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,11 @@ import Link from "next/link";
 import { OnboardingWizard } from "@/components/OnboardingWizard";
 import { HomeAsk } from "@/components/HomeAsk";
 import { Trail } from "@/components/Trail";
+import { FeaturedArtifacts } from "@/components/FeaturedArtifacts";
 import { Avatar, Mark } from "@/components/folio/primitives";
 import { listCommonsPages } from "@/lib/commons";
+import { listWikiPages } from "@/lib/wiki";
+import { selectFeaturedArtifacts } from "@/lib/page-types";
 import { listContributors } from "@/lib/contributors";
 import { getContributorIndex } from "@/lib/contributor-index";
 import { getTrail } from "@/lib/trail";
@@ -29,10 +32,13 @@ export default async function Home() {
   // init on cold starts, and makes listContributors/getTrail take their O(1)
   // anonymous index fast-path for EVERY visitor (a signed-in principal would
   // force the slow per-page scan here).
-  const [commonsPages, contributors, trail] = await Promise.all([
+  const [commonsPages, allPages, contributors, trail] = await Promise.all([
     // Read the public commons from the commons index (falls back to deriving
     // the public set when the index is empty).
     listCommonsPages(),
+    // All pages (incl. artifacts, which the commons excludes) for the featured
+    // gallery — O(1) via the page index, same anonymous fast-path.
+    listWikiPages(),
     listContributors(null),
     getTrail(10, null),
   ]);
@@ -40,6 +46,12 @@ export default async function Home() {
   // listCommonsPages already excludes private + agent-scoped pages.
   const pages = commonsPages;
   const pageCount = pages.length;
+
+  // Featured artifacts: recent PUBLIC html/slides pages — the visual, shareable
+  // outputs people build from the commons. Artifacts live outside the commons
+  // (owner-scoped), so we read them from the full page list. The helper keeps
+  // ONLY non-private artifacts (this homepage renders anonymously and is cached).
+  const artifacts = selectFeaturedArtifacts(allPages);
   const sourceCount = pages.reduce((n, p) => n + (p.sourceCount ?? 0), 0);
   const topContributors = contributors.slice(0, 5);
 
@@ -293,6 +305,31 @@ export default async function Home() {
               </div>
             </aside>
           </section>
+
+          {/* Featured artifacts — the visual, shareable pages people render from
+              the commons. Hidden when there are none yet. */}
+          {artifacts.length > 0 && (
+            <section className="shell" style={{ marginTop: 96, marginBottom: 40 }}>
+              <div style={{ marginBottom: 20 }}>
+                <p className="fmark" style={{ marginBottom: 8 }}>
+                  artifacts
+                </p>
+                <p
+                  style={{
+                    margin: 0,
+                    fontSize: 14,
+                    color: "var(--muted)",
+                    maxWidth: "58ch",
+                    lineHeight: 1.55,
+                  }}
+                >
+                  Visual pages — explainers, decks, essays — rendered from a
+                  question and shared.
+                </p>
+              </div>
+              <FeaturedArtifacts pages={artifacts} />
+            </section>
+          )}
         </>
       )}
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { Avatar, Mark } from "@/components/folio/primitives";
 import { listCommonsPages } from "@/lib/commons";
 import { listWikiPages } from "@/lib/wiki";
 import { selectFeaturedArtifacts } from "@/lib/page-types";
+import { logger } from "@/lib/logger";
 import { listContributors } from "@/lib/contributors";
 import { getContributorIndex } from "@/lib/contributor-index";
 import { getTrail } from "@/lib/trail";
@@ -37,8 +38,14 @@ export default async function Home() {
     // the public set when the index is empty).
     listCommonsPages(),
     // All pages (incl. artifacts, which the commons excludes) for the featured
-    // gallery — O(1) via the page index, same anonymous fast-path.
-    listWikiPages(),
+    // gallery — O(1) via the page index; returns ALL pages (no principal),
+    // privacy is filtered below in selectFeaturedArtifacts. The gallery is a
+    // non-essential enhancement (hidden when empty), so a read failure here
+    // degrades to "no gallery" rather than 500ing the whole homepage.
+    listWikiPages().catch((err) => {
+      logger.error("home", "featured-artifacts list failed; hiding gallery", err);
+      return [];
+    }),
     listContributors(null),
     getTrail(10, null),
   ]);

--- a/src/components/FeaturedArtifacts.tsx
+++ b/src/components/FeaturedArtifacts.tsx
@@ -6,15 +6,15 @@ import { isAgentHandle } from "@/lib/agent-handle";
 import { Avatar, Mark } from "@/components/folio/primitives";
 
 /**
- * Homepage gallery of recent PUBLIC artifacts — the rendered, shareable pages
- * (`type:"html"`/`"slides"`) people build from the commons. Boxed Folio cards in
- * a responsive grid: the same card language as the profile artifacts
- * ({@link "./ProfileBlogIndex"}), but with owner attribution (the homepage mixes
+ * Homepage gallery of recent PUBLIC, human-made artifacts — the rendered,
+ * shareable pages (`type:"html"`/`"slides"`) people build from the commons.
+ * Boxed Folio cards in a responsive grid: the same card language as the profile
+ * artifacts (`ProfileBlogIndex`), but with owner attribution (the homepage mixes
  * authors) and a correct HTML/SLIDES badge.
  *
- * Presentational only. The homepage selects + supplies the pages and is
- * responsible for the public-only filter — a private artifact must never reach
- * this anonymous, cacheable surface.
+ * Presentational only — it renders whatever pages it's given. The homepage's
+ * `selectFeaturedArtifacts` does the public-only + human-made selection, so a
+ * private artifact never reaches this anonymous, cacheable surface.
  */
 function ArtifactCard({ page }: { page: IndexEntry }) {
   const rel = page.updated ? formatRelativeTime(page.updated) : null;

--- a/src/components/FeaturedArtifacts.tsx
+++ b/src/components/FeaturedArtifacts.tsx
@@ -1,0 +1,127 @@
+import Link from "next/link";
+import type { IndexEntry } from "@/lib/types";
+import { formatRelativeTime } from "@/lib/format";
+import { wikiUrlFor } from "@/lib/share-url";
+import { isAgentHandle } from "@/lib/agent-handle";
+import { Avatar, Mark } from "@/components/folio/primitives";
+
+/**
+ * Homepage gallery of recent PUBLIC artifacts — the rendered, shareable pages
+ * (`type:"html"`/`"slides"`) people build from the commons. Boxed Folio cards in
+ * a responsive grid: the same card language as the profile artifacts
+ * ({@link "./ProfileBlogIndex"}), but with owner attribution (the homepage mixes
+ * authors) and a correct HTML/SLIDES badge.
+ *
+ * Presentational only. The homepage selects + supplies the pages and is
+ * responsible for the public-only filter — a private artifact must never reach
+ * this anonymous, cacheable surface.
+ */
+function ArtifactCard({ page }: { page: IndexEntry }) {
+  const rel = page.updated ? formatRelativeTime(page.updated) : null;
+  // Hide the legacy/system placeholder owner; show real humans + agents.
+  const owner = page.owner && page.owner !== "system" ? page.owner : null;
+  const agent = owner ? isAgentHandle(owner) : false;
+  const kind = page.type === "slides" ? "Slides" : "HTML";
+
+  return (
+    <Link
+      href={wikiUrlFor(page.slug, page)}
+      className="stack group rounded-[14px] border border-[color:var(--rule)] hover:border-accent/40 transition-colors"
+      style={{
+        gap: 9,
+        textDecoration: "none",
+        background: "var(--paper)",
+        padding: "16px 18px 18px",
+      }}
+    >
+      <span
+        className="receipt"
+        style={{
+          alignSelf: "flex-start",
+          fontSize: 9.5,
+          letterSpacing: ".12em",
+          textTransform: "uppercase",
+          color: "var(--accent)",
+          background: "var(--accent-soft)",
+          border: "1px solid var(--rule)",
+          borderRadius: 4,
+          padding: "2px 7px",
+        }}
+      >
+        {kind}
+      </span>
+      <h3
+        className="group-hover:text-accent transition-colors"
+        style={{
+          margin: 0,
+          fontSize: 18,
+          fontWeight: 600,
+          letterSpacing: "-.01em",
+          lineHeight: 1.25,
+          color: "var(--ink)",
+        }}
+      >
+        {page.title}
+      </h3>
+      {page.summary && (
+        <p
+          style={{
+            margin: 0,
+            fontSize: 13.5,
+            color: "var(--muted)",
+            lineHeight: 1.55,
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+          }}
+        >
+          {page.summary}
+        </p>
+      )}
+      <div
+        className="row"
+        style={{ gap: 8, alignItems: "center", marginTop: 2 }}
+      >
+        {owner && (
+          <span
+            className="row"
+            style={{ gap: 7, alignItems: "center", minWidth: 0 }}
+          >
+            <Avatar id={owner} agent={agent} size={20} />
+            <Mark id={owner} agent={agent} />
+          </span>
+        )}
+        {rel && (
+          <span
+            className="receipt"
+            style={{
+              fontSize: 11,
+              color: "var(--faint)",
+              marginLeft: "auto",
+              flexShrink: 0,
+            }}
+          >
+            {rel}
+          </span>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+export function FeaturedArtifacts({ pages }: { pages: IndexEntry[] }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(min(300px, 100%), 1fr))",
+        gap: 18,
+      }}
+    >
+      {pages.map((page) => (
+        <ArtifactCard key={page.slug} page={page} />
+      ))}
+    </div>
+  );
+}

--- a/src/lib/__tests__/page-types.test.ts
+++ b/src/lib/__tests__/page-types.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+  isAgentScopedType,
+  isArtifactType,
+  selectFeaturedArtifacts,
+} from "../page-types";
+import type { IndexEntry } from "../types";
+
+describe("isArtifactType", () => {
+  it("is true only for html/slides", () => {
+    expect(isArtifactType("html")).toBe(true);
+    expect(isArtifactType("slides")).toBe(true);
+    expect(isArtifactType("agent-knowledge")).toBe(false);
+    expect(isArtifactType(undefined)).toBe(false);
+  });
+});
+
+describe("isAgentScopedType", () => {
+  it("is true for any agent-* type", () => {
+    expect(isAgentScopedType("agent-identity")).toBe(true);
+    expect(isAgentScopedType("html")).toBe(false);
+    expect(isAgentScopedType(undefined)).toBe(false);
+  });
+});
+
+function entry(over: Partial<IndexEntry>): IndexEntry {
+  return {
+    slug: over.slug ?? "s",
+    title: over.title ?? "T",
+    summary: over.summary ?? "",
+    ...over,
+  };
+}
+
+describe("selectFeaturedArtifacts", () => {
+  it("keeps only html/slides artifacts, dropping non-artifacts", () => {
+    const out = selectFeaturedArtifacts([
+      entry({ slug: "a", type: "html" }),
+      entry({ slug: "b", type: "slides" }),
+      entry({ slug: "c", type: undefined }), // a synthesized commons page
+      entry({ slug: "d", type: "agent-knowledge" }),
+    ]);
+    expect(out.map((p) => p.slug)).toEqual(["a", "b"]);
+  });
+
+  it("NEVER surfaces a private artifact (the homepage is public + cached)", () => {
+    const out = selectFeaturedArtifacts([
+      entry({ slug: "pub", type: "html", visibility: "public" }),
+      entry({ slug: "secret", type: "html", visibility: "private" }),
+      entry({ slug: "default", type: "slides" }), // no visibility → public
+    ]);
+    expect(out.map((p) => p.slug)).toEqual(["pub", "default"]);
+    expect(out.some((p) => p.slug === "secret")).toBe(false);
+  });
+
+  it("sorts newest-updated first", () => {
+    const out = selectFeaturedArtifacts([
+      entry({ slug: "old", type: "html", updated: "2026-01-01" }),
+      entry({ slug: "new", type: "html", updated: "2026-06-01" }),
+      entry({ slug: "mid", type: "html", updated: "2026-03-01" }),
+    ]);
+    expect(out.map((p) => p.slug)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("treats a missing `updated` as oldest (sorts last)", () => {
+    const out = selectFeaturedArtifacts([
+      entry({ slug: "dated", type: "html", updated: "2026-01-01" }),
+      entry({ slug: "undated", type: "html" }),
+    ]);
+    expect(out.map((p) => p.slug)).toEqual(["dated", "undated"]);
+  });
+
+  it("caps at the limit (default 6)", () => {
+    const many = Array.from({ length: 9 }, (_, i) =>
+      entry({ slug: `a${i}`, type: "html", updated: `2026-01-0${i}` }),
+    );
+    expect(selectFeaturedArtifacts(many)).toHaveLength(6);
+    expect(selectFeaturedArtifacts(many, 3)).toHaveLength(3);
+  });
+
+  it("returns an empty array when there are no artifacts", () => {
+    expect(
+      selectFeaturedArtifacts([entry({ slug: "x", type: undefined })]),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/page-types.test.ts
+++ b/src/lib/__tests__/page-types.test.ts
@@ -28,6 +28,7 @@ function entry(over: Partial<IndexEntry>): IndexEntry {
     slug: over.slug ?? "s",
     title: over.title ?? "T",
     summary: over.summary ?? "",
+    owner: "alice", // a human owner by default; override to test the filter
     ...over,
   };
 }
@@ -51,6 +52,40 @@ describe("selectFeaturedArtifacts", () => {
     ]);
     expect(out.map((p) => p.slug)).toEqual(["pub", "default"]);
     expect(out.some((p) => p.slug === "secret")).toBe(false);
+  });
+
+  it("never leaks a private artifact even when it's newest and over the limit", () => {
+    // The private artifacts are the NEWEST and the list overflows `limit`. A
+    // filter-AFTER-slice refactor would take them into the cut, then drop them —
+    // leaving the gallery short or empty. The filter must precede the slice, so
+    // the result is exactly the public set, no private leak.
+    const pages = [
+      ...Array.from({ length: 6 }, (_, i) =>
+        entry({
+          slug: `priv${i}`,
+          type: "html",
+          visibility: "private",
+          updated: `2026-09-1${i}`,
+        }),
+      ),
+      ...Array.from({ length: 3 }, (_, i) =>
+        entry({ slug: `pub${i}`, type: "html", updated: `2026-01-1${i}` }),
+      ),
+    ];
+    const out = selectFeaturedArtifacts(pages, 4);
+    expect(out.some((p) => p.slug.startsWith("priv"))).toBe(false);
+    expect(out.map((p) => p.slug)).toEqual(["pub2", "pub1", "pub0"]);
+  });
+
+  it("features only HUMAN-made artifacts — excludes agents, automation, unattributed", () => {
+    const out = selectFeaturedArtifacts([
+      entry({ slug: "human", type: "html", owner: "alice" }),
+      entry({ slug: "agent", type: "html", owner: "alice--yoyo" }),
+      entry({ slug: "bare-agent", type: "html", owner: "yoyo" }),
+      entry({ slug: "system", type: "html", owner: "system" }),
+      entry({ slug: "anon", type: "html", owner: undefined }),
+    ]);
+    expect(out.map((p) => p.slug)).toEqual(["human"]);
   });
 
   it("sorts newest-updated first", () => {

--- a/src/lib/page-types.ts
+++ b/src/lib/page-types.ts
@@ -5,6 +5,8 @@
  * server. `wiki.ts` re-exports these for existing server importers.
  */
 
+import type { IndexEntry } from "./types";
+
 /**
  * True when a page `type` marks it as agent-scoped (`agent-identity`,
  * `agent-knowledge`, …). Such pages are excluded from the public browse feed
@@ -23,4 +25,23 @@ export function isAgentScopedType(type: string | undefined): boolean {
  */
 export function isArtifactType(type: string | undefined): boolean {
   return type === "html" || type === "slides";
+}
+
+/**
+ * Select the artifacts to feature on the homepage gallery: recent PUBLIC
+ * `html`/`slides` pages, newest-updated first, capped at `limit`.
+ *
+ * SECURITY: the homepage renders anonymously and is cached, so this filters to
+ * NON-PRIVATE artifacts only — a `visibility:"private"` page must never surface
+ * there. (A missing `visibility` is public by default, matching the rest of the
+ * read model.) Pure so the invariant is unit-tested away from the page.
+ */
+export function selectFeaturedArtifacts(
+  pages: IndexEntry[],
+  limit = 6,
+): IndexEntry[] {
+  return pages
+    .filter((p) => isArtifactType(p.type) && p.visibility !== "private")
+    .sort((a, b) => (b.updated ?? "").localeCompare(a.updated ?? ""))
+    .slice(0, limit);
 }

--- a/src/lib/page-types.ts
+++ b/src/lib/page-types.ts
@@ -6,6 +6,12 @@
  */
 
 import type { IndexEntry } from "./types";
+import { isAgentHandle, isAutomationActor } from "./agent-handle";
+
+/** A human owner: attributed, and neither an agent nor an automation actor. */
+function isHumanOwner(owner: string | undefined): boolean {
+  return !!owner && !isAgentHandle(owner) && !isAutomationActor(owner);
+}
 
 /**
  * True when a page `type` marks it as agent-scoped (`agent-identity`,
@@ -28,20 +34,29 @@ export function isArtifactType(type: string | undefined): boolean {
 }
 
 /**
- * Select the artifacts to feature on the homepage gallery: recent PUBLIC
- * `html`/`slides` pages, newest-updated first, capped at `limit`.
+ * Select the artifacts to feature on the homepage gallery: recent PUBLIC,
+ * HUMAN-MADE `html`/`slides` pages, newest-updated first, capped at `limit`.
+ *
+ * "Personal" means human-made: agent-owned (`<owner>--yoyo`/`yoyo`) and
+ * automation (system / linter / seed) artifacts are excluded, as are
+ * unattributed ones — the gallery showcases what people build.
  *
  * SECURITY: the homepage renders anonymously and is cached, so this filters to
  * NON-PRIVATE artifacts only — a `visibility:"private"` page must never surface
  * there. (A missing `visibility` is public by default, matching the rest of the
- * read model.) Pure so the invariant is unit-tested away from the page.
+ * read model.) Pure so the invariants are unit-tested away from the page.
  */
 export function selectFeaturedArtifacts(
   pages: IndexEntry[],
   limit = 6,
 ): IndexEntry[] {
   return pages
-    .filter((p) => isArtifactType(p.type) && p.visibility !== "private")
+    .filter(
+      (p) =>
+        isArtifactType(p.type) &&
+        p.visibility !== "private" &&
+        isHumanOwner(p.owner),
+    )
     .sort((a, b) => (b.updated ?? "").localeCompare(a.updated ?? ""))
     .slice(0, limit);
 }


### PR DESCRIPTION
## What

A new **artifacts** gallery on the frontpage — the visual, shareable pages people render from the commons (`type:html` / `type:slides`) — placed right **under the trail + contributors** grid, as requested.

## Design (kept consistent with Folio)

- New `FeaturedArtifacts` component: a responsive card grid reusing the **same card language as the profile artifact cards** (`ProfileBlogIndex`) — `var(--rule)` border, 14px radius, paper bg, the accent type-badge, 18/600 title, 2-line summary clamp. Added two things appropriate for a shared frontpage:
  - **Owner attribution** (`Avatar` + `Mark`, the same primitives the contributors rail uses) — since the homepage mixes authors, unlike a profile.
  - A correct **HTML / SLIDES** badge (the profile card hardcoded "HTML").
  - A working hover (border + title → accent), matching `WikiPageCard`'s interaction convention.
- Section header matches the homepage's existing pattern: lowercase `fmark` eyebrow + a muted subline.

## Data & security

- Artifacts are **excluded from the commons** (they live owner-scoped at `/u/<tenant>/<slug>`), so the homepage now also reads the full page list via `listWikiPages()` — O(1) through the page index, the same anonymous fast-path the rest of the page uses. Cards link via `wikiUrlFor(...)`.
- **The homepage renders anonymously and is cached**, so the selection keeps **only non-private artifacts** — a `visibility:"private"` page must never surface here. I extracted the selection into a pure `selectFeaturedArtifacts()` helper specifically so that invariant is unit-tested.
- The section **hides gracefully** when there are no public artifacts yet.

## Verification

- New tests (`page-types.test.ts`, 8): private never surfaces, non-artifacts excluded, newest-updated first, missing-`updated` sorts last, capped at the limit, empty → empty.
- `pnpm lint` 0 errors · `pnpm build` + `pnpm build:cloudflare` clean · full suite **3159 passed**.

## Notes / choices to sanity-check

- Features **recent public artifacts by all authors** (human and agent — the owner mark distinguishes them, consistent with the trail/contributors which already show both). If you'd rather show human-only "personal" ones, it's a one-line filter.
- Limit is 6 (2 rows of 3 on a wide viewport). Easy to tune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)