### PR TITLE
yoyo: cut the profile trail's revision I/O (measured 92% bottleneck)

### DIFF
--- a/src/lib/__tests__/revisions.test.ts
+++ b/src/lib/__tests__/revisions.test.ts
@@ -146,6 +146,27 @@ describe("listRevisionAuthors", () => {
     expect(revs[0]).not.toHaveProperty("sizeBytes");
   });
 
+  it("ranks by NUMERIC timestamp, not lexicographically", async () => {
+    await ensureDirectories();
+    const dir = getRevisionsDir("numsort");
+    await fs.mkdir(dir, { recursive: true });
+    // 14-digit 1e13 is newer than 13-digit 9e12, but as STRINGS "10000000000000"
+    // sorts BEFORE "9000000000000" — a lexicographic sort would pick the wrong
+    // newest. cap=1 forces the ranking to decide the single winner.
+    await fs.writeFile(path.join(dir, "9000000000000.md"), "older", "utf-8");
+    await fs.writeFile(path.join(dir, "10000000000000.md"), "newer", "utf-8");
+    const revs = await listRevisionAuthors("numsort", 1);
+    expect(revs.map((r) => r.timestamp)).toEqual([10000000000000]);
+  });
+
+  it("returns [] for max <= 0 (reads no sidecars)", async () => {
+    await ensureDirectories();
+    const dir = getRevisionsDir("zerocap");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "1000000000000.md"), "v1", "utf-8");
+    expect(await listRevisionAuthors("zerocap", 0)).toEqual([]);
+  });
+
   it("reads author/reason from sidecars and leaves them undefined when absent", async () => {
     await ensureDirectories();
     const dir = getRevisionsDir("attrib");

--- a/src/lib/__tests__/revisions.test.ts
+++ b/src/lib/__tests__/revisions.test.ts
@@ -5,6 +5,7 @@ import path from "path";
 import {
   saveRevision,
   listRevisions,
+  listRevisionAuthors,
   readRevision,
   readRevisionMeta,
   deleteRevisions,
@@ -123,6 +124,56 @@ describe("listRevisions", () => {
     expect(revisions[0].author).toBeUndefined();
     expect(revisions[1].author).toBe("alice");
     expect(revisions[2].author).toBeUndefined();
+  });
+});
+
+describe("listRevisionAuthors", () => {
+  it("caps to the newest `max` revisions (by filename timestamp), newest-first", async () => {
+    await ensureDirectories();
+    const dir = getRevisionsDir("capped");
+    await fs.mkdir(dir, { recursive: true });
+    // Five revisions; the cap must keep only the three newest, without reading
+    // the older two at all (ranking is by filename, so this needs no content).
+    for (const ts of [1, 2, 3, 4, 5]) {
+      await fs.writeFile(path.join(dir, `${ts}000000000000.md`), `v${ts}`, "utf-8");
+    }
+    const revs = await listRevisionAuthors("capped", 3);
+    expect(revs.map((r) => r.timestamp)).toEqual([
+      5000000000000, 4000000000000, 3000000000000,
+    ]);
+    // Shape: timestamp + ISO date, no sizeBytes (the stat is intentionally skipped).
+    expect(revs[0].date).toBe(new Date(5000000000000).toISOString());
+    expect(revs[0]).not.toHaveProperty("sizeBytes");
+  });
+
+  it("reads author/reason from sidecars and leaves them undefined when absent", async () => {
+    await ensureDirectories();
+    const dir = getRevisionsDir("attrib");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "1000000000000.md"), "v1", "utf-8"); // no sidecar
+    await fs.writeFile(path.join(dir, "2000000000000.md"), "v2", "utf-8");
+    await fs.writeFile(
+      path.join(dir, "2000000000000.meta.json"),
+      JSON.stringify({ author: "alice", reason: "fix typo" }),
+      "utf-8",
+    );
+    const revs = await listRevisionAuthors("attrib", 20);
+    expect(revs[0]).toMatchObject({ timestamp: 2000000000000, author: "alice", reason: "fix typo" });
+    expect(revs[1].author).toBeUndefined();
+    expect(revs[1].reason).toBeUndefined();
+  });
+
+  it("returns empty for a page with no revisions, and skips non-revision entries", async () => {
+    await ensureDirectories();
+    expect(await listRevisionAuthors("none", 20)).toEqual([]);
+
+    const dir = getRevisionsDir("noise");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "1000000000000.md"), "v1", "utf-8");
+    await fs.writeFile(path.join(dir, "README.txt"), "ignore", "utf-8");
+    await fs.writeFile(path.join(dir, "notanumber.md"), "ignore", "utf-8");
+    const revs = await listRevisionAuthors("noise", 20);
+    expect(revs.map((r) => r.timestamp)).toEqual([1000000000000]);
   });
 });
 

--- a/src/lib/__tests__/trail.test.ts
+++ b/src/lib/__tests__/trail.test.ts
@@ -11,15 +11,15 @@ vi.mock("../wiki", () => ({
   tenantForOwner: (o?: string) => o ?? "commons",
   ownerToTenant: (o?: string) => o ?? "commons",
 }));
-vi.mock("../revisions", () => ({ listRevisions: vi.fn() }));
+vi.mock("../revisions", () => ({ listRevisionAuthors: vi.fn() }));
 
 import { trailEventsForPages } from "../trail";
 import { readWikiPageWithFrontmatter } from "../wiki";
-import { listRevisions } from "../revisions";
+import { listRevisionAuthors } from "../revisions";
 import { logger } from "../logger";
 
 const mockedReadPage = vi.mocked(readWikiPageWithFrontmatter);
-const mockedListRevisions = vi.mocked(listRevisions);
+const mockedListRevisionAuthors = vi.mocked(listRevisionAuthors);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -40,7 +40,7 @@ describe("trailEventsForPages — actor normalization", () => {
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
-    mockedListRevisions.mockResolvedValue([
+    mockedListRevisionAuthors.mockResolvedValue([
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       { author: "lint-fix", timestamp: 1_700_000_000_000, date: "2026-06-10" } as any,
     ]);
@@ -70,7 +70,7 @@ describe("trailEventsForPages — actor normalization", () => {
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
-    mockedListRevisions.mockResolvedValue([]);
+    mockedListRevisionAuthors.mockResolvedValue([]);
 
     const events = await trailEventsForPages([{ slug: "p", title: "P" }]);
     expect(events).toHaveLength(1);
@@ -82,7 +82,7 @@ describe("trailEventsForPages — actor normalization", () => {
     const src = JSON.stringify([
       { type: "url", url: "https://e.com", fetched: "2026-06-10T00:00:00.000Z", triggered_by: "alice" },
     ]);
-    mockedListRevisions.mockResolvedValue([]);
+    mockedListRevisionAuthors.mockResolvedValue([]);
 
     // A plain public page → reachable at /wiki/<slug>.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -104,7 +104,7 @@ describe("trailEventsForPages — actor normalization", () => {
     // No sources → no ingest event; the lone event is from a revision (edit).
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockedReadPage.mockResolvedValue({ frontmatter: { type: "html" } } as any);
-    mockedListRevisions.mockResolvedValue([
+    mockedListRevisionAuthors.mockResolvedValue([
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       { author: "alice", timestamp: 1_700_000_000_000, date: "2026-06-10" } as any,
     ]);
@@ -122,7 +122,7 @@ describe("trailEventsForPages — actor normalization", () => {
       frontmatter: { sources: src, visibility: "private" },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
-    mockedListRevisions.mockResolvedValue([]);
+    mockedListRevisionAuthors.mockResolvedValue([]);
     const events = await trailEventsForPages([{ slug: "secret", title: "Secret" }]);
     expect(events[0].commons).toBe(false);
   });
@@ -130,7 +130,7 @@ describe("trailEventsForPages — actor normalization", () => {
   it("defaults commons=false and logs when the page read fails (not a silent swallow)", async () => {
     const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
     mockedReadPage.mockRejectedValue(new Error("R2 down"));
-    mockedListRevisions.mockResolvedValue([
+    mockedListRevisionAuthors.mockResolvedValue([
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       { author: "alice", timestamp: 1_700_000_000_000, date: "2026-06-10" } as any,
     ]);

--- a/src/lib/revisions.ts
+++ b/src/lib/revisions.ts
@@ -181,6 +181,71 @@ export async function listRevisions(slug: string): Promise<Revision[]> {
     .sort((a, b) => b.timestamp - a.timestamp);
 }
 
+/** A revision's attribution, without the `stat`/`sizeBytes` an activity feed never shows. */
+export interface RevisionAuthor {
+  timestamp: number;
+  date: string;
+  author?: string;
+  reason?: string;
+}
+
+/**
+ * Lighter-weight revision lister for activity feeds (the trail). Unlike
+ * {@link listRevisions} it does NOT `stat` each revision — feeds never show
+ * `sizeBytes`, and that stat was a wasted round-trip per revision. The timestamp
+ * is parsed from the filename, so ranking and the `max` cap need ZERO reads;
+ * only the capped set's `.meta.json` sidecars are fetched (for author/reason).
+ *
+ * Why it matters: the user-profile / recent trail scans many pages, each with
+ * potentially many revisions. `listRevisions` cost O(total revisions × 2 reads);
+ * this costs O(pages × min(revisions, max)) — the dominant cost of that scan.
+ * `max` bounds per-page work because a feed only surfaces a page's most RECENT
+ * edits anyway (older ones can't out-rank other pages' activity in the cap).
+ */
+export async function listRevisionAuthors(
+  slug: string,
+  max: number,
+): Promise<RevisionAuthor[]> {
+  validateSlug(slug);
+  const storage = getStorage();
+  const dirPath = revisionsRelPath(slug);
+
+  let entries: { name: string; isDirectory: boolean }[];
+  try {
+    entries = await storage.listFiles(dirPath);
+  } catch (err) {
+    if (!isEnoent(err)) {
+      logger.warn("revisions", `unexpected error reading revision dir for "${slug}":`, err);
+    }
+    return [];
+  }
+
+  // Timestamps live in the filename — rank newest-first and cap WITHOUT reading.
+  const stems = entries
+    .filter((entry) => !entry.isDirectory && entry.name.endsWith(".md"))
+    .map((entry) => Number(entry.name.slice(0, -3)))
+    .filter((ts) => Number.isFinite(ts) && ts > 0)
+    .sort((a, b) => b - a)
+    .slice(0, Math.max(0, max));
+
+  // Read ONLY the capped set's attribution sidecars (no stat).
+  return Promise.all(
+    stems.map(async (timestamp): Promise<RevisionAuthor> => {
+      let author: string | undefined;
+      let reason: string | undefined;
+      try {
+        const raw = await storage.readFile(revisionsRelPath(slug, `${timestamp}.meta.json`));
+        const meta = JSON.parse(raw) as { author?: string; reason?: string };
+        if (typeof meta.author === "string") author = meta.author;
+        if (typeof meta.reason === "string") reason = meta.reason;
+      } catch {
+        // No sidecar → unattributed (legacy revision); still a valid event.
+      }
+      return { timestamp, date: new Date(timestamp).toISOString(), author, reason };
+    }),
+  );
+}
+
 /**
  * Read a specific revision's content.
  *

--- a/src/lib/revisions.ts
+++ b/src/lib/revisions.ts
@@ -193,8 +193,9 @@ export interface RevisionAuthor {
  * Lighter-weight revision lister for activity feeds (the trail). Unlike
  * {@link listRevisions} it does NOT `stat` each revision — feeds never show
  * `sizeBytes`, and that stat was a wasted round-trip per revision. The timestamp
- * is parsed from the filename, so ranking and the `max` cap need ZERO reads;
- * only the capped set's `.meta.json` sidecars are fetched (for author/reason).
+ * is parsed from the filename, so ranking and the `max` cap need ZERO
+ * per-revision reads (just the one directory listing); only the capped set's
+ * `.meta.json` sidecars are then fetched (for author/reason).
  *
  * Why it matters: the user-profile / recent trail scans many pages, each with
  * potentially many revisions. `listRevisions` cost O(total revisions × 2 reads);
@@ -238,8 +239,18 @@ export async function listRevisionAuthors(
         const meta = JSON.parse(raw) as { author?: string; reason?: string };
         if (typeof meta.author === "string") author = meta.author;
         if (typeof meta.reason === "string") reason = meta.reason;
-      } catch {
-        // No sidecar → unattributed (legacy revision); still a valid event.
+      } catch (err) {
+        // A MISSING sidecar (ENOENT) is expected — an unattributed legacy
+        // revision, still a valid event. A corrupt/unparseable sidecar or a real
+        // read fault is NOT expected: surface it (matching readRevisionMeta and
+        // this file's convention) rather than silently dropping the attribution.
+        if (!isEnoent(err)) {
+          logger.warn(
+            "revisions",
+            `unexpected error reading revision meta "${slug}@${timestamp}":`,
+            err,
+          );
+        }
       }
       return { timestamp, date: new Date(timestamp).toISOString(), author, reason };
     }),

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -1,5 +1,5 @@
 import { listReadableWikiPages, readWikiPageWithFrontmatter, isAgentScopedType, ownerToTenant } from "./wiki";
-import { listRevisions } from "./revisions";
+import { listRevisionAuthors } from "./revisions";
 import { parseSources } from "./sources";
 import { isAgentHandle } from "./agents";
 import { normalizeActor } from "./agent-handle";
@@ -42,6 +42,13 @@ export interface TrailEvent {
 // bumps), so the freshest 30 pages reliably over-fill the list — reading more
 // is wasted I/O on the homepage path.
 const MAX_PAGES_SCANNED = 30;
+
+// Per-page revision cap for the trail. A feed only surfaces a page's most RECENT
+// edits — older ones can't out-rank other pages' activity within the event cap —
+// so reading every revision of every scanned page was the trail's dominant I/O
+// (these pages are agent-maintained and accrue many revisions). Reading the
+// newest few per page bounds it; the dedup window collapses edit bursts anyway.
+const MAX_REVISIONS_PER_PAGE = 20;
 
 /**
  * The public activity trail. For anonymous reads (`principal == null` — the
@@ -174,9 +181,11 @@ export async function trailEventsForPages(
         // Page unreadable — skip its ingests.
       }
 
-      // Edits — attributed revisions.
+      // Edits — attributed revisions. Lighter than listRevisions: no per-revision
+      // stat, and capped to the newest few (the trail's dominant cost was reading
+      // every revision of every scanned page).
       try {
-        const revisions = await listRevisions(page.slug);
+        const revisions = await listRevisionAuthors(page.slug, MAX_REVISIONS_PER_PAGE);
         for (const r of revisions) {
           if (!r.author) continue;
           const actor = normalizeActor(r.author);

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -47,7 +47,8 @@ const MAX_PAGES_SCANNED = 30;
 // edits — older ones can't out-rank other pages' activity within the event cap —
 // so reading every revision of every scanned page was the trail's dominant I/O
 // (these pages are agent-maintained and accrue many revisions). Reading the
-// newest few per page bounds it; the dedup window collapses edit bursts anyway.
+// newest few per page bounds it; the dedup window collapses same-actor edit
+// bursts (within ~2 min) anyway.
 const MAX_REVISIONS_PER_PAGE = 20;
 
 /**
@@ -182,8 +183,8 @@ export async function trailEventsForPages(
       }
 
       // Edits — attributed revisions. Lighter than listRevisions: no per-revision
-      // stat, and capped to the newest few (the trail's dominant cost was reading
-      // every revision of every scanned page).
+      // stat, and capped to the most recent MAX_REVISIONS_PER_PAGE per page (the
+      // trail's dominant cost was reading every revision of every scanned page).
       try {
         const revisions = await listRevisionAuthors(page.slug, MAX_REVISIONS_PER_PAGE);
         for (const r of revisions) {
@@ -202,7 +203,8 @@ export async function trailEventsForPages(
           });
         }
       } catch {
-        // No revisions — skip.
+        // Defensive only: listRevisionAuthors is fail-soft (returns [] on a read
+        // error), so this guards a pathological storage throw — skip these edits.
       }
 
       return evs;


### PR DESCRIPTION
### The measurement (from #640, on prod)
`…/u/yuanhao?debug=perf` — two runs:

| call | run 1 | run 2 |
|---|---|---|
| getPrincipal | 0ms | 0ms |
| slugsForOwner | 0ms | 0ms |
| listReadableWikiPages | 279ms | 348ms |
| **trailEventsForPages** | **11415ms** | **12466ms** |
| listAgentsForOwner | 641ms | 548ms |
| buildContributorProfile | 24ms | 4ms |
| listVaults | 20ms | 6ms |
| getDiscussionStatsForSlugs | 17ms | 5ms |
| **total** | **12396ms** | **13377ms** |

So **`trailEventsForPages` is ~92%** — not `buildContributorProfile` (4ms; #635's index *is* seeded — my earlier blame was wrong). #638 parallelized `listRevisions` *internally*, but the **round-trip count** was the problem.

### Root cause
The trail scans ≤30 of the handle's pages; per page it called `listRevisions`, which does a `stat` **and** a `.meta.json` read for **every** revision. These pages are agent-maintained (reconciles, lint-fixes, re-ingests) and accrue many revisions → **O(total revisions × 2 reads)**. The `stat` only yields `sizeBytes`, which a feed never shows.

### Fix
New `listRevisionAuthors(slug, max)`:
- ranks revisions by **filename timestamp** (zero reads), caps to the newest `max`,
- reads **only** that set's attribution sidecars — **no `stat`**.

The trail uses it with a per-page cap of **20** → **O(pages × min(revisions, 20))**. The cap is sound for a *recent-activity* feed: a page's older edits can't out-rank other pages' activity within the 60-event cap, and the 2-min dedup window already collapses edit bursts. `listRevisions` is untouched (the revision-history UI still needs `sizeBytes`).

### Verify
The `?debug=perf` instrumentation stays in place. After deploy I'll re-pull `…/u/yuanhao?debug=perf` and report the new `trailEventsForPages` number; a follow-up removes the instrumentation (and parallelizes the remaining ~0.9s serial tail of independent calls).

Tests: `listRevisionAuthors` (cap + newest-first, attribution, empty/noise); trail tests repointed. Lint 0 errors, full suite **3186 passed**, both builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)