### PR TITLE
yoyo: parallelize listRevisions' per-revision reads (the real /u/<handle> bottleneck)

### DIFF
--- a/src/lib/__tests__/revisions.test.ts
+++ b/src/lib/__tests__/revisions.test.ts
@@ -95,6 +95,35 @@ describe("listRevisions", () => {
     const revisions = await listRevisions("no-history");
     expect(revisions).toEqual([]);
   });
+
+  it("keeps no-sidecar revisions alongside sidecar ones (mixed), newest-first; skips non-revision entries", async () => {
+    await ensureDirectories();
+    const dir = getRevisionsDir("mixed");
+    await fs.mkdir(dir, { recursive: true });
+    // Three real revisions; only the MIDDLE one carries an author sidecar.
+    await fs.writeFile(path.join(dir, "1000000000000.md"), "v1", "utf-8");
+    await fs.writeFile(path.join(dir, "2000000000000.md"), "v2", "utf-8");
+    await fs.writeFile(
+      path.join(dir, "2000000000000.meta.json"),
+      JSON.stringify({ author: "alice" }),
+      "utf-8",
+    );
+    await fs.writeFile(path.join(dir, "3000000000000.md"), "v3", "utf-8");
+    // Entries that must be skipped, not counted (and not drop the real ones).
+    await fs.writeFile(path.join(dir, "README.txt"), "ignore", "utf-8");
+    await fs.writeFile(path.join(dir, "notanumber.md"), "ignore", "utf-8");
+
+    const revisions = await listRevisions("mixed");
+    // All three real revisions survive (the null-filter must not over-drop the
+    // no-sidecar ones), newest-first; the invalid entries are excluded.
+    expect(revisions.map((r) => r.timestamp)).toEqual([
+      3000000000000, 2000000000000, 1000000000000,
+    ]);
+    // The sidecar author lands ONLY on the middle revision.
+    expect(revisions[0].author).toBeUndefined();
+    expect(revisions[1].author).toBe("alice");
+    expect(revisions[2].author).toBeUndefined();
+  });
 });
 
 describe("readRevision", () => {

--- a/src/lib/revisions.ts
+++ b/src/lib/revisions.ts
@@ -124,53 +124,60 @@ export async function listRevisions(slug: string): Promise<Revision[]> {
     return [];
   }
 
-  const revisions: Revision[] = [];
+  // Read each revision's stat + optional meta sidecar CONCURRENTLY. The old
+  // serial loop did 2 sequential storage round-trips (stat, then meta) per
+  // revision, so a heavily-revised page cost O(revisions) round-trips — which
+  // dominated the user-profile activity trail (it scans up to 30 pages, gated by
+  // the worst one). Mapping in parallel makes each page ~2 round-trips total
+  // (all stats overlap, then all metas), with no change to the total op count.
+  const built = await Promise.all(
+    entries.map(async (entry): Promise<Revision | null> => {
+      if (entry.isDirectory || !entry.name.endsWith(".md")) return null;
+      const stem = entry.name.slice(0, -3); // strip ".md"
+      const timestamp = Number(stem);
+      if (Number.isNaN(timestamp) || timestamp <= 0) return null;
 
-  for (const entry of entries) {
-    if (entry.isDirectory) continue;
-    if (!entry.name.endsWith(".md")) continue;
-    const stem = entry.name.slice(0, -3); // strip ".md"
-    const timestamp = Number(stem);
-    if (Number.isNaN(timestamp) || timestamp <= 0) continue;
-
-    try {
-      const stat = await storage.stat(revisionsRelPath(slug, entry.name));
-
-      // Read the optional author/reason sidecar.
-      let author: string | undefined;
-      let reason: string | undefined;
       try {
-        const metaRaw = await storage.readFile(revisionsRelPath(slug, `${stem}.meta.json`));
-        const meta = JSON.parse(metaRaw) as { author?: string; reason?: string };
-        if (typeof meta.author === "string") {
-          author = meta.author;
-        }
-        if (typeof meta.reason === "string") {
-          reason = meta.reason;
-        }
-      } catch {
-        // No sidecar → no author/reason attribution (backward compat).
-      }
+        const stat = await storage.stat(revisionsRelPath(slug, entry.name));
 
-      revisions.push({
-        timestamp,
-        date: new Date(timestamp).toISOString(),
-        slug,
-        sizeBytes: stat.size,
-        ...(author !== undefined && { author }),
-        ...(reason !== undefined && { reason }),
-      });
-    } catch (err) {
-      // File disappeared between listFiles and stat — skip.
-      if (!isEnoent(err)) {
-        logger.warn("revisions", `unexpected error stating revision file "${entry.name}":`, err);
+        // Read the optional author/reason sidecar.
+        let author: string | undefined;
+        let reason: string | undefined;
+        try {
+          const metaRaw = await storage.readFile(revisionsRelPath(slug, `${stem}.meta.json`));
+          const meta = JSON.parse(metaRaw) as { author?: string; reason?: string };
+          if (typeof meta.author === "string") {
+            author = meta.author;
+          }
+          if (typeof meta.reason === "string") {
+            reason = meta.reason;
+          }
+        } catch {
+          // No sidecar → no author/reason attribution (backward compat).
+        }
+
+        return {
+          timestamp,
+          date: new Date(timestamp).toISOString(),
+          slug,
+          sizeBytes: stat.size,
+          ...(author !== undefined && { author }),
+          ...(reason !== undefined && { reason }),
+        };
+      } catch (err) {
+        // File disappeared between listFiles and stat — skip.
+        if (!isEnoent(err)) {
+          logger.warn("revisions", `unexpected error stating revision file "${entry.name}":`, err);
+        }
+        return null;
       }
-    }
-  }
+    }),
+  );
 
   // Sort newest first.
-  revisions.sort((a, b) => b.timestamp - a.timestamp);
-  return revisions;
+  return built
+    .filter((r): r is Revision => r !== null)
+    .sort((a, b) => b.timestamp - a.timestamp);
 }
 
 /**

--- a/src/lib/revisions.ts
+++ b/src/lib/revisions.ts
@@ -128,8 +128,9 @@ export async function listRevisions(slug: string): Promise<Revision[]> {
   // serial loop did 2 sequential storage round-trips (stat, then meta) per
   // revision, so a heavily-revised page cost O(revisions) round-trips — which
   // dominated the user-profile activity trail (it scans up to 30 pages, gated by
-  // the worst one). Mapping in parallel makes each page ~2 round-trips total
-  // (all stats overlap, then all metas), with no change to the total op count.
+  // the worst one). Mapping in parallel collapses each page to ~2 round-trips
+  // DEEP (all stats overlap, then all metas) — the op COUNT is unchanged, only
+  // the latency.
   const built = await Promise.all(
     entries.map(async (entry): Promise<Revision | null> => {
       if (entry.isDirectory || !entry.name.endsWith(".md")) return null;


### PR DESCRIPTION
## Why (the part I got wrong the first time)

After #635 made `buildContributorProfile` index-backed, I expected `/u/<handle>` to be fast — but it was **still ~19s** (homepage 2.6s, `/wiki` 0.8s). So I measured and traced it properly this time:

- TTFB is ~0.4s (the layout shell flushes), then the body streams ~19s later → a server `await` is slow.
- The profile's one expensive call the fast pages avoid is the **activity trail** (`trailEventsForPages`), which calls `listRevisions` for up to 30 of the handle's commons pages. (The homepage uses the recent-index instead.)
- `listRevisions` read each revision's `stat` + `.meta.json` **sequentially**. A page yoyo has reconciled/refreshed dozens of times → dozens × 2 serial round-trips, and the trail awaits all pages, so the single worst-revised page gated the whole render (~18s).

## Fix

Map the revision entries with `Promise.all` instead of the serial `for` loop. Each page now costs ~2 round-trips (all `stat`s overlap, then all metas) instead of O(revisions).

- **Output is byte-identical**: same fields, same skip rules (dir / non-`.md` / bad timestamp), same backward-compat sidecar tolerance, same newest-first sort, same warn logging.
- **No new subrequest-limit exposure**: the total storage-op count is unchanged — only concurrency rises — and the serial version already completed under the limit.
- **Helps every caller**: the profile trail, the contributor-scan fallback (`computeScanData`), and the revisions UI.

## Verification

- Existing tests cover the contract unchanged: `revisions.test.ts` (25), `trail.test.ts` (6), `contributors.test.ts` (29) — all pass.
- `pnpm lint` 0 errors · `pnpm build` + `pnpm build:cloudflare` clean · full suite **3177 passed**.

This is the follow-up I flagged on #635. Together they take the profile from "scan every page's revisions serially + (pre-#635) every discuss file" down to index reads + parallel per-page revision reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)