### PR TITLE
yoyo: Save-to-yopedia capture surfaces (bookmarklet + PWA share + iOS) + how-to page

### DIFF
--- a/public/pwa-icon.svg
+++ b/public/pwa-icon.svg
@@ -1,0 +1,14 @@
+<svg width="512" height="512" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="7" fill="#0a0a0b"/>
+  <g stroke="#d4d4d8" stroke-width="2" stroke-linecap="round" opacity="0.5">
+    <line x1="9" y1="13" x2="16" y2="9"/>
+    <line x1="16" y1="9" x2="24" y2="14"/>
+    <line x1="16" y1="9" x2="17" y2="23"/>
+    <line x1="9" y1="13" x2="17" y2="23"/>
+    <line x1="17" y1="23" x2="24" y2="14"/>
+  </g>
+  <circle cx="9" cy="13" r="2.4" fill="#e4e4e7"/>
+  <circle cx="24" cy="14" r="2.4" fill="#e4e4e7"/>
+  <circle cx="17" cy="23" r="2.4" fill="#e4e4e7"/>
+  <circle cx="16" cy="9" r="3.2" fill="#818cf8"/>
+</svg>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,10 @@
+// Minimal service worker. Its ONLY purpose is to make yopedia an installable PWA,
+// which is what unlocks the Web Share Target (sharing a link to yopedia from the
+// OS share sheet). It deliberately does NOT cache or intercept anything: the
+// fetch handler never calls respondWith(), so every request goes to the network
+// normally — it can't serve stale content or break the app.
+self.addEventListener("install", () => self.skipWaiting());
+self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+self.addEventListener("fetch", () => {
+  // no-op — let the browser handle the request as if no SW were present.
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Footer } from "@/components/Footer";
 import { SiteChrome } from "@/components/SiteChrome";
 import { ClientProviders } from "@/components/ClientProviders";
 import { EnsureYoyo } from "@/components/EnsureYoyo";
+import { RegisterSW } from "@/components/RegisterSW";
 import "./globals.css";
 
 // Self-hosted via next/font (no runtime Google CDN calls). Exposed as CSS
@@ -85,6 +86,7 @@ export default function RootLayout({
         <ClerkProvider waitlistUrl="/waitlist">
           <ClientProviders>
             <EnsureYoyo />
+            <RegisterSW />
             <SiteChrome nav={<NavHeader />} footer={<Footer />}>
               {children}
             </SiteChrome>

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,37 @@
+import type { MetadataRoute } from "next";
+
+/**
+ * PWA manifest. Beyond making yopedia installable, its real job is the **Web
+ * Share Target**: once installed (Android Chrome especially), yopedia appears in
+ * the OS share sheet, and sharing a link does `GET /save?url=&title=&text=` →
+ * the capture page ingests it. iOS Safari doesn't support share_target (the
+ * /save guide documents an Apple Shortcut for that case).
+ *
+ * `share_target` isn't in Next's `MetadataRoute.Manifest` type yet, so we build
+ * the object and cast — Next JSON-serializes it verbatim, so the field IS emitted
+ * in `/manifest.webmanifest`. (See share-target.test.ts, which asserts the shape.)
+ */
+export default function manifest(): MetadataRoute.Manifest {
+  // Typed base (so display/icons are validated), then graft on share_target and
+  // cast — Next serializes the whole object, so share_target reaches the output.
+  const base: MetadataRoute.Manifest = {
+    name: "yopedia — a shared second brain for humans and agents",
+    short_name: "yopedia",
+    description: "Save any link to yopedia for ingesting into the commons.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#0a0a0b",
+    theme_color: "#0a0a0b",
+    icons: [
+      { src: "/pwa-icon.svg", sizes: "any", type: "image/svg+xml", purpose: "any" },
+    ],
+  };
+  return {
+    ...base,
+    share_target: {
+      action: "/save",
+      method: "GET",
+      params: { title: "title", text: "text", url: "url" },
+    },
+  } as MetadataRoute.Manifest;
+}

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -7,14 +7,12 @@ import type { MetadataRoute } from "next";
  * the capture page ingests it. iOS Safari doesn't support share_target (the
  * /save guide documents an Apple Shortcut for that case).
  *
- * `share_target` isn't in Next's `MetadataRoute.Manifest` type yet, so we build
- * the object and cast — Next JSON-serializes it verbatim, so the field IS emitted
- * in `/manifest.webmanifest`. (See share-target.test.ts, which asserts the shape.)
+ * `share_target` is a typed field on Next's `MetadataRoute.Manifest`, and Next
+ * serializes this object into `/manifest.webmanifest`. (share-target.test.ts
+ * asserts the share_target shape so a refactor can't silently drop the surface.)
  */
 export default function manifest(): MetadataRoute.Manifest {
-  // Typed base (so display/icons are validated), then graft on share_target and
-  // cast — Next serializes the whole object, so share_target reaches the output.
-  const base: MetadataRoute.Manifest = {
+  return {
     name: "yopedia — a shared second brain for humans and agents",
     short_name: "yopedia",
     description: "Save any link to yopedia for ingesting into the commons.",
@@ -25,13 +23,10 @@ export default function manifest(): MetadataRoute.Manifest {
     icons: [
       { src: "/pwa-icon.svg", sizes: "any", type: "image/svg+xml", purpose: "any" },
     ],
-  };
-  return {
-    ...base,
     share_target: {
       action: "/save",
       method: "GET",
       params: { title: "title", text: "text", url: "url" },
     },
-  } as MetadataRoute.Manifest;
+  };
 }

--- a/src/app/save/page.tsx
+++ b/src/app/save/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { SaveCapture } from "@/components/SaveCapture";
+import { SaveGuide } from "@/components/SaveGuide";
+import { resolveSharedUrl } from "@/lib/share-target";
+
+export const metadata: Metadata = {
+  title: "Save to yopedia",
+  description: "Send any link to yopedia for ingesting — bookmarklet, share sheet, or shortcut.",
+  // The capture action shouldn't be indexed; the guide (no ?url) is fine but low value.
+  robots: { index: false, follow: false },
+};
+
+const first = (v: string | string[] | undefined): string | undefined =>
+  Array.isArray(v) ? v[0] : v;
+
+/**
+ * Dual-mode capture route:
+ *  - `/save?url=…`  → the capture action (bookmarklet popup / PWA share / Shortcut)
+ *  - `/save`        → the how-to guide for setting up those surfaces
+ */
+export default async function SavePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const url = resolveSharedUrl(first(sp.url), first(sp.text));
+  const title = first(sp.title);
+
+  return (
+    <main style={{ maxWidth: 720, margin: "0 auto", padding: "56px 24px 88px" }}>
+      {url ? <SaveCapture url={url} title={title} /> : <SaveGuide />}
+    </main>
+  );
+}

--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -16,12 +16,14 @@ const primaryLinks = [
   { href: "/wiki", label: "Browse" },
   { href: "/query", label: "Ask" },
   { href: "/ingest", label: "Ingest" },
+  { href: "/save", label: "Save" },
 ];
 
 /** Which primary link should read as "active" for the current path. */
 function getActiveHref(pathname: string): string | null {
   if (pathname === "/query" || pathname.startsWith("/query/")) return "/query";
   if (pathname === "/ingest" || pathname.startsWith("/ingest/")) return "/ingest";
+  if (pathname === "/save" || pathname.startsWith("/save/")) return "/save";
   // Browse owns the commons + article reading surfaces.
   if (
     pathname === "/wiki" ||

--- a/src/components/RegisterSW.tsx
+++ b/src/components/RegisterSW.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Registers the minimal service worker (`/sw.js`) so yopedia is installable as a
+ * PWA — the prerequisite for the Web Share Target. Pure progressive enhancement:
+ * if registration fails (older browser, blocked SW), the site works unchanged and
+ * we just log a warning. Mounted once in the root layout; renders nothing.
+ */
+export function RegisterSW() {
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return;
+    navigator.serviceWorker.register("/sw.js").catch((err) => {
+      console.warn("[pwa] service worker registration failed:", err);
+    });
+  }, []);
+  return null;
+}

--- a/src/components/SaveCapture.tsx
+++ b/src/components/SaveCapture.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { useUser, useClerk } from "@clerk/nextjs";
+import { IngestVaultPicker } from "./IngestVaultPicker";
+
+type Status = "loading" | "signin" | "saving" | "saved" | "error";
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * The capture target for all three surfaces (bookmarklet popup, PWA share, iOS
+ * Shortcut). It runs on yopedia's own origin, so the user's session cookie
+ * authenticates the save automatically. When signed in it fires `POST /api/ingest`
+ * immediately (the click/share WAS the intent), shows status, and offers to also
+ * file the page into a vault. Signed-out → a sign-in prompt; the save fires once
+ * the session lands.
+ */
+export function SaveCapture({ url, title }: { url: string; title?: string }) {
+  const { isSignedIn, isLoaded } = useUser();
+  const { openSignIn } = useClerk();
+  const [status, setStatus] = useState<Status>("loading");
+  const [vaultId, setVaultId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const firedRef = useRef(false);
+
+  async function save(vault: string | null) {
+    setStatus("saving");
+    setError(null);
+    try {
+      const res = await fetch("/api/ingest", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          url,
+          ...(title ? { title } : {}),
+          ...(vault ? { vaultId: vault } : {}),
+        }),
+      });
+      if (res.status === 401) {
+        setStatus("signin");
+        return;
+      }
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(data.error ?? `Save failed (${res.status})`);
+        setStatus("error");
+        return;
+      }
+      setStatus("saved");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error");
+      setStatus("error");
+    }
+  }
+
+  // Auto-fire once when signed in. The bookmarklet/share click is itself the
+  // intent to save, so we don't make the user click again. Re-ingesting the same
+  // URL is deduped server-side, so a refresh is harmless.
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (!isSignedIn) {
+      setStatus("signin");
+      return;
+    }
+    if (firedRef.current) return;
+    firedRef.current = true;
+    void save(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoaded, isSignedIn]);
+
+  const host = hostOf(url);
+
+  return (
+    <div className="shell" style={{ maxWidth: 460, margin: "0 auto", padding: "8px 0" }}>
+      <h1 className="display" style={{ fontSize: 22, margin: "0 0 4px" }}>
+        Save to yopedia
+      </h1>
+      <p
+        className="receipt"
+        style={{
+          fontSize: 12.5,
+          color: "var(--muted)",
+          margin: "0 0 18px",
+          wordBreak: "break-all",
+        }}
+        title={url}
+      >
+        {title ? <strong style={{ color: "var(--ink)" }}>{title}</strong> : null}
+        {title ? <br /> : null}
+        {url}
+      </p>
+
+      {status === "loading" && (
+        <p style={{ color: "var(--muted)", fontSize: 13 }}>Checking your session…</p>
+      )}
+
+      {status === "signin" && (
+        <div>
+          <p style={{ fontSize: 13.5, marginBottom: 12 }}>
+            Sign in to save this page to yopedia.
+          </p>
+          <button
+            type="button"
+            className="receipt"
+            // Modal sign-in keeps us on this page; once the session lands,
+            // isSignedIn flips and the auto-save effect fires. No redirect needed.
+            onClick={() => openSignIn()}
+            style={btnPrimary}
+          >
+            Sign in & save
+          </button>
+        </div>
+      )}
+
+      {status === "saving" && (
+        <p style={{ fontSize: 13.5, color: "var(--muted)" }}>Saving {host}…</p>
+      )}
+
+      {status === "error" && (
+        <div>
+          <p style={{ fontSize: 13.5, color: "var(--danger, #dc2626)", marginBottom: 12 }}>
+            {error}
+          </p>
+          <button type="button" className="receipt" onClick={() => save(vaultId)} style={btnPrimary}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {status === "saved" && (
+        <div>
+          <p style={{ fontSize: 14, marginBottom: 16 }}>
+            <span style={{ color: "var(--accent)" }}>✓ Saved.</span> yopedia is reading{" "}
+            <strong>{host}</strong> now — it’ll appear in the commons shortly.
+          </p>
+
+          <label
+            className="receipt"
+            style={{ display: "block", fontSize: 11.5, color: "var(--muted)", marginBottom: 6 }}
+          >
+            Also file it in a vault (optional)
+          </label>
+          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            <IngestVaultPicker value={vaultId} onChange={setVaultId} />
+            {vaultId && (
+              <button type="button" className="receipt" onClick={() => save(vaultId)} style={btnSecondary}>
+                Add to vault
+              </button>
+            )}
+          </div>
+
+          <div style={{ marginTop: 22, display: "flex", gap: 10 }}>
+            <button type="button" className="receipt" onClick={() => window.close()} style={btnPrimary}>
+              Done
+            </button>
+            <a href="/ingest" className="receipt" style={{ ...btnSecondary, textDecoration: "none", lineHeight: "1.9" }}>
+              View activity
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const btnPrimary: CSSProperties = {
+  fontSize: 13,
+  padding: "7px 16px",
+  borderRadius: 8,
+  border: "1px solid var(--rule)",
+  background: "var(--accent-soft)",
+  color: "var(--accent)",
+  cursor: "pointer",
+};
+
+const btnSecondary: CSSProperties = {
+  fontSize: 12.5,
+  padding: "6px 12px",
+  borderRadius: 8,
+  border: "1px solid var(--rule)",
+  background: "transparent",
+  color: "var(--muted)",
+  cursor: "pointer",
+};

--- a/src/components/SaveCapture.tsx
+++ b/src/components/SaveCapture.tsx
@@ -3,16 +3,9 @@
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { useUser, useClerk } from "@clerk/nextjs";
 import { IngestVaultPicker } from "./IngestVaultPicker";
+import { hostOf } from "@/lib/share-target";
 
 type Status = "loading" | "signin" | "saving" | "saved" | "error";
-
-function hostOf(url: string): string {
-  try {
-    return new URL(url).hostname.replace(/^www\./, "");
-  } catch {
-    return url;
-  }
-}
 
 /**
  * The capture target for all three surfaces (bookmarklet popup, PWA share, iOS

--- a/src/components/SaveGuide.tsx
+++ b/src/components/SaveGuide.tsx
@@ -12,7 +12,7 @@ import { buildBookmarklet } from "@/lib/share-target";
 export function SaveGuide() {
   const linkRef = useRef<HTMLAnchorElement>(null);
   const [bookmarklet, setBookmarklet] = useState("");
-  const [copied, setCopied] = useState(false);
+  const [copyState, setCopyState] = useState<"idle" | "ok" | "fail">("idle");
 
   useEffect(() => {
     const bm = buildBookmarklet(window.location.origin);
@@ -25,10 +25,13 @@ export function SaveGuide() {
   async function copy() {
     try {
       await navigator.clipboard.writeText(bookmarklet);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1800);
+      setCopyState("ok");
+      setTimeout(() => setCopyState("idle"), 1800);
     } catch {
-      setCopied(false);
+      // Clipboard can fail (denied permission, insecure context, older browser).
+      // This IS the fallback affordance, so tell the user to grab the visible code
+      // above rather than silently resetting to a no-op state.
+      setCopyState("fail");
     }
   }
 
@@ -82,7 +85,11 @@ export function SaveGuide() {
           </p>
           <pre style={preStyle}>{bookmarklet}</pre>
           <button type="button" className="receipt" onClick={copy} style={btnSecondary}>
-            {copied ? "Copied ✓" : "Copy code"}
+            {copyState === "ok"
+              ? "Copied ✓"
+              : copyState === "fail"
+                ? "Copy failed — select the code above"
+                : "Copy code"}
           </button>
         </details>
         <p style={{ ...noteStyle }}>

--- a/src/components/SaveGuide.tsx
+++ b/src/components/SaveGuide.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { buildBookmarklet } from "@/lib/share-target";
+
+/**
+ * The "how to use Save to yopedia" page (rendered at /save with no ?url). Walks a
+ * visitor through the three no-extension capture surfaces: a desktop bookmarklet,
+ * the PWA share target (Android), and iOS. The bookmarklet is generated from the
+ * live origin so it always points at wherever yopedia is served.
+ */
+export function SaveGuide() {
+  const linkRef = useRef<HTMLAnchorElement>(null);
+  const [bookmarklet, setBookmarklet] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const bm = buildBookmarklet(window.location.origin);
+    setBookmarklet(bm);
+    // React refuses to render a javascript: href, so set it on the live node —
+    // dragging the link to the bookmarks bar copies this href verbatim.
+    linkRef.current?.setAttribute("href", bm);
+  }, []);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(bookmarklet);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <div className="shell" style={{ maxWidth: 640, margin: "0 auto" }}>
+      <h1 className="display" style={{ fontSize: 30, margin: "0 0 6px" }}>
+        Save to yopedia
+      </h1>
+      <p style={{ color: "var(--muted)", fontSize: 14.5, margin: "0 0 28px", lineHeight: 1.55 }}>
+        Send any page you’re reading to yopedia in one click — it fetches the link
+        and ingests it into the commons. No browser extension required. Pick the
+        method for your device.
+      </p>
+
+      {/* 1 — Desktop bookmarklet */}
+      <section style={sectionStyle}>
+        <h2 style={h2Style}>① Desktop — bookmarklet</h2>
+        <p style={pStyle}>
+          Drag this button up to your bookmarks bar. Then, on any page, click it —
+          a small window opens and saves the page.
+        </p>
+        <div style={{ display: "flex", gap: 12, alignItems: "center", flexWrap: "wrap", margin: "14px 0" }}>
+          <a
+            ref={linkRef}
+            href="#"
+            onClick={(e) => e.preventDefault()}
+            draggable
+            title="Drag me to your bookmarks bar"
+            className="receipt"
+            style={{
+              display: "inline-block",
+              fontSize: 13.5,
+              fontWeight: 600,
+              padding: "9px 16px",
+              borderRadius: 8,
+              border: "1px solid var(--rule)",
+              background: "var(--accent-soft)",
+              color: "var(--accent)",
+              textDecoration: "none",
+              cursor: "grab",
+            }}
+          >
+            📑 Save to yopedia
+          </a>
+          <span style={{ fontSize: 12, color: "var(--faint)" }}>← drag me to the bookmarks bar</span>
+        </div>
+        <details style={{ fontSize: 12.5, color: "var(--muted)" }}>
+          <summary style={{ cursor: "pointer" }}>Can’t drag it? Copy the code instead</summary>
+          <p style={{ margin: "8px 0" }}>
+            Create a new bookmark and paste this as its URL/address:
+          </p>
+          <pre style={preStyle}>{bookmarklet}</pre>
+          <button type="button" className="receipt" onClick={copy} style={btnSecondary}>
+            {copied ? "Copied ✓" : "Copy code"}
+          </button>
+        </details>
+        <p style={{ ...noteStyle }}>
+          Works in any desktop browser. A few sites (e.g. GitHub, X) block
+          bookmarklets via their security policy — there it won’t run.
+        </p>
+      </section>
+
+      {/* 2 — Android / PWA share target */}
+      <section style={sectionStyle}>
+        <h2 style={h2Style}>② Android — install &amp; share</h2>
+        <ol style={olStyle}>
+          <li>
+            Open yopedia in Chrome → menu (⋮) → <strong>Install app</strong> (or
+            “Add to Home screen”).
+          </li>
+          <li>
+            Now in any app, tap <strong>Share</strong> → choose{" "}
+            <strong>yopedia</strong> from the share sheet. The link is saved.
+          </li>
+        </ol>
+        <p style={noteStyle}>
+          Uses the Web Share Target — yopedia registers as a share destination
+          once installed.
+        </p>
+      </section>
+
+      {/* 3 — iOS */}
+      <section style={{ ...sectionStyle, borderBottom: "none" }}>
+        <h2 style={h2Style}>③ iPhone / iPad</h2>
+        <p style={pStyle}>
+          iOS Safari doesn’t support share-to-web-app, so use one of these:
+        </p>
+        <p style={{ ...pStyle, marginTop: 10 }}>
+          <strong>Bookmarklet (simplest):</strong> in Safari, bookmark any page,
+          then edit that bookmark and replace its address with the copied code
+          above. Tap it from your bookmarks on any page to save.
+        </p>
+        <p style={{ ...pStyle, marginTop: 10 }}>
+          <strong>Share-sheet Shortcut:</strong> open the Shortcuts app → new
+          shortcut → enable <em>Use with Share Sheet</em> (accept URLs) → add an{" "}
+          <em>Open URLs</em> action with{" "}
+          <code style={codeStyle}>/save?url=</code> + the Shortcut input. Then{" "}
+          Share → your shortcut.
+        </p>
+      </section>
+
+      <p style={{ marginTop: 28, fontSize: 13, color: "var(--muted)" }}>
+        Saving requires a signed-in yopedia account — the first save will prompt
+        you to sign in, then continue.
+      </p>
+    </div>
+  );
+}
+
+const sectionStyle: CSSProperties = {
+  padding: "20px 0",
+  borderBottom: "1px solid var(--rule)",
+};
+const h2Style: CSSProperties = { fontSize: 16, margin: "0 0 8px" };
+const pStyle: CSSProperties = { fontSize: 13.5, color: "var(--ink)", margin: 0, lineHeight: 1.6 };
+const noteStyle: CSSProperties = {
+  fontSize: 12,
+  color: "var(--faint)",
+  margin: "12px 0 0",
+  lineHeight: 1.5,
+};
+const olStyle: CSSProperties = {
+  fontSize: 13.5,
+  color: "var(--ink)",
+  lineHeight: 1.7,
+  margin: 0,
+  paddingLeft: 20,
+};
+const preStyle: CSSProperties = {
+  fontSize: 11,
+  background: "var(--surface, #18181b0a)",
+  border: "1px solid var(--rule)",
+  borderRadius: 6,
+  padding: 10,
+  overflow: "auto",
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-all",
+};
+const codeStyle: CSSProperties = {
+  fontSize: 12,
+  background: "var(--surface, #18181b0a)",
+  padding: "1px 5px",
+  borderRadius: 4,
+};
+const btnSecondary: CSSProperties = {
+  fontSize: 12.5,
+  padding: "6px 12px",
+  borderRadius: 8,
+  border: "1px solid var(--rule)",
+  background: "transparent",
+  color: "var(--muted)",
+  cursor: "pointer",
+};

--- a/src/lib/__tests__/share-target.test.ts
+++ b/src/lib/__tests__/share-target.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveSharedUrl, buildBookmarklet } from "../share-target";
+import { resolveSharedUrl, buildBookmarklet, hostOf } from "../share-target";
 import manifest from "@/app/manifest";
 
 describe("resolveSharedUrl", () => {
@@ -29,6 +29,14 @@ describe("resolveSharedUrl", () => {
     expect(resolveSharedUrl("", "no link here")).toBeNull();
     expect(resolveSharedUrl(null, null)).toBeNull();
   });
+
+  it("keeps query-string chars when recovering a link from text (no truncation)", () => {
+    // Pins that the extraction char-class doesn't get tightened to drop ?,&,= —
+    // a tweet-style share carries the full tracking URL inline.
+    expect(
+      resolveSharedUrl(undefined, "read https://example.com/p?utm=x&y=2 thanks"),
+    ).toBe("https://example.com/p?utm=x&y=2");
+  });
 });
 
 describe("buildBookmarklet", () => {
@@ -45,6 +53,24 @@ describe("buildBookmarklet", () => {
     expect(buildBookmarklet("https://yopedia.yolog.dev/")).toContain(
       "https://yopedia.yolog.dev/save?url=",
     );
+  });
+
+  it("produces a syntactically valid javascript: body (catches quote/paren slips)", () => {
+    const body = buildBookmarklet("https://yopedia.yolog.dev").replace(/^javascript:/, "");
+    // If a future edit unbalances a quote/paren, this throws at parse time —
+    // something substring matching can't catch.
+    expect(() => new Function(body)).not.toThrow();
+  });
+});
+
+describe("hostOf", () => {
+  it("returns the hostname without a leading www.", () => {
+    expect(hostOf("https://www.example.com/a/b?c=1")).toBe("example.com");
+    expect(hostOf("https://sub.example.com/x")).toBe("sub.example.com");
+  });
+
+  it("returns the raw input unchanged when it doesn't parse as a URL", () => {
+    expect(hostOf("not a url")).toBe("not a url");
   });
 });
 

--- a/src/lib/__tests__/share-target.test.ts
+++ b/src/lib/__tests__/share-target.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { resolveSharedUrl, buildBookmarklet } from "../share-target";
+import manifest from "@/app/manifest";
+
+describe("resolveSharedUrl", () => {
+  it("prefers an explicit url param", () => {
+    expect(resolveSharedUrl("https://example.com/a", "ignored")).toBe(
+      "https://example.com/a",
+    );
+  });
+
+  it("trims surrounding whitespace on the url param", () => {
+    expect(resolveSharedUrl("  https://example.com/a  ")).toBe("https://example.com/a");
+  });
+
+  it("falls back to the first http(s) link in text (Web Share Target quirk)", () => {
+    expect(
+      resolveSharedUrl(undefined, "Great read: https://example.com/post via @x"),
+    ).toBe("https://example.com/post");
+  });
+
+  it("ignores a non-http url param and recovers from text", () => {
+    expect(resolveSharedUrl("not-a-url", "see https://example.com/x")).toBe(
+      "https://example.com/x",
+    );
+  });
+
+  it("returns null when neither carries a url", () => {
+    expect(resolveSharedUrl("", "no link here")).toBeNull();
+    expect(resolveSharedUrl(null, null)).toBeNull();
+  });
+});
+
+describe("buildBookmarklet", () => {
+  it("opens the given origin's /save with the encoded current url + title", () => {
+    const bm = buildBookmarklet("https://yopedia.yolog.dev");
+    expect(bm.startsWith("javascript:")).toBe(true);
+    expect(bm).toContain("https://yopedia.yolog.dev/save?url=");
+    expect(bm).toContain("encodeURIComponent(location.href)");
+    expect(bm).toContain("encodeURIComponent(document.title)");
+    expect(bm).toContain("window.open(");
+  });
+
+  it("strips a trailing slash from the origin (no double slash before /save)", () => {
+    expect(buildBookmarklet("https://yopedia.yolog.dev/")).toContain(
+      "https://yopedia.yolog.dev/save?url=",
+    );
+  });
+});
+
+describe("PWA manifest share target", () => {
+  it("registers /save as a GET share target so the OS share sheet sends links there", () => {
+    // share_target isn't in Next's Manifest TS type yet, but it IS emitted at
+    // runtime — assert the shape so a refactor can't silently drop the surface.
+    const m = manifest() as unknown as {
+      share_target?: { action: string; method: string; params: Record<string, string> };
+    };
+    expect(m.share_target?.action).toBe("/save");
+    expect(m.share_target?.method).toBe("GET");
+    expect(m.share_target?.params.url).toBe("url");
+    expect(m.share_target?.params.text).toBe("text");
+  });
+});

--- a/src/lib/share-target.ts
+++ b/src/lib/share-target.ts
@@ -1,0 +1,40 @@
+// Capture surfaces — the shared logic behind the three no-extension ways to send
+// a URL to yopedia for ingesting: a desktop bookmarklet, the PWA Web Share Target
+// (Android), and an iOS Shortcut. All three land on `/save`, which fires the
+// existing authed `POST /api/ingest`. These helpers are pure so they're testable
+// in isolation (the surfaces themselves are a page + a manifest).
+
+const URL_RE = /https?:\/\/[^\s<>"']+/i;
+
+/**
+ * Resolve the URL to ingest from a capture request's params. Prefers an explicit
+ * `url`, but falls back to the FIRST http(s) link found in `text` — the Web Share
+ * Target spec lets a sharing app drop the link into `text` instead of `url` (many
+ * Android apps do), so we recover it. Returns null when neither yields a URL.
+ */
+export function resolveSharedUrl(
+  url?: string | null,
+  text?: string | null,
+): string | null {
+  const direct = (url ?? "").trim();
+  if (/^https?:\/\//i.test(direct)) return direct;
+  const fromText = (text ?? "").match(URL_RE)?.[0];
+  return fromText ?? null;
+}
+
+/**
+ * Build the desktop bookmarklet for a given site origin. Clicking it on any page
+ * opens yopedia's `/save` in a small popup, passing the current tab's URL + title.
+ * The popup loads on yopedia's OWN origin, so the user's existing session cookie
+ * authenticates the save — no token, no CORS. Generated from the live origin so it
+ * always points at wherever yopedia is served (e.g. yopedia.yolog.dev).
+ */
+export function buildBookmarklet(origin: string): string {
+  const base = origin.replace(/\/+$/, "");
+  return (
+    "javascript:(function(){window.open('" +
+    base +
+    "/save?url='+encodeURIComponent(location.href)+'&title='+encodeURIComponent(document.title)," +
+    "'yopedia-save','width=440,height=620,noopener=no');})();"
+  );
+}

--- a/src/lib/share-target.ts
+++ b/src/lib/share-target.ts
@@ -29,6 +29,19 @@ export function resolveSharedUrl(
  * authenticates the save — no token, no CORS. Generated from the live origin so it
  * always points at wherever yopedia is served (e.g. yopedia.yolog.dev).
  */
+/**
+ * Display host for a URL — the hostname without a leading `www.`, or the raw
+ * input unchanged if it doesn't parse. Used by the capture UI to show
+ * "example.com" instead of a long URL.
+ */
+export function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
 export function buildBookmarklet(origin: string): string {
   const base = origin.replace(/\/+$/, "");
   return (


### PR DESCRIPTION
Instapaper-style **"save the page I'm reading → yopedia"** with **no browser extension**. Three capture surfaces, all funneling into one new page.

### The keystone: `/save`
Runs on yopedia's own origin, so the user's **session cookie authenticates it** (no token, no CORS). Dual-mode:
- `/save?url=…&title=…` → **SaveCapture**: auto-fires the existing authed `POST /api/ingest` on load (the click/share *is* the intent), shows "Saved ✓", offers a **vault picker**, and prompts sign-in if needed (then continues). Re-ingest is deduped server-side, so refresh is harmless.
- `/save` (no url) → **SaveGuide**: the how-to page for all three surfaces.

### The three surfaces
1. **Desktop — bookmarklet.** A `javascript:` bookmark (drag-to-bookmarks button + copy fallback on the guide) that opens `/save?url=…` in a popup. Built from the live origin via `buildBookmarklet()`.
2. **Android — PWA Web Share Target.** `app/manifest.ts` declares `share_target` → `GET /save`; a **minimal no-op service worker** (`public/sw.js`, registered by `RegisterSW`) makes yopedia installable so it shows up in the OS share sheet. The SW never calls `respondWith` — it can't cache or break anything.
3. **iOS — documented.** Safari bookmarklet, or a share-sheet Shortcut (steps on the guide). (iOS Safari has no Web Share Target.)

### Notes
- `resolveSharedUrl()` recovers the link from the share **`text`** field too (many Android apps put it there, not `url`).
- "Save" added to the primary nav → the guide.
- `/save` is `noindex` (it's an action/utility page).

### Tests / gates
Pure helpers unit-tested (`resolveSharedUrl`, `buildBookmarklet`) + a manifest test pinning `share_target.action === "/save"`. Lint 0 errors, full suite **3243 passed**, both builds clean.

Known follow-up (not blocking): the PWA icon is the existing SVG (`/pwa-icon.svg`); some installers prefer PNG 192/512 — easy to add later if install prompts are finicky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)