### PR TITLE
yoyo: speed up the /u/<handle> profile — serve contributor stats from the index

### DIFF
--- a/src/lib/__tests__/contributors.test.ts
+++ b/src/lib/__tests__/contributors.test.ts
@@ -208,6 +208,21 @@ describe("contributors data layer", () => {
       expect(profile.editCount).toBe(1);
     });
 
+    it("returns an empty profile (no scan) for a handle absent from a present index", async () => {
+      await createPage("idx-page2", "Idx2", "# Idx2\n\nc");
+      await saveRevision("idx-page2", "# Idx2\n\nv1", "alice");
+      const { rebuildContributorIndex } = await import("../contributor-index");
+      await rebuildContributorIndex(); // index present, knows only alice
+      // bob isn't in the index; give him on-disk activity a scan WOULD find.
+      await saveRevision("idx-page2", "# Idx2\n\nv2", "bob");
+      // Index present → bob short-circuits to a zeroed profile, NOT a scan
+      // (which would report editCount 1). Guards the "absent handle still skips
+      // the scan" contract against a regression that re-scans unknown handles.
+      const profile = await buildContributorProfile("bob");
+      expect(profile.handle).toBe("bob");
+      expect(profile.editCount).toBe(0);
+    });
+
     it("counts talk comments and threads", async () => {
       await ensureDirectories();
 

--- a/src/lib/__tests__/contributors.test.ts
+++ b/src/lib/__tests__/contributors.test.ts
@@ -194,6 +194,20 @@ describe("contributors data layer", () => {
       expect(profile.pagesEdited).toBe(2);
     });
 
+    it("uses the contributor index when present (O(1) fast-path, not a live scan)", async () => {
+      await createPage("idx-page", "Idx", "# Idx\n\nc");
+      await saveRevision("idx-page", "# Idx\n\nv1", "alice");
+      // Seed the index from the current on-disk state → alice has 1 edit.
+      const { rebuildContributorIndex } = await import("../contributor-index");
+      await rebuildContributorIndex();
+      // Add MORE on-disk activity the index doesn't know about.
+      await saveRevision("idx-page", "# Idx\n\nv2", "alice");
+      // The profile must come from the (now-stale) index, not a fresh scan — so
+      // it still reports 1 edit. A re-scan would read the revisions → 2.
+      const profile = await buildContributorProfile("alice");
+      expect(profile.editCount).toBe(1);
+    });
+
     it("counts talk comments and threads", async () => {
       await ensureDirectories();
 

--- a/src/lib/contributor-index.ts
+++ b/src/lib/contributor-index.ts
@@ -135,8 +135,9 @@ function profileFromIndexAuthor(
  * Build ONE handle's profile from the index, or `null` when the index is ABSENT
  * (the caller should then fall back to the live scan). A handle missing from a
  * PRESENT index has no recorded public contributions → an empty profile, so the
- * caller still avoids the scan. The O(1) read behind the `/u/<handle>` profile +
- * `/api/contributors/<handle>` (mirrors {@link profilesFromIndex} for one handle).
+ * caller still avoids the scan. This is the O(1) read behind the `/u/<handle>`
+ * profile + `/api/contributors/<handle>` (mirrors {@link profilesFromIndex} for
+ * a single handle).
  */
 export async function contributorProfileFromIndex(
   handle: string,

--- a/src/lib/contributor-index.ts
+++ b/src/lib/contributor-index.ts
@@ -131,6 +131,21 @@ function profileFromIndexAuthor(
   };
 }
 
+/**
+ * Build ONE handle's profile from the index, or `null` when the index is ABSENT
+ * (the caller should then fall back to the live scan). A handle missing from a
+ * PRESENT index has no recorded public contributions → an empty profile, so the
+ * caller still avoids the scan. The O(1) read behind the `/u/<handle>` profile +
+ * `/api/contributors/<handle>` (mirrors {@link profilesFromIndex} for one handle).
+ */
+export async function contributorProfileFromIndex(
+  handle: string,
+): Promise<ContributorProfile | null> {
+  const idx = await getContributorIndex();
+  if (!idx) return null;
+  return profileFromIndexAuthor(handle, idx.authors[handle] ?? emptyIndexAuthor());
+}
+
 /** Build the full sorted profile list from the index (homepage / contributors page). */
 export function profilesFromIndex(idx: ContributorIndex): ContributorProfile[] {
   const profiles = Object.entries(idx.authors).map(([handle, a]) =>

--- a/src/lib/contributors.ts
+++ b/src/lib/contributors.ts
@@ -264,6 +264,13 @@ function buildProfileFromActivity(
  * scan and uses the pre-computed data. This is the recommended path when
  * building profiles for multiple handles (e.g. batch badge rendering).
  *
+ * Otherwise it reads the precomputed contributor index (the handle's public
+ * edit/comment/thread/trust tallies) — an O(1) read instead of scanning every
+ * page's revisions + every discuss file. Only a MISSING index falls through to
+ * the live scan (which still honors `principal`). Because the index reflects
+ * PUBLIC contributions, the profile shows public-contribution stats — the right
+ * thing for this public surface, and consistent with `listContributors`.
+ *
  * Returns a zeroed-out profile (not an error) when the handle has no activity.
  */
 export async function buildContributorProfile(
@@ -271,7 +278,12 @@ export async function buildContributorProfile(
   scanData?: ContributorScanData,
   principal: Principal | null = null,
 ): Promise<ContributorProfile> {
-  const data = scanData ?? await computeScanData(principal);
+  if (!scanData) {
+    const { contributorProfileFromIndex } = await import("./contributor-index");
+    const fromIndex = await contributorProfileFromIndex(handle);
+    if (fromIndex) return fromIndex;
+  }
+  const data = scanData ?? (await computeScanData(principal));
   const act = data.activityMap.get(handle) ?? emptyActivity();
   const revertCount = data.revertCounts.get(handle) ?? 0;
   return buildProfileFromActivity(handle, act, revertCount);

--- a/src/lib/contributors.ts
+++ b/src/lib/contributors.ts
@@ -279,9 +279,20 @@ export async function buildContributorProfile(
   principal: Principal | null = null,
 ): Promise<ContributorProfile> {
   if (!scanData) {
-    const { contributorProfileFromIndex } = await import("./contributor-index");
-    const fromIndex = await contributorProfileFromIndex(handle);
-    if (fromIndex) return fromIndex;
+    try {
+      const { contributorProfileFromIndex } = await import("./contributor-index");
+      const fromIndex = await contributorProfileFromIndex(handle);
+      if (fromIndex) return fromIndex;
+    } catch (err) {
+      // The index is purely an accelerator — a module-load or build error here
+      // must degrade to the live scan, never crash the profile page awaiting
+      // this. Log it (don't swallow silently) so a broken index is visible.
+      logger.warn(
+        "contributors",
+        `contributor-index fast-path failed for "${handle}"; falling back to the live scan:`,
+        err,
+      );
+    }
   }
   const data = scanData ?? (await computeScanData(principal));
   const act = data.activityMap.get(handle) ?? emptyActivity();


### PR DESCRIPTION
## Problem

`/u/<handle>` was slow. Mapping its data calls, every O(1)-index call was fine **except** `buildContributorProfile(handle, undefined, principal)`: with no `scanData` it runs `computeScanData`, which reads **every page's revisions + every discuss file** — uncapped O(all-pages) I/O — on **every** profile render. On a large wiki that's hundreds of reads and dominates render time.

## Fix (same pattern the homepage uses)

A `_idx:contributors` index already stores each handle's public edit/comment/thread/trust tallies (the homepage reads it for its stats — that's *why* the homepage is fast). Serve the profile from it:

- **`contributor-index.ts`**: new `contributorProfileFromIndex(handle)` — builds one handle's `ContributorProfile` from the index in O(1), or returns `null` when the index is absent (so the caller falls back to the live scan). Reuses the existing `profileFromIndexAuthor`.
- **`buildContributorProfile`**: index-first when no `scanData` is supplied. Only a **missing** index falls through to the scan (still honoring `principal`). Because the index reflects **public** contributions, the profile shows public-contribution stats — the right thing for this public surface, and consistent with `listContributors`.
- **Test**: seeds the index, then diverges the on-disk state, and asserts the profile returns the **stale index value** (proving the fast-path is taken, not a re-scan).

### Behavior note
For the owner viewing their *own* profile while signed in, stats now reflect **public** contributions only (private-page edits no longer inflate the count). That's consistent with the "Public pages owned or contributed by {handle}" framing and with how `listContributors` already works.

## Remaining secondary costs (noted, not in this PR)

- `trailEventsForPages` is already **capped at 30 pages** (`MAX_PAGES_SCANNED`) — bounded, far smaller than the unbounded contributor scan removed here.
- `listAgentsForOwner` scans the (small) agents dir.

If the page still feels slow after this, the next step would be a per-handle recent-events index for the activity trail — a bigger change (new index + write-path maintenance), so I left it out unless it's warranted.

## Verification

`pnpm lint` 0 errors · `pnpm build` + `pnpm build:cloudflare` clean · full suite **3167 passed** (incl. the new fast-path test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)