### PR TITLE
yoyo: harden LLM query endpoints to signed-in-only (defense-in-depth)

### DIFF
--- a/src/app/api/query/route.ts
+++ b/src/app/api/query/route.ts
@@ -50,11 +50,24 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Querying invokes the LLM (a real cost), so it's signed-in-only. The
+    // middleware write-gate already 401s anonymous POSTs to /api/**; this is
+    // defense-in-depth at the cost-critical endpoint so a future middleware/
+    // matcher change can't silently open free anonymous querying. (Agents query
+    // via MCP — query() directly — not this route, so this doesn't gate them.)
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json(
+        { error: "Sign in required to query yopedia." },
+        { status: 401 },
+      );
+    }
+
     const result = await query(
       question.trim(),
       parseFormat(format),
       scope || undefined,
-      await getPrincipal(),
+      principal,
     );
 
     return NextResponse.json(result);

--- a/src/app/api/query/stream/route.ts
+++ b/src/app/api/query/stream/route.ts
@@ -60,7 +60,19 @@ export async function POST(request: NextRequest) {
     }
 
     const trimmedQuestion = question.trim();
+
+    // Querying invokes the LLM (a real cost), so it's signed-in-only. The
+    // middleware write-gate already 401s anonymous POSTs to /api/**; this is
+    // defense-in-depth at the cost-critical endpoint so a future middleware/
+    // matcher change can't silently open free anonymous querying. (Agents query
+    // via MCP — query() directly — not this route, so this doesn't gate them.)
     const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json(
+        { error: "Sign in required to query yopedia." },
+        { status: 401 },
+      );
+    }
 
     // Resolve scope to a set of slugs (handles the "mine" lens; empty "mine"
     // falls back to the full commons).

--- a/src/lib/__tests__/middleware-write-gate.test.ts
+++ b/src/lib/__tests__/middleware-write-gate.test.ts
@@ -40,6 +40,16 @@ describe("write-gate in-route auth exemptions", () => {
     expect(authenticatesInRoute("/api/wiki/transformers/discuss")).toBe(false);
   });
 
+  it("does NOT exempt the LLM query endpoints — they stay signed-in-only", () => {
+    // Querying costs a real LLM call. These are POST routes that must NOT be
+    // added to the in-route exemption list, or the write-gate would stop 401ing
+    // anonymous callers and free querying would open up. (The routes also self-
+    // guard on a null principal as defense-in-depth.) The only public query path
+    // is GET /api/query/demo — whitelisted to 3 questions + KV-cached.
+    expect(authenticatesInRoute("/api/query")).toBe(false);
+    expect(authenticatesInRoute("/api/query/stream")).toBe(false);
+  });
+
   it("exempts wiki revisions sub-route for service-token callers", () => {
     expect(authenticatesInRoute("/api/wiki/transformers/revisions")).toBe(true);
     expect(authenticatesInRoute("/api/wiki/test-slug/revisions")).toBe(true);

--- a/src/lib/__tests__/query-route.test.ts
+++ b/src/lib/__tests__/query-route.test.ts
@@ -4,15 +4,17 @@ import { NextRequest } from "next/server";
 vi.mock("@/lib/query", () => ({
   query: vi.fn(async () => ({ answer: "ok", sources: [] })),
 }));
-vi.mock("@/lib/auth", () => ({ getPrincipal: vi.fn(async () => null) }));
+vi.mock("@/lib/auth", () => ({ getPrincipal: vi.fn() }));
 vi.mock("@/lib/logger", () => ({
   logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn() },
 }));
 
 import { query } from "@/lib/query";
+import { getPrincipal } from "@/lib/auth";
 import { POST } from "@/app/api/query/route";
 
 const mockedQuery = vi.mocked(query);
+const mockedGetPrincipal = vi.mocked(getPrincipal);
 
 function makeRequest(body: unknown): NextRequest {
   return new NextRequest("http://localhost/api/query", {
@@ -22,7 +24,13 @@ function makeRequest(body: unknown): NextRequest {
   });
 }
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: a signed-in user — the middleware already guarantees this for any
+  // POST /api/query, so the route's own guard passes and we exercise the body.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockedGetPrincipal.mockResolvedValue({ handle: "tester" } as any);
+});
 
 describe("POST /api/query — format validation", () => {
   it("accepts format:'html' and threads it to query()", async () => {
@@ -44,5 +52,15 @@ describe("POST /api/query — format validation", () => {
     expect(res.status).toBe(400);
     expect((await res.json()).error).toMatch(/format must be/);
     expect(mockedQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/query — auth (LLM cost gate)", () => {
+  it("401s an unauthenticated caller and never runs the LLM query", async () => {
+    mockedGetPrincipal.mockResolvedValueOnce(null); // anonymous
+    const res = await POST(makeRequest({ question: "what is A?", format: "prose" }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toMatch(/sign in/i);
+    expect(mockedQuery).not.toHaveBeenCalled(); // no LLM call for anonymous
   });
 });

--- a/src/lib/__tests__/query-stream-route.test.ts
+++ b/src/lib/__tests__/query-stream-route.test.ts
@@ -11,9 +11,7 @@ vi.mock("@/lib/logger", () => ({
   logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn() },
 }));
 
-vi.mock("@/lib/auth", () => ({
-  getPrincipal: vi.fn(async () => ({ id: "u", handle: "u" })),
-}));
+vi.mock("@/lib/auth", () => ({ getPrincipal: vi.fn() }));
 
 vi.mock("@/lib/search", () => ({
   // Default to UNSCOPED; individual tests override per scope.
@@ -44,11 +42,13 @@ vi.mock("@/lib/query", () => ({
 import { listReadableWikiPages } from "@/lib/wiki";
 import { resolveScopeSlugs } from "@/lib/search";
 import { selectPagesForQuery } from "@/lib/query";
+import { getPrincipal } from "@/lib/auth";
 import { POST } from "@/app/api/query/stream/route";
 
 const mockedList = vi.mocked(listReadableWikiPages);
 const mockedScope = vi.mocked(resolveScopeSlugs);
 const mockedSelect = vi.mocked(selectPagesForQuery);
+const mockedGetPrincipal = vi.mocked(getPrincipal);
 
 const ENTRIES = [
   { slug: "concept-a", title: "A", summary: "", type: undefined },
@@ -68,6 +68,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockedList.mockResolvedValue(ENTRIES);
   mockedScope.mockResolvedValue({ scopeSlugs: undefined });
+  // Default: a signed-in user (the middleware guarantees a session for POST).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockedGetPrincipal.mockResolvedValue({ id: "u", handle: "u" } as any);
 });
 
 describe("POST /api/query/stream — agent-scope filtering (#413)", () => {
@@ -115,6 +118,15 @@ describe("POST /api/query/stream — agent-scope filtering (#413)", () => {
   it("rejects an invalid format with 400", async () => {
     const res = await POST(makeRequest({ question: "?", format: "bogus" }));
     expect(res.status).toBe(400);
+    expect(mockedSelect).not.toHaveBeenCalled();
+  });
+
+  it("401s an unauthenticated caller and never selects pages / calls the LLM", async () => {
+    mockedGetPrincipal.mockResolvedValueOnce(null); // anonymous
+    const res = await POST(makeRequest({ question: "what is A?" }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toMatch(/sign in/i);
+    // Stopped before any expensive work — no page selection, no LLM stream.
     expect(mockedSelect).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Now that `yopedia.yolog.dev` is public, this locks down the cost-critical query path so anonymous traffic can't run up the LLM bill.

### Current state (already gated — verified)
- **Real queries** are `POST /api/query` and `POST /api/query/stream`. The middleware write-gate 401s any unauthenticated POST to `/api/**`, and these routes are **not** in the in-route-auth exemption list — so anonymous callers already get 401.
- The only public query path is `GET /api/query/demo`, hard-whitelisted to **3 homepage questions** and KV-cached → at most 3 LLM calls ever. Not abusable.

So no anonymous LLM hole exists today. The gap this closes: the **middleware was the single enforcement point**.

### Changes
- **In-route guard** on both query routes: reject a null principal with `401` *before* invoking the LLM — defense-in-depth so a future middleware/matcher change can't silently open free querying. (Agents query via MCP → `query()` directly, not these routes, so they're unaffected.)
- **Regression tests:** assert `/api/query` + `/api/query/stream` stay out of the in-route-auth exemptions (must remain write-gated), and that an anonymous `POST /api/query` returns 401 with the LLM never called.

Lint 0 errors, full suite **3201 passed**, both builds clean.

Note: this is independent of the domain PR (#681) — separate branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)