### PR TITLE
yoyo: per-owner activity index — O(1) profile trail (future-proof)

### DIFF
--- a/src/app/u/[handle]/page.tsx
+++ b/src/app/u/[handle]/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { listReadableWikiPages, isArtifactType } from "@/lib/wiki";
+import { listReadableWikiPages, isArtifactType, tenantForOwner } from "@/lib/wiki";
 import { slugsForOwner } from "@/lib/search";
 import { listAgentsForOwner } from "@/lib/agents";
 import { getDiscussionStatsForSlugs } from "@/lib/talk";
@@ -8,7 +8,7 @@ import { listVaults } from "@/lib/vault";
 import { decodeSlug } from "@/lib/slugify";
 import { buildContributorProfile } from "@/lib/contributors";
 import { belongsInCommons } from "@/lib/commons";
-import { trailEventsForPages } from "@/lib/trail";
+import { getOwnerTrail } from "@/lib/trail";
 import { Trail } from "@/components/Trail";
 import { ProfileBlogIndex } from "@/components/ProfileBlogIndex";
 
@@ -84,9 +84,12 @@ export default async function UserPage({
   const vaults = vaultsAll.filter((v) => v.visibility === "public");
 
   // The remaining two reads depend on the derived page lists above, so they form
-  // a second concurrent tier (the trail dominates; stats overlaps it for free).
+  // a second concurrent tier. The trail is served from the per-owner activity
+  // index (O(1) once seeded) keyed by the SAME tenant the write path pushes to
+  // (slugsForOwner matched these pages by `tenantForOwner(handle)`), with the
+  // scan as the cold-start seed + fallback.
   const [trail, statsMap] = await Promise.all([
-    trailEventsForPages(commonsPages, 60),
+    getOwnerTrail(tenantForOwner(handle), commonsPages, 60),
     getDiscussionStatsForSlugs(artifacts.map((p) => p.slug)),
   ]);
   const discussionStats: Record<string, { total: number; open: number }> = {};

--- a/src/lib/__tests__/lifecycle.test.ts
+++ b/src/lib/__tests__/lifecycle.test.ts
@@ -873,6 +873,27 @@ describe("recent trail action labeling", () => {
     expect((await getRecentIndex("tester"))?.some((e) => e.slug === "owned-page")).toBe(false);
     expect((await getRecentIndex())?.some((e) => e.slug === "owned-page")).toBe(false);
   });
+
+  it("fans a write out to a CONTRIBUTOR's index, not just the owner's", async () => {
+    const { getRecentIndex } = await import("../recent-index");
+    await getStorage().putIndex("recent", []);
+    await getStorage().putIndex("recent:owner-x", []);
+    await getStorage().putIndex("recent:contrib-y", []);
+
+    // Owned by owner-x with contrib-y as a contributor → the page shows on BOTH
+    // profiles (slugsForOwner matches owner + contributors), so its activity must
+    // reach BOTH per-tenant indexes — else contrib-y's profile trail goes stale.
+    const content = serializeFrontmatter(
+      { title: "Shared Page", owner: "owner-x", contributors: ["contrib-y"] },
+      "# Shared Page\n\nv1.",
+    );
+    await writeWikiPageWithSideEffects(
+      makeOpts({ slug: "shared-page", title: "Shared Page", author: "owner-x", content }),
+    );
+
+    expect((await getRecentIndex("owner-x"))?.some((e) => e.slug === "shared-page")).toBe(true);
+    expect((await getRecentIndex("contrib-y"))?.some((e) => e.slug === "shared-page")).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/__tests__/lifecycle.test.ts
+++ b/src/lib/__tests__/lifecycle.test.ts
@@ -851,6 +851,28 @@ describe("recent trail action labeling", () => {
     expect(actions).toContain("edited");
     expect(actions).not.toContain("re-ingested");
   });
+
+  it("a delete prunes the page from BOTH the global and the owner's per-tenant index", async () => {
+    const { getRecentIndex } = await import("../recent-index");
+    await getStorage().putIndex("recent", []);
+    await getStorage().putIndex("recent:tester", []); // owner tester's profile index
+
+    // An owned, public commons page → its event routes to recent:tester + global.
+    const content = serializeFrontmatter(
+      { title: "Owned Page", owner: "tester" },
+      "# Owned Page\n\nv1.",
+    );
+    await writeWikiPageWithSideEffects(
+      makeOpts({ slug: "owned-page", title: "Owned Page", author: "tester", content }),
+    );
+    expect((await getRecentIndex("tester"))?.some((e) => e.slug === "owned-page")).toBe(true);
+    expect((await getRecentIndex())?.some((e) => e.slug === "owned-page")).toBe(true);
+
+    // Delete → pruned from BOTH; the per-tenant key is derived from prevContent's owner.
+    await deleteWikiPage("owned-page");
+    expect((await getRecentIndex("tester"))?.some((e) => e.slug === "owned-page")).toBe(false);
+    expect((await getRecentIndex())?.some((e) => e.slug === "owned-page")).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/__tests__/recent-index.test.ts
+++ b/src/lib/__tests__/recent-index.test.ts
@@ -93,6 +93,42 @@ describe("recent-index", () => {
     expect(idx?.map((e) => e.slug)).toEqual(["page-b"]);
   });
 
+  it("pushRecentEvent routes to BOTH the global and the owner's per-tenant index", async () => {
+    await getStorage().putIndex("recent", []);
+    await getStorage().putIndex("recent:alice", []);
+    await pushRecentEvent(ev({ ts: 1000, slug: "page-a", tenant: "alice" }));
+    expect((await getRecentIndex())?.map((e) => e.slug)).toEqual(["page-a"]);
+    expect((await getRecentIndex("alice"))?.map((e) => e.slug)).toEqual(["page-a"]);
+  });
+
+  it("a per-tenant index is independent — its push no-ops until that tenant is seeded", async () => {
+    await getStorage().putIndex("recent", []); // global seeded; alice NOT
+    await pushRecentEvent(ev({ ts: 1000, slug: "page-a", tenant: "alice" }));
+    expect((await getRecentIndex())?.map((e) => e.slug)).toEqual(["page-a"]); // global got it
+    expect(await getRecentIndex("alice")).toBeNull(); // per-tenant still unseeded → no-op
+  });
+
+  it("routes events to the index matching their tenant (owners stay isolated)", async () => {
+    await getStorage().putIndex("recent", []);
+    await getStorage().putIndex("recent:alice", []);
+    await getStorage().putIndex("recent:bob", []);
+    await pushRecentEvent(ev({ ts: 1000, slug: "a1", tenant: "alice" }));
+    await pushRecentEvent(ev({ ts: 2000, slug: "b1", tenant: "bob" }));
+    expect((await getRecentIndex("alice"))?.map((e) => e.slug)).toEqual(["a1"]);
+    expect((await getRecentIndex("bob"))?.map((e) => e.slug)).toEqual(["b1"]);
+    expect((await getRecentIndex())?.map((e) => e.slug)).toEqual(["b1", "a1"]); // global has both
+  });
+
+  it("removeRecentForSlug(slug, tenant) prunes BOTH the global and per-tenant index", async () => {
+    await getStorage().putIndex("recent", []);
+    await getStorage().putIndex("recent:alice", []);
+    await pushRecentEvent(ev({ ts: 1000, slug: "page-a", tenant: "alice" }));
+    await pushRecentEvent(ev({ ts: 2000, slug: "page-b", tenant: "alice" }));
+    await removeRecentForSlug("page-a", "alice");
+    expect((await getRecentIndex())?.map((e) => e.slug)).toEqual(["page-b"]);
+    expect((await getRecentIndex("alice"))?.map((e) => e.slug)).toEqual(["page-b"]);
+  });
+
   it("getTrail serves the index for anonymous reads, capped to limit", async () => {
     await seedEmpty();
     await pushRecentEvent(ev({ ts: 1000, slug: "page-a" }));

--- a/src/lib/__tests__/recent-index.test.ts
+++ b/src/lib/__tests__/recent-index.test.ts
@@ -119,14 +119,41 @@ describe("recent-index", () => {
     expect((await getRecentIndex())?.map((e) => e.slug)).toEqual(["b1", "a1"]); // global has both
   });
 
-  it("removeRecentForSlug(slug, tenant) prunes BOTH the global and per-tenant index", async () => {
+  it("removeRecentForSlug(slug, tenants) prunes the global and each per-tenant index", async () => {
     await getStorage().putIndex("recent", []);
     await getStorage().putIndex("recent:alice", []);
     await pushRecentEvent(ev({ ts: 1000, slug: "page-a", tenant: "alice" }));
     await pushRecentEvent(ev({ ts: 2000, slug: "page-b", tenant: "alice" }));
-    await removeRecentForSlug("page-a", "alice");
+    await removeRecentForSlug("page-a", ["alice"]);
     expect((await getRecentIndex())?.map((e) => e.slug)).toEqual(["page-b"]);
     expect((await getRecentIndex("alice"))?.map((e) => e.slug)).toEqual(["page-b"]);
+  });
+
+  it("fans an event out to owner AND contributor indexes (a contributor's trail stays fresh)", async () => {
+    await getStorage().putIndex("recent", []);
+    await getStorage().putIndex("recent:owner", []);
+    await getStorage().putIndex("recent:contrib", []);
+    // The lifecycle passes [owner, ...contributors] as the routing tenants.
+    await pushRecentEvent(ev({ slug: "shared", tenant: "owner" }), ["owner", "contrib"]);
+    expect((await getRecentIndex("owner"))?.some((e) => e.slug === "shared")).toBe(true);
+    expect((await getRecentIndex("contrib"))?.some((e) => e.slug === "shared")).toBe(true);
+  });
+
+  it("the profile READ key equals the write PUSH key for a normalized owner (end-to-end)", async () => {
+    const { getOwnerTrail } = await import("../trail");
+    const { tenantForOwner } = await import("../wiki");
+    const handle = "Alice Smith"; // tenantForOwner → "alice-smith" (normalized)
+    const tenant = tenantForOwner(handle);
+    await getStorage().putIndex(`recent:${tenant}`, []); // seed the per-owner index
+    // Write path keys by tenantForOwner(owner):
+    await pushRecentEvent(ev({ slug: "page-a", title: "Page A", tenant }), [tenant]);
+    // Read path keys by tenantForOwner(handle) — must resolve to the SAME index:
+    const trail = await getOwnerTrail(
+      tenantForOwner(handle),
+      [{ slug: "page-a", title: "Page A" }],
+      60,
+    );
+    expect(trail.map((e) => e.slug)).toEqual(["page-a"]);
   });
 
   it("getTrail serves the index for anonymous reads, capped to limit", async () => {

--- a/src/lib/__tests__/trail.test.ts
+++ b/src/lib/__tests__/trail.test.ts
@@ -13,18 +13,18 @@ vi.mock("../wiki", () => ({
 }));
 vi.mock("../revisions", () => ({ listRevisionAuthors: vi.fn() }));
 // getOwnerTrail dynamically imports recent-index; mock it to drive index hit/miss.
-vi.mock("../recent-index", () => ({ getRecentIndex: vi.fn(), putRecentIndex: vi.fn() }));
+vi.mock("../recent-index", () => ({ getRecentIndex: vi.fn(), seedRecentIndexIfAbsent: vi.fn() }));
 
 import { trailEventsForPages, getOwnerTrail } from "../trail";
 import { readWikiPageWithFrontmatter } from "../wiki";
 import { listRevisionAuthors } from "../revisions";
-import { getRecentIndex, putRecentIndex } from "../recent-index";
+import { getRecentIndex, seedRecentIndexIfAbsent } from "../recent-index";
 import { logger } from "../logger";
 
 const mockedReadPage = vi.mocked(readWikiPageWithFrontmatter);
 const mockedListRevisionAuthors = vi.mocked(listRevisionAuthors);
 const mockedGetRecentIndex = vi.mocked(getRecentIndex);
-const mockedPutRecentIndex = vi.mocked(putRecentIndex);
+const mockedSeedRecentIndexIfAbsent = vi.mocked(seedRecentIndexIfAbsent);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -174,7 +174,7 @@ describe("getOwnerTrail", () => {
     expect(trail.map((e) => e.slug)).toEqual(["kept"]); // "gone" filtered out
     expect(trail[0].title).toBe("Current Title"); // snapshot title refreshed to live
     expect(mockedReadPage).not.toHaveBeenCalled(); // O(1) read — no scan
-    expect(mockedPutRecentIndex).not.toHaveBeenCalled(); // index hit doesn't re-seed
+    expect(mockedSeedRecentIndexIfAbsent).not.toHaveBeenCalled(); // index hit doesn't re-seed
   });
 
   it("respects the limit when serving the index", async () => {
@@ -207,8 +207,11 @@ describe("getOwnerTrail", () => {
 
     const trail = await getOwnerTrail("alice", [{ slug: "p", title: "P" }], 60);
     expect(trail.length).toBeGreaterThanOrEqual(1); // built from the scan
+    expect(trail[0].slug).toBe("p");
     expect(mockedReadPage).toHaveBeenCalled(); // scanned
-    // Seeded the per-owner index (keyed by tenant) for next time.
-    expect(mockedPutRecentIndex).toHaveBeenCalledWith(expect.any(Array), "alice");
+    // Seeded the per-owner index (keyed by tenant) for next time — and RETURNS
+    // exactly what it seeded (guards against seeding right but returning wrong).
+    expect(mockedSeedRecentIndexIfAbsent).toHaveBeenCalledWith(expect.any(Array), "alice");
+    expect(trail).toEqual(mockedSeedRecentIndexIfAbsent.mock.calls[0][0]);
   });
 });

--- a/src/lib/__tests__/trail.test.ts
+++ b/src/lib/__tests__/trail.test.ts
@@ -12,14 +12,19 @@ vi.mock("../wiki", () => ({
   ownerToTenant: (o?: string) => o ?? "commons",
 }));
 vi.mock("../revisions", () => ({ listRevisionAuthors: vi.fn() }));
+// getOwnerTrail dynamically imports recent-index; mock it to drive index hit/miss.
+vi.mock("../recent-index", () => ({ getRecentIndex: vi.fn(), putRecentIndex: vi.fn() }));
 
-import { trailEventsForPages } from "../trail";
+import { trailEventsForPages, getOwnerTrail } from "../trail";
 import { readWikiPageWithFrontmatter } from "../wiki";
 import { listRevisionAuthors } from "../revisions";
+import { getRecentIndex, putRecentIndex } from "../recent-index";
 import { logger } from "../logger";
 
 const mockedReadPage = vi.mocked(readWikiPageWithFrontmatter);
 const mockedListRevisionAuthors = vi.mocked(listRevisionAuthors);
+const mockedGetRecentIndex = vi.mocked(getRecentIndex);
+const mockedPutRecentIndex = vi.mocked(putRecentIndex);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -138,5 +143,72 @@ describe("trailEventsForPages — actor normalization", () => {
     expect(events).toHaveLength(1); // the edit event survives the read failure
     expect(events[0].commons).toBe(false);
     expect(warn).toHaveBeenCalled(); // the unexpected read error is surfaced
+  });
+});
+
+describe("getOwnerTrail", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ev = (over: Record<string, unknown>): any => ({
+    ts: 1000,
+    when: "2026-06-10T00:00:00.000Z",
+    actor: "alice",
+    isAgent: false,
+    action: "edited",
+    slug: "page-a",
+    title: "Page A",
+    tenant: "alice",
+    commons: true,
+    ...over,
+  });
+
+  it("serves the per-owner index — filtering to current commons pages + refreshing titles, no scan", async () => {
+    mockedGetRecentIndex.mockResolvedValue([
+      ev({ ts: 3000, slug: "kept", title: "Stale Snapshot Title" }),
+      ev({ ts: 2000, slug: "gone" }), // not in commonsPages → deleted/private → dropped
+    ]);
+    const trail = await getOwnerTrail(
+      "alice",
+      [{ slug: "kept", title: "Current Title" }],
+      60,
+    );
+    expect(trail.map((e) => e.slug)).toEqual(["kept"]); // "gone" filtered out
+    expect(trail[0].title).toBe("Current Title"); // snapshot title refreshed to live
+    expect(mockedReadPage).not.toHaveBeenCalled(); // O(1) read — no scan
+    expect(mockedPutRecentIndex).not.toHaveBeenCalled(); // index hit doesn't re-seed
+  });
+
+  it("respects the limit when serving the index", async () => {
+    mockedGetRecentIndex.mockResolvedValue([
+      ev({ ts: 3000, slug: "a", title: "A" }),
+      ev({ ts: 2000, slug: "b", title: "B" }),
+    ]);
+    const trail = await getOwnerTrail(
+      "alice",
+      [
+        { slug: "a", title: "A" },
+        { slug: "b", title: "B" },
+      ],
+      1,
+    );
+    expect(trail.map((e) => e.slug)).toEqual(["a"]);
+  });
+
+  it("falls back to the scan and lazily seeds the index when it's absent", async () => {
+    mockedGetRecentIndex.mockResolvedValue(null); // unseeded
+    mockedReadPage.mockResolvedValue({
+      frontmatter: {
+        sources: JSON.stringify([
+          { type: "url", url: "https://e.com", fetched: "2026-06-10T00:00:00.000Z", triggered_by: "alice" },
+        ]),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    mockedListRevisionAuthors.mockResolvedValue([]);
+
+    const trail = await getOwnerTrail("alice", [{ slug: "p", title: "P" }], 60);
+    expect(trail.length).toBeGreaterThanOrEqual(1); // built from the scan
+    expect(mockedReadPage).toHaveBeenCalled(); // scanned
+    // Seeded the per-owner index (keyed by tenant) for next time.
+    expect(mockedPutRecentIndex).toHaveBeenCalledWith(expect.any(Array), "alice");
   });
 });

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -26,7 +26,7 @@ import { getErrorMessage } from "./errors";
 import { removeAliasForPage, updateAliasIndexForPage } from "./alias-index";
 import { removeSourceForPage } from "./source-index";
 import { syncCommonsForPage, removeCommonsEntryBySlug, belongsInCommons } from "./commons";
-import { syncOwnerIndexForPage, removeOwnerIndexForSlug } from "./owner-index";
+import { syncOwnerIndexForPage, removeOwnerIndexForSlug, tenantsForPage } from "./owner-index";
 import { syncBacklinksForPage, removeBacklinksForSlug } from "./backlink-index";
 import { recordEditForAuthor } from "./contributor-index";
 import { pushRecentEvent, removeRecentForSlug } from "./recent-index";
@@ -225,6 +225,7 @@ async function runPageLifecycleOp(
   // Capture the deleted page's owner BEFORE removing it, so step 3c knows which
   // tenant silo to mirror the removal into (the flat file is gone afterward).
   let deletedOwner: string | undefined;
+  let deletedContributors: string[] = [];
 
   // Capture the page's PREVIOUS content before overwrite so the backlink index
   // can diff outbound links (write path). undefined for a brand-new page.
@@ -246,8 +247,13 @@ async function runPageLifecycleOp(
         typeof pre?.frontmatter.owner === "string"
           ? pre.frontmatter.owner
           : undefined;
+      deletedContributors = Array.isArray(pre?.frontmatter.contributors)
+        ? (pre.frontmatter.contributors as unknown[]).filter(
+            (c): c is string => typeof c === "string",
+          )
+        : [];
     } catch {
-      // Owner unknown → falls back to the default tenant in step 3c.
+      // Owner/contributors unknown → falls back to the default tenant in step 3c.
     }
     try {
       await getStorage().deleteFile(wikiRelPath(`${slug}.md`));
@@ -459,11 +465,13 @@ async function runPageLifecycleOp(
   //        the daily rebuild has seeded the index. Fail-soft.
   try {
     if (op.kind === "delete") {
-      // Prune the owner's per-tenant index too, keyed the SAME way the push (and
-      // the silo cleanup at removeSiloForPage) derive it. `deletedOwner` was
-      // captured before the file was removed; tenantForOwner maps an unknown
-      // owner to the default tenant — exactly where its events were pushed.
-      await removeRecentForSlug(slug, tenantForOwner(deletedOwner));
+      // Prune every per-tenant index the page's events were pushed to — its owner
+      // AND every contributor (the SAME fan-out as the push and owner-index), so a
+      // contributor's profile trail doesn't retain a deleted page. `deletedOwner`/
+      // `deletedContributors` were captured before the file was removed.
+      await removeRecentForSlug(slug, [
+        ...tenantsForPage(deletedOwner, deletedContributors),
+      ]);
     } else if (op.author) {
       const fm = parseFrontmatter(op.content).data;
       const isCommons = belongsInCommons({
@@ -485,29 +493,37 @@ async function runPageLifecycleOp(
         // Fold automation actors (system / lint-fix / yopedia) into the agent so
         // the incrementally-pushed event matches the scan/index normalization.
         const actor = normalizeActor(op.author);
-        await pushRecentEvent({
-          ts: now,
-          when: new Date(now).toISOString(),
-          actor,
-          isAgent: isAgentHandle(actor),
-          // An ingest onto a page that already existed is a re-ingest — label
-          // it distinctly (prevContent is undefined only for a brand-new page).
-          action:
-            logOp === "ingest"
-              ? prevContent
-                ? "re-ingested"
-                : "ingested"
-              : "edited",
-          ...(sourceType ? { sourceType } : {}),
-          slug,
-          title: op.title,
-          tenant: tenantForOwner(
-            typeof fm.owner === "string" ? fm.owner : undefined,
-          ),
-          // This push is gated by `isCommons` above, so the page is, by
-          // construction, a public commons page → links at `/wiki/<slug>`.
-          commons: true,
-        });
+        const owner = typeof fm.owner === "string" ? fm.owner : undefined;
+        const contributors = Array.isArray(fm.contributors)
+          ? (fm.contributors as unknown[]).filter((c): c is string => typeof c === "string")
+          : undefined;
+        await pushRecentEvent(
+          {
+            ts: now,
+            when: new Date(now).toISOString(),
+            actor,
+            isAgent: isAgentHandle(actor),
+            // An ingest onto a page that already existed is a re-ingest — label
+            // it distinctly (prevContent is undefined only for a brand-new page).
+            action:
+              logOp === "ingest"
+                ? prevContent
+                  ? "re-ingested"
+                  : "ingested"
+                : "edited",
+            ...(sourceType ? { sourceType } : {}),
+            slug,
+            title: op.title,
+            // The event's tenant is the OWNER's (the canonical /wiki/<slug> link).
+            tenant: tenantForOwner(owner),
+            // This push is gated by `isCommons` above, so the page is, by
+            // construction, a public commons page → links at `/wiki/<slug>`.
+            commons: true,
+          },
+          // …but route it into EVERY relevant profile index: owner + contributors,
+          // so a contributor's trail stays fresh too (mirrors the owner-index).
+          [...tenantsForPage(owner, contributors)],
+        );
       }
     }
   } catch (err) {

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -459,7 +459,11 @@ async function runPageLifecycleOp(
   //        the daily rebuild has seeded the index. Fail-soft.
   try {
     if (op.kind === "delete") {
-      await removeRecentForSlug(slug);
+      // Prune the owner's per-tenant index too, keyed the SAME way the push (and
+      // the silo cleanup at removeSiloForPage) derive it. `deletedOwner` was
+      // captured before the file was removed; tenantForOwner maps an unknown
+      // owner to the default tenant — exactly where its events were pushed.
+      await removeRecentForSlug(slug, tenantForOwner(deletedOwner));
     } else if (op.author) {
       const fm = parseFrontmatter(op.content).data;
       const isCommons = belongsInCommons({

--- a/src/lib/owner-index.ts
+++ b/src/lib/owner-index.ts
@@ -50,8 +50,13 @@ async function putOwnerIndex(idx: OwnerIndex): Promise<void> {
   await getStorage().putIndex(OWNER_INDEX_KEY, idx);
 }
 
-/** Tenants a page belongs to: its owner's tenant + every contributor's tenant. */
-function tenantsForPage(owner?: string, contributors?: string[]): Set<string> {
+/**
+ * Tenants a page belongs to: its owner's tenant + every contributor's tenant.
+ * Exported so the recent-activity index fans a page's events out to the SAME
+ * tenant set this index uses — keeping `slugsForOwner` (read) and the per-owner
+ * trail (write) keyed identically, so a contributor's profile stays fresh too.
+ */
+export function tenantsForPage(owner?: string, contributors?: string[]): Set<string> {
   const tenants = new Set<string>();
   tenants.add(tenantForOwner(owner));
   for (const c of contributors ?? []) {

--- a/src/lib/recent-index.ts
+++ b/src/lib/recent-index.ts
@@ -22,25 +22,42 @@ const MAX_RECENT = 60;
 /** Collapse near-duplicate events (same actor+action+page within ~2 min). */
 const DEDUP_WINDOW_MS = 120_000;
 
+// Two flavors share one set of machinery: the GLOBAL list (`recent`, the
+// homepage Trail) and PER-OWNER lists (`recent:<tenant>`, each owner's profile
+// trail). A per-owner list is the O(1) read that replaces the profile's
+// O(pages × revisions) scan — lazily seeded on first profile view and kept fresh
+// by the same push/remove below (every write already carries the page's
+// `tenant`). `tenant` undefined ⇒ the global list.
+function recentKey(tenant?: string): string {
+  return tenant ? `${RECENT_KEY}:${tenant}` : RECENT_KEY;
+}
+function recentLock(tenant?: string): string {
+  return tenant ? `${RECENT_LOCK}:${tenant}` : RECENT_LOCK;
+}
+
 /**
- * The recent-activity list, newest-first — or `null` when the index has never
- * been seeded (caller should fall back to {@link scanTrail}). Distinguishing
- * "absent" (`null`) from "seeded but empty" (`[]`) is what prevents a single
- * write from seeding a misleading partial list.
+ * The recent-activity list, newest-first — global, or for one `tenant`. `null`
+ * when that index has never been seeded (caller should fall back to a scan).
+ * Distinguishing "absent" (`null`) from "seeded but empty" (`[]`) is what
+ * prevents a single write from seeding a misleading partial list.
  */
-export async function getRecentIndex(): Promise<TrailEvent[] | null> {
+export async function getRecentIndex(tenant?: string): Promise<TrailEvent[] | null> {
   try {
-    const idx = await getStorage().getIndex<TrailEvent[]>(RECENT_KEY);
+    const idx = await getStorage().getIndex<TrailEvent[]>(recentKey(tenant));
     if (!Array.isArray(idx)) return null;
     return idx;
   } catch (err) {
-    logger.warn("recent-index", "read failed; falling back to scan", err);
+    logger.warn("recent-index", `read failed (${tenant ?? "global"}); falling back to scan`, err);
     return null;
   }
 }
 
-async function putRecentIndex(events: TrailEvent[]): Promise<void> {
-  await getStorage().putIndex(RECENT_KEY, events.slice(0, MAX_RECENT));
+/**
+ * Seed/overwrite an index (global or per-`tenant`) — used by the global daily
+ * rebuild and the per-owner lazy seed. Capped at {@link MAX_RECENT}.
+ */
+export async function putRecentIndex(events: TrailEvent[], tenant?: string): Promise<void> {
+  await getStorage().putIndex(recentKey(tenant), events.slice(0, MAX_RECENT));
 }
 
 /**
@@ -48,10 +65,12 @@ async function putRecentIndex(events: TrailEvent[]): Promise<void> {
  * daily rebuild seeds it) — we never fabricate a partial recent list from one
  * write, which would hide all prior activity until the next rebuild.
  */
-export async function pushRecentEvent(event: TrailEvent): Promise<void> {
-  await withFileLock(RECENT_LOCK, async () => {
-    const idx = await getRecentIndex();
-    if (idx === null) return; // not seeded yet — daily rebuild will seed it
+/** Push `event` to the front of ONE index (global or per-tenant). No-op until
+ *  that index is seeded — we never fabricate a partial list from a single write. */
+async function pushToIndex(tenant: string | undefined, event: TrailEvent): Promise<void> {
+  await withFileLock(recentLock(tenant), async () => {
+    const idx = await getRecentIndex(tenant);
+    if (idx === null) return; // not seeded yet
     const deduped = idx.filter(
       (d) =>
         !(
@@ -63,18 +82,38 @@ export async function pushRecentEvent(event: TrailEvent): Promise<void> {
     );
     deduped.unshift(event);
     deduped.sort((a, b) => b.ts - a.ts);
-    await putRecentIndex(deduped);
+    await putRecentIndex(deduped, tenant);
   });
 }
 
-/** Drop every event for a slug (page deleted). No-op until seeded. */
-export async function removeRecentForSlug(slug: string): Promise<void> {
-  await withFileLock(RECENT_LOCK, async () => {
-    const idx = await getRecentIndex();
+/**
+ * Push a new activity event to BOTH the global list and the page-owner's
+ * per-tenant list. Each NO-OPS until its own index is seeded (the daily rebuild
+ * seeds the global one; the first profile view seeds the per-owner one), so we
+ * never fabricate a partial list that would hide all prior activity.
+ */
+export async function pushRecentEvent(event: TrailEvent): Promise<void> {
+  await pushToIndex(undefined, event);
+  if (event.tenant) await pushToIndex(event.tenant, event);
+}
+
+/** Drop every event for a slug from ONE index. No-op until seeded. */
+async function removeFromIndex(tenant: string | undefined, slug: string): Promise<void> {
+  await withFileLock(recentLock(tenant), async () => {
+    const idx = await getRecentIndex(tenant);
     if (idx === null) return;
     const next = idx.filter((e) => e.slug !== slug);
-    if (next.length !== idx.length) await putRecentIndex(next);
+    if (next.length !== idx.length) await putRecentIndex(next, tenant);
   });
+}
+
+/**
+ * Drop every event for a slug (page deleted) from the global list and, when the
+ * owner's `tenant` is known, that owner's per-tenant list. No-op until seeded.
+ */
+export async function removeRecentForSlug(slug: string, tenant?: string): Promise<void> {
+  await removeFromIndex(undefined, slug);
+  if (tenant) await removeFromIndex(tenant, slug);
 }
 
 /** Reconstruct the recent list from the authoritative scan (daily self-heal). */

--- a/src/lib/recent-index.ts
+++ b/src/lib/recent-index.ts
@@ -65,12 +65,30 @@ export async function putRecentIndex(events: TrailEvent[], tenant?: string): Pro
  * daily rebuild seeds it) — we never fabricate a partial recent list from one
  * write, which would hide all prior activity until the next rebuild.
  */
+/**
+ * Read an index for a MUTATION (push/remove). Like {@link getRecentIndex} it
+ * returns `null` for an absent index, but it logs a genuine read FAULT
+ * distinctly — the read-path's "falling back to scan" message is false here. A
+ * push/remove that can't read the current list NO-OPS (it can't safely append to
+ * a list it didn't read); the next cold seed / daily rebuild reconciles. Both
+ * "absent" and "faulted" return `null`, so the caller no-ops either way.
+ */
+async function readForMutation(tenant?: string): Promise<TrailEvent[] | null> {
+  try {
+    const idx = await getStorage().getIndex<TrailEvent[]>(recentKey(tenant));
+    return Array.isArray(idx) ? idx : null;
+  } catch (err) {
+    logger.warn("recent-index", `read failed during update (${tenant ?? "global"}); skipping`, err);
+    return null;
+  }
+}
+
 /** Push `event` to the front of ONE index (global or per-tenant). No-op until
  *  that index is seeded — we never fabricate a partial list from a single write. */
 async function pushToIndex(tenant: string | undefined, event: TrailEvent): Promise<void> {
   await withFileLock(recentLock(tenant), async () => {
-    const idx = await getRecentIndex(tenant);
-    if (idx === null) return; // not seeded yet
+    const idx = await readForMutation(tenant);
+    if (idx === null) return; // not seeded (or unreadable) — skip
     const deduped = idx.filter(
       (d) =>
         !(
@@ -87,20 +105,46 @@ async function pushToIndex(tenant: string | undefined, event: TrailEvent): Promi
 }
 
 /**
- * Push a new activity event to BOTH the global list and the page-owner's
- * per-tenant list. Each NO-OPS until its own index is seeded (the daily rebuild
- * seeds the global one; the first profile view seeds the per-owner one), so we
- * never fabricate a partial list that would hide all prior activity.
+ * Push a new activity event to the global list AND to every per-owner list the
+ * page belongs to — its owner's tenant plus each contributor's tenant (`tenants`,
+ * the SAME set owner-index/slugsForOwner use). Pushing only to the owner would
+ * leave a CONTRIBUTOR's profile trail permanently stale for that page after its
+ * index is seeded. Each index NO-OPS until its own is seeded (the daily rebuild
+ * seeds the global one; the first profile view seeds a per-owner one).
  */
-export async function pushRecentEvent(event: TrailEvent): Promise<void> {
+export async function pushRecentEvent(
+  event: TrailEvent,
+  tenants: string[] = event.tenant ? [event.tenant] : [],
+): Promise<void> {
   await pushToIndex(undefined, event);
-  if (event.tenant) await pushToIndex(event.tenant, event);
+  const seen = new Set<string>();
+  for (const tenant of tenants) {
+    if (tenant && !seen.has(tenant)) {
+      seen.add(tenant);
+      await pushToIndex(tenant, event);
+    }
+  }
+}
+
+/**
+ * Seed a per-owner index from a scan, but ONLY if it's still absent and under the
+ * tenant's lock — so a concurrent push (or another cold view's seed) isn't
+ * clobbered by an unlocked overwrite (a lost update).
+ */
+export async function seedRecentIndexIfAbsent(
+  events: TrailEvent[],
+  tenant: string,
+): Promise<void> {
+  await withFileLock(recentLock(tenant), async () => {
+    if ((await getRecentIndex(tenant)) !== null) return; // already seeded / a push beat us
+    await putRecentIndex(events, tenant);
+  });
 }
 
 /** Drop every event for a slug from ONE index. No-op until seeded. */
 async function removeFromIndex(tenant: string | undefined, slug: string): Promise<void> {
   await withFileLock(recentLock(tenant), async () => {
-    const idx = await getRecentIndex(tenant);
+    const idx = await readForMutation(tenant);
     if (idx === null) return;
     const next = idx.filter((e) => e.slug !== slug);
     if (next.length !== idx.length) await putRecentIndex(next, tenant);
@@ -108,12 +152,18 @@ async function removeFromIndex(tenant: string | undefined, slug: string): Promis
 }
 
 /**
- * Drop every event for a slug (page deleted) from the global list and, when the
- * owner's `tenant` is known, that owner's per-tenant list. No-op until seeded.
+ * Drop every event for a slug (page deleted) from the global list and each of the
+ * page's per-owner lists (`tenants` = owner + contributors). No-op until seeded.
  */
-export async function removeRecentForSlug(slug: string, tenant?: string): Promise<void> {
+export async function removeRecentForSlug(slug: string, tenants: string[] = []): Promise<void> {
   await removeFromIndex(undefined, slug);
-  if (tenant) await removeFromIndex(tenant, slug);
+  const seen = new Set<string>();
+  for (const tenant of tenants) {
+    if (tenant && !seen.has(tenant)) {
+      seen.add(tenant);
+      await removeFromIndex(tenant, slug);
+    }
+  }
 }
 
 /** Reconstruct the recent list from the authoritative scan (daily self-heal). */

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -100,17 +100,20 @@ async function withCurrentTitles(
  * O(pages × revisions) scan into a single KV read once warm.
  *
  * `commonsPages` is the owner's CURRENT public commons pages (the caller already
- * has them). Index events are reconciled against it on every read: any whose
- * page is gone (deleted) or no longer a public commons page (turned private)
- * is dropped, and snapshot titles are refreshed to the live title — so the index
- * only needs to be append-fresh (push on write), not perfectly pruned.
+ * has them). Index events are reconciled against it on every read: any whose page
+ * is gone (deleted) or no longer a public commons page (turned private) is dropped
+ * at the PAGE level, and snapshot titles are refreshed to the live title. So the
+ * index only needs to be append-correct — the write path fans each event out to
+ * every owner+contributor tenant, and reads handle page-level removal/renames. It
+ * does NOT (and need not) heal a still-public page's events: events are only ever
+ * appended, never individually invalidated, so there's nothing to reconcile there.
  */
 export async function getOwnerTrail(
   tenant: string,
   commonsPages: { slug: string; title: string; owner?: string }[],
   limit: number,
 ): Promise<TrailEvent[]> {
-  const { getRecentIndex, putRecentIndex } = await import("./recent-index");
+  const { getRecentIndex, seedRecentIndexIfAbsent } = await import("./recent-index");
   const idx = await getRecentIndex(tenant);
   if (idx !== null) {
     const titleBySlug = new Map(commonsPages.map((p) => [p.slug, p.title]));
@@ -122,11 +125,12 @@ export async function getOwnerTrail(
       })
       .slice(0, limit);
   }
-  // Cold: scan, then lazily seed the per-owner index for next time (fail-soft —
+  // Cold: scan, then lazily seed the per-owner index for next time (under the
+  // tenant lock + only-if-absent, so a racing push isn't clobbered; fail-soft —
   // a seed failure just means the next view scans again).
   const events = await trailEventsForPages(commonsPages, limit);
   try {
-    await putRecentIndex(events, tenant);
+    await seedRecentIndexIfAbsent(events, tenant);
   } catch (err) {
     logger.warn("recent-index", `owner trail seed skipped for "${tenant}":`, err);
   }

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -93,6 +93,47 @@ async function withCurrentTitles(
 }
 
 /**
+ * The activity trail for ONE owner's profile (the pages a `tenant` owns). Serves
+ * the per-owner `recent:<tenant>` index in O(1) when seeded, falling back to the
+ * {@link trailEventsForPages} scan and lazily seeding the index from it. This is
+ * the profile's analogue of {@link getTrail} for the homepage — it turns an
+ * O(pages × revisions) scan into a single KV read once warm.
+ *
+ * `commonsPages` is the owner's CURRENT public commons pages (the caller already
+ * has them). Index events are reconciled against it on every read: any whose
+ * page is gone (deleted) or no longer a public commons page (turned private)
+ * is dropped, and snapshot titles are refreshed to the live title — so the index
+ * only needs to be append-fresh (push on write), not perfectly pruned.
+ */
+export async function getOwnerTrail(
+  tenant: string,
+  commonsPages: { slug: string; title: string; owner?: string }[],
+  limit: number,
+): Promise<TrailEvent[]> {
+  const { getRecentIndex, putRecentIndex } = await import("./recent-index");
+  const idx = await getRecentIndex(tenant);
+  if (idx !== null) {
+    const titleBySlug = new Map(commonsPages.map((p) => [p.slug, p.title]));
+    return idx
+      .filter((e) => titleBySlug.has(e.slug)) // drop deleted / now-private pages
+      .map((e) => {
+        const current = titleBySlug.get(e.slug);
+        return current && current !== e.title ? { ...e, title: current } : e;
+      })
+      .slice(0, limit);
+  }
+  // Cold: scan, then lazily seed the per-owner index for next time (fail-soft —
+  // a seed failure just means the next view scans again).
+  const events = await trailEventsForPages(commonsPages, limit);
+  try {
+    await putRecentIndex(events, tenant);
+  } catch (err) {
+    logger.warn("recent-index", `owner trail seed skipped for "${tenant}":`, err);
+  }
+  return events;
+}
+
+/**
  * Build the activity trail by merging recent ingests (from each page's
  * `sources[]` provenance) and edits (from revision metadata) into one
  * time-sorted feed. Agent-scoped pages are excluded; agent *actors* are kept


### PR DESCRIPTION
The finish line for the profile-perf work you asked to take all the way. After #641–#643 the profile was ~2.5s, but the trail was still an **O(your pages)** scan (~2.4s for 21 pages — and it grows with page count). This gives it the same **O(1)-read** treatment the homepage Trail already uses.

### Design
The homepage serves its trail from a precomputed `recent` index (one KV read). I generalized that index to be **per-owner**:

- **`recent-index.ts`** — parameterized by an optional `tenant`. Keys: `recent` (global) and `recent:<tenant>` (one per owner). `pushRecentEvent` writes **both** the global list and the page-owner's list (each no-ops until seeded); `removeRecentForSlug(slug, tenant)` prunes both.
- **`trail.ts` → `getOwnerTrail(tenant, commonsPages, limit)`** — serves `recent:<tenant>` in one KV read, **reconciled against the caller's current `commonsPages` on read**: events for deleted / now-private pages are dropped and snapshot titles refreshed. So the index only needs to be *append-fresh*, not perfectly pruned. Falls back to the `trailEventsForPages` scan + lazily seeds the index when absent.
- **profile page** — `getOwnerTrail(tenantForOwner(handle), …)`. The key matches the push **exactly**: `slugsForOwner` already matches a profile's pages by `tenantForOwner(handle)`, and `tenantForOwner === ownerToTenant`.
- **lifecycle delete** — prunes the owner's per-tenant index too, keyed by the same `deletedOwner`/`tenantForOwner` the silo cleanup already uses.

### Why it's correct (and self-healing)
| change | handled by |
|---|---|
| new ingest/edit | `pushRecentEvent` → both indexes (fresh immediately) |
| delete | `removeRecentForSlug(slug, tenant)` on the delete path |
| page turned private / title changed | **read-time filter** against current `commonsPages` |
| cold start / never seeded | scan fallback + lazy seed |
| rare fail-soft missed push | re-seeds whenever the index is absent (only residual drift) |

### Perf
Once seeded, the trail is **one KV read** instead of the page-scan — the profile should drop from ~2.5s to **sub-second**, and it no longer scales with the owner's page count.

Tests: per-tenant routing / isolation / independence / prune (`recent-index`), `getOwnerTrail` index-hit (filter + title refresh, no scan) / limit / cold-seed (`trail`), and a `lifecycle` delete that prunes **both** indexes. Lint 0 errors, full suite **3196 passed**, both builds clean.

I'll confirm the live `curl` time after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)