### PR TITLE
yoyo: open artifacts in the full-screen share view (homepage gallery + profiles)

### DIFF
--- a/src/components/FeaturedArtifacts.tsx
+++ b/src/components/FeaturedArtifacts.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { IndexEntry } from "@/lib/types";
 import { formatRelativeTime } from "@/lib/format";
-import { wikiUrlFor } from "@/lib/share-url";
+import { sharePath, ownerToTenant } from "@/lib/links";
 import { isAgentHandle } from "@/lib/agent-handle";
 import { Avatar, Mark } from "@/components/folio/primitives";
 
@@ -25,7 +25,9 @@ function ArtifactCard({ page }: { page: IndexEntry }) {
 
   return (
     <Link
-      href={wikiUrlFor(page.slug, page)}
+      // Open the artifact in the chrome-less full-screen share view (its content
+      // fills the viewport), not the wiki-chromed owner page.
+      href={sharePath(ownerToTenant(page.owner), page.slug)}
       className="stack group rounded-[14px] border border-[color:var(--rule)] hover:border-accent/40 transition-colors"
       style={{
         gap: 9,

--- a/src/components/ProfileBlogIndex.tsx
+++ b/src/components/ProfileBlogIndex.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { IndexEntry } from "@/lib/types";
 import { formatRelativeTime } from "@/lib/format";
-import { commonsPath, pagePath, ownerToTenant } from "@/lib/links";
+import { commonsPath, pagePath, sharePath, ownerToTenant } from "@/lib/links";
 import { isArtifactType } from "@/lib/page-types";
 
 /**
@@ -20,12 +20,12 @@ function ProfileCard({
 }) {
   const rel = page.updated ? formatRelativeTime(page.updated) : null;
   const open = discussion?.open ?? 0;
-  // Artifacts (and private/agent pages) have no global URL → owner-scoped
-  // /u/<tenant>/<slug>; only public commons pages link to /wiki/<slug>.
-  const href =
-    page.visibility !== "private" &&
-    !page.type?.startsWith("agent-") &&
-    !isArtifactType(page.type)
+  // Open an artifact in the chrome-less full-screen share view (its rendered
+  // content fills the viewport), not the wiki-chromed owner page. Non-artifacts:
+  // a public commons page → /wiki/<slug>, else the owner-scoped /u/<tenant>/<slug>.
+  const href = isArtifactType(page.type)
+    ? sharePath(ownerToTenant(page.owner), page.slug)
+    : page.visibility !== "private" && !page.type?.startsWith("agent-")
       ? commonsPath(page.slug)
       : pagePath(ownerToTenant(page.owner), page.slug);
 

--- a/src/lib/__tests__/links.test.ts
+++ b/src/lib/__tests__/links.test.ts
@@ -9,6 +9,7 @@ import {
   pagePath,
   editPath,
   rawPath,
+  sharePath,
   resolveSlugPath,
   profileHref,
 } from "../links";
@@ -152,6 +153,14 @@ describe("canonical URL builders", () => {
     expect(commonsPath("retrieval-augmented-generation")).toBe(
       "/wiki/retrieval-augmented-generation",
     );
+  });
+
+  it("builds the full-screen share path /share/<tenant>/<slug>", () => {
+    expect(sharePath("yuanhao", "billionaire-math")).toBe(
+      "/share/yuanhao/billionaire-math",
+    );
+    // Raw slug (incl. Unicode), like pagePath — the route + browser encode it.
+    expect(sharePath("yuanhao", "math-解释")).toBe("/share/yuanhao/math-解释");
   });
 
   it("builds the profile URL /u/<handle>, percent-encoding unsafe handles", () => {

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -113,8 +113,10 @@ export function editPath(tenant: string, slug: string): string {
  * view of a page (`SiteChrome` renders `/share/*` bare). Used to "open" an
  * artifact so its rendered content fills the viewport, rather than the
  * wiki-chromed `/u/<tenant>/<slug>`. Same `(tenant, slug)` addressing and raw
- * slug as {@link pagePath}; the share route read-gates identically, so a private
- * page's share URL is only viewable by its owner (a non-owner gets the same 404).
+ * slug as {@link pagePath}. The share route applies the same `canReadFrontmatter`
+ * read-gate as the owner page, so a private page is shown only to readers it
+ * permits (its owner, an admin, or the agent's human owner) and 404s for anyone
+ * else — no existence leak.
  */
 export function sharePath(tenant: string, slug: string): string {
   return `/share/${tenant}/${slug}`;

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -108,6 +108,18 @@ export function editPath(tenant: string, slug: string): string {
   return `/u/${tenant}/${slug}/edit`;
 }
 
+/**
+ * Full-screen SHARE URL `/share/<tenant>/<slug>` — the chrome-less, immersive
+ * view of a page (`SiteChrome` renders `/share/*` bare). Used to "open" an
+ * artifact so its rendered content fills the viewport, rather than the
+ * wiki-chromed `/u/<tenant>/<slug>`. Same `(tenant, slug)` addressing and raw
+ * slug as {@link pagePath}; the share route read-gates identically, so a private
+ * page's share URL is only viewable by its owner (a non-owner gets the same 404).
+ */
+export function sharePath(tenant: string, slug: string): string {
+  return `/share/${tenant}/${slug}`;
+}
+
 /** Canonical raw-source URL `/u/<tenant>/raw/<slug>`. */
 export function rawPath(tenant: string, slug: string): string {
   return `/u/${tenant}/raw/${slug}`;


### PR DESCRIPTION
## What

Make an artifact card open the artifact **immersively** — the chrome-less full-screen share view (`/share/<tenant>/<slug>`, rendered bare by `SiteChrome`: the HtmlPreview fills the viewport, slides render as a deck) — instead of the wiki-chromed owner page (`/u/<tenant>/<slug>`, which wraps it in nav + sources + discussion).

Applied to **both** "view this artifact" surfaces:
- the homepage **featured gallery** (`FeaturedArtifacts`), and
- the **profile** artifact cards (`ProfileBlogIndex`).

In-prose wikilinks and the wiki/browse rows keep pointing at the canonical `/u/...` page (those are "read about it" contexts).

## How

- New `sharePath(tenant, slug)` in `links.ts`, mirroring `pagePath` (raw slug; the route + browser encode Unicode).
- `FeaturedArtifacts` → `sharePath(ownerToTenant(owner), slug)`.
- `ProfileBlogIndex` → `sharePath` for artifacts; the non-artifact fallback (public commons `/wiki/<slug>` vs owner-scoped `/u/<tenant>/<slug>`) is preserved for safety.

## Security

The share route read-gates **identically** to the owner page (`canReadFrontmatter`), so a private artifact's share URL is viewable only by its owner — a non-owner gets the same neutral 404, no existence leak. The homepage gallery already features public artifacts only; on a profile, a private artifact card only appears for the owner (who can read its share URL).

## Verification

- New `sharePath` test (incl. a Unicode slug).
- `pnpm lint` 0 errors · `pnpm build` + `pnpm build:cloudflare` clean · full suite **3163 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)