### PR TITLE
yoyo: remove profile-perf instrumentation + parallelize the profile reads

### DIFF
--- a/src/app/u/[handle]/page.tsx
+++ b/src/app/u/[handle]/page.tsx
@@ -46,34 +46,27 @@ function StatCell({ label, value }: { label: string; value: string | number }) {
 // anyone (guests included) — yopedia is a public observer surface.
 export default async function UserPage({
   params,
-  searchParams,
 }: {
   params: Promise<{ handle: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { handle: encoded } = await params;
   const handle = decodeSlug(encoded);
-  const { debug } = await searchParams;
 
-  // --- TEMP per-call server timing (remove after profile-perf diagnosis) ---
-  // Each await below is an independent storage round-trip whose cost is prod
-  // KV/R2 latency (invisible locally). Measure them on prod to find the real
-  // bottleneck instead of guessing. `?debug=perf` renders the breakdown; a
-  // `[profile-perf]` line is also logged.
-  const perf: Array<[string, number]> = [];
-  const timed = async <T,>(label: string, p: Promise<T>): Promise<T> => {
-    const start = performance.now();
-    try {
-      return await p;
-    } finally {
-      perf.push([label, Math.round(performance.now() - start)]);
-    }
-  };
-  const tStart = performance.now();
+  const principal = await getPrincipal();
+  // These reads are independent (each only needs `handle`/`principal`), so fetch
+  // them concurrently rather than serially — the page is render-blocked on the
+  // SLOWEST, not their sum. (Measured: the serial waterfall was a needless ~1s.)
+  const [mineList, readable, agents, contrib, vaultsAll] = await Promise.all([
+    slugsForOwner(handle),
+    listReadableWikiPages(principal),
+    listAgentsForOwner(handle),
+    // Contribution stats (edits/comments/trust) — moved here from the retired
+    // /wiki/contributors/<handle> page. Shown only when the handle has activity.
+    buildContributorProfile(handle, undefined, principal),
+    listVaults(handle),
+  ]);
 
-  const principal = await timed("getPrincipal", getPrincipal());
-  const mine = new Set(await timed("slugsForOwner", slugsForOwner(handle)));
-  const readable = await timed("listReadableWikiPages", listReadableWikiPages(principal));
+  const mine = new Set(mineList);
   // Newest-first, so the profile reads like a blog index.
   const pages = readable
     .filter((p) => mine.has(p.slug))
@@ -82,39 +75,22 @@ export default async function UserPage({
   // (ingests + edits on those pages); saved HTML artifacts render as cards.
   const commonsPages = pages.filter((p) => belongsInCommons(p));
   const artifacts = pages.filter((p) => isArtifactType(p.type));
-  const trail = await timed("trailEventsForPages", trailEventsForPages(commonsPages, 60));
-  const agents = await timed("listAgentsForOwner", listAgentsForOwner(handle));
-
-  // Contribution stats (edits/comments/trust) — moved here from the retired
-  // /wiki/contributors/<handle> page. Shown only when the handle has activity.
-  const contrib = await timed(
-    "buildContributorProfile",
-    buildContributorProfile(handle, undefined, principal),
-  );
   const hasActivity =
     contrib.editCount > 0 ||
     contrib.commentCount > 0 ||
     contrib.threadsCreated > 0;
-
   // Public vaults this handle owns — their curated reference lenses over the
   // commons. Private vaults are hidden on the public profile.
-  const vaults = (await timed("listVaults", listVaults(handle))).filter(
-    (v) => v.visibility === "public",
-  );
+  const vaults = vaultsAll.filter((v) => v.visibility === "public");
 
-  const statsMap = await timed(
-    "getDiscussionStatsForSlugs",
+  // The remaining two reads depend on the derived page lists above, so they form
+  // a second concurrent tier (the trail dominates; stats overlaps it for free).
+  const [trail, statsMap] = await Promise.all([
+    trailEventsForPages(commonsPages, 60),
     getDiscussionStatsForSlugs(artifacts.map((p) => p.slug)),
-  );
+  ]);
   const discussionStats: Record<string, { total: number; open: number }> = {};
   for (const [slug, stats] of statsMap) discussionStats[slug] = stats;
-
-  const perfTotal = Math.round(performance.now() - tStart);
-  console.log(
-    `[profile-perf] handle=${handle} total=${perfTotal}ms ${perf
-      .map(([k, v]) => `${k}=${v}`)
-      .join(" ")} pages=${pages.length} commons=${commonsPages.length} artifacts=${artifacts.length}`,
-  );
 
   return (
     <main
@@ -124,24 +100,6 @@ export default async function UserPage({
         padding: "56px 24px 88px",
       }}
     >
-      {debug === "perf" && (
-        <pre
-          style={{
-            fontSize: 11,
-            background: "var(--accent-soft)",
-            padding: 12,
-            borderRadius: 6,
-            overflow: "auto",
-            marginBottom: 16,
-          }}
-        >
-          {`PROFILE-PERF-START\ntotal=${perfTotal}ms\n${perf
-            .map(([k, v]) => `${k}=${v}ms`)
-            .join(
-              "\n",
-            )}\npages=${pages.length} commons=${commonsPages.length} artifacts=${artifacts.length}\nPROFILE-PERF-END`}
-        </pre>
-      )}
       <header style={{ marginBottom: 28 }}>
         <Link
           href="/wiki?scope=all"


### PR DESCRIPTION
Closes out the profile-perf work.

### 1. Remove the instrumentation
The `?debug=perf` timing block + `[profile-perf]` log (from #640) did their job — they proved `trailEventsForPages` was ~92% of the load and drove #641/#642. Removed: the `timed()` helper, the `console.log`, the `?debug=perf` `<pre>`, and the now-unused `searchParams`.

### 2. Parallelize the data fetch (free ~1s)
The page made **8 serial `await`s**. `getPrincipal` runs first (others need it); then the five independent reads run concurrently; then the two that depend on the derived page lists run concurrently:
```
getPrincipal
→ Promise.all(slugsForOwner, listReadableWikiPages, listAgentsForOwner, buildContributorProfile, listVaults)
→ Promise.all(trailEventsForPages, getDiscussionStatsForSlugs)
```
Render-blocked on the slowest tier, not the sum. Pure data-fetch reshape — every derivation, filter, and the JSX are unchanged.

### The arc (all measured on prod via the now-removed instrumentation)
| | trail | total |
|---|---|---|
| original | 11.4–12.5s | 12.4–13.4s |
| after #641 (drop wasted stat) | 6.1–6.2s | 6.9–7.1s |
| after #642 (skip-unattributed + cap) | 2.3–2.5s | 3.3–3.4s |
| **after this (parallelize)** | ~2.4s | **~2.5s expected** |

Lint 0 errors, full suite **3188 passed**, both builds clean. I'll confirm the final `curl` time on prod after deploy.

**Still on the table:** the trail (~2.4s) remains the single biggest cost because it's still an `O(your pages)` scan. If you want the profile **sub-second and scale-proof**, the next step is a per-owner activity index (the O(1)-read pattern the homepage already uses). Say the word and I'll build it; otherwise this is a clean 5×-faster stopping point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)