### PR TITLE
yoyo: make /ingest "Recent ingests" server-backed (survives domain move + shows bookmarklet saves)

### DIFF
--- a/src/app/api/ingest/history/route.ts
+++ b/src/app/api/ingest/history/route.ts
@@ -1,14 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import { readLedger } from "@/lib/ingest";
 import { getPrincipal } from "@/lib/auth";
+import { listReadableWikiPages } from "@/lib/wiki";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 
 /**
  * GET /api/ingest/history?limit=50
  *
- * Returns recent ingest ledger entries as a JSON array, most recent first.
- * Requires authentication — source URLs are private activity metadata.
+ * Recent ingest ledger entries, most recent first — SCOPED to pages the caller
+ * can read. The ledger is one GLOBAL append-only JSONL with no owner field, so
+ * without this filter any signed-in viewer would see every user's ingest source
+ * URLs + resulting slugs, including private-vault ingests. We drop entries whose
+ * resulting page the caller can't read: commons provenance is already public on
+ * the page itself, and private pages are hidden from non-owners. (A stricter
+ * "my ingests only" view would persist an owner on each ledger entry — a larger
+ * change; readability-scoping closes the leak without a ledger migration.)
  */
 export async function GET(request: NextRequest) {
   try {
@@ -28,7 +35,15 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const entries = await readLedger(limit);
+    // Only surface entries whose resulting page the caller can read (O(1) page
+    // index + in-memory canReadEntry). Drops other users' private-page ingests.
+    const readable = new Set(
+      (await listReadableWikiPages(principal)).map((p) => p.slug),
+    );
+    const entries = (await readLedger())
+      .filter((e) => e.primary_slug && readable.has(e.primary_slug))
+      .slice(0, limit ?? 50);
+
     return NextResponse.json({ entries });
   } catch (error) {
     logger.error("ingest", "Ingest history GET error", error);

--- a/src/components/RecentIngests.tsx
+++ b/src/components/RecentIngests.tsx
@@ -4,13 +4,15 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { getRecentJobIds } from "@/lib/recent-ingests";
 import { commonsPath } from "@/lib/links";
+import { hostOf } from "@/lib/share-target";
 
-/** A queued/processing job submitted from THIS browser (live status). */
+/** A still-running (or failed) job submitted from THIS browser (live status). */
 interface InFlight {
   jobId: string;
-  status: "queued" | "processing";
+  status: "queued" | "processing" | "failed";
   url?: string;
   title?: string;
+  error?: string;
 }
 
 /** A completed ingest from the server ledger (durable, all sources). */
@@ -35,26 +37,19 @@ function ago(iso: string): string {
   return `${Math.floor(h / 24)}d ago`;
 }
 
-function hostOf(url: string): string {
-  try {
-    return new URL(url).hostname.replace(/^www\./, "");
-  } catch {
-    return url;
-  }
-}
-
 /**
  * Recent ingest activity. The durable list comes from the SERVER ledger
- * (`/api/ingest/history`) so it survives across domains/devices and includes
- * EVERY ingest path — the form, the queue, MCP, and the "Save to yopedia"
- * bookmarklet/share (which don't touch this browser's localStorage). On top of
- * that, jobs this browser just submitted are polled by id for live status until
- * they land in the ledger. Refreshes on tab focus so a bookmarklet save made in
- * a popup appears when you come back.
+ * (`/api/ingest/history`, scoped to pages the caller can read) so it survives
+ * across domains/devices and includes EVERY ingest path — the form, the queue,
+ * MCP, and the "Save to yopedia" bookmarklet/share (which don't touch this
+ * browser's localStorage). On top of that, jobs this browser just submitted are
+ * polled by id for live status (incl. failures) until they land in the ledger.
+ * Refreshes on tab focus so a bookmarklet save made in a popup appears on return.
  */
 export function RecentIngests() {
   const [inflight, setInflight] = useState<InFlight[]>([]);
   const [history, setHistory] = useState<LedgerEntry[]>([]);
+  const [errored, setErrored] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -67,13 +62,25 @@ export function RecentIngests() {
         const res = await fetch("/api/ingest/history?limit=20");
         if (res.ok) {
           const data = (await res.json()) as { entries?: LedgerEntry[] };
-          if (!cancelled) setHistory(Array.isArray(data.entries) ? data.entries : []);
+          if (!cancelled) {
+            setHistory(Array.isArray(data.entries) ? data.entries : []);
+            setErrored(false);
+          }
+        } else if (res.status !== 401) {
+          // 401 = signed out (expected → stay quiet). Anything else is a real
+          // fault: don't let a 500ing ledger look like "no recent ingests".
+          console.warn("[recent-ingests] history fetch failed:", res.status);
+          if (!cancelled) setErrored(true);
         }
-      } catch {
-        // Leave the last-known history in place on a transient failure.
+      } catch (err) {
+        // Keep the last-known history, but record the fault so a persistent
+        // outage isn't invisible (esp. an empty first load).
+        console.warn("[recent-ingests] history fetch error:", err);
+        if (!cancelled) setErrored(true);
       }
 
-      // 2. This browser's in-flight jobs (live status until they land above).
+      // 2. This browser's in-flight (and just-failed) jobs (live status until
+      //    success lands in the ledger above).
       const ids = getRecentJobIds();
       const results = ids.length
         ? await Promise.all(
@@ -91,16 +98,22 @@ export function RecentIngests() {
           )
         : [];
       if (cancelled) return;
+      // Keep queued/processing (live) AND failed (so a failure isn't silent);
+      // drop "done" — those surface via the ledger, avoiding a duplicate row.
       const live = results.filter(
         (j): j is InFlight =>
-          j !== null && (j.status === "queued" || j.status === "processing"),
+          j !== null &&
+          (j.status === "queued" || j.status === "processing" || j.status === "failed"),
       );
       setInflight(live);
 
-      // Keep refreshing while a job is in flight (so its completion shows in the
-      // ledger), bounded so a stuck job can't drive an endless background loop.
+      // Keep refreshing while a job is still running (so its completion shows in
+      // the ledger), bounded so a stuck job can't drive an endless background loop.
       polls += 1;
-      if (polls < 90 && live.length > 0) timer = setTimeout(tick, 4000);
+      const stillRunning = live.some(
+        (j) => j.status === "queued" || j.status === "processing",
+      );
+      if (polls < 90 && stillRunning) timer = setTimeout(tick, 4000);
     }
 
     tick();
@@ -117,7 +130,20 @@ export function RecentIngests() {
     };
   }, []);
 
-  if (inflight.length === 0 && history.length === 0) return null;
+  if (inflight.length === 0 && history.length === 0) {
+    if (!errored) return null;
+    // A load error with nothing to show — say so rather than looking empty.
+    return (
+      <section style={{ marginTop: 36, paddingTop: 24, borderTop: "1px solid var(--rule)" }}>
+        <p className="fmark" style={{ marginBottom: 12 }}>
+          Recent ingests
+        </p>
+        <p style={{ fontSize: 13, color: "var(--muted)" }}>
+          Couldn’t load recent activity — try again in a moment.
+        </p>
+      </section>
+    );
+  }
 
   return (
     <section style={{ marginTop: 36, paddingTop: 24, borderTop: "1px solid var(--rule)" }}>
@@ -125,20 +151,31 @@ export function RecentIngests() {
         Recent ingests
       </p>
       <ul className="stack" style={{ gap: 9, listStyle: "none", margin: 0, padding: 0 }}>
-        {inflight.map((j) => (
-          <li
-            key={j.jobId}
-            className="row"
-            style={{ gap: 10, alignItems: "baseline", flexWrap: "wrap" }}
-          >
-            <span className="receipt" style={{ fontSize: 11, color: "var(--accent)", minWidth: 64 }}>
-              {j.status === "processing" ? "working…" : "queued"}
-            </span>
-            <span style={{ fontSize: 13.5, color: "var(--ink-2)", wordBreak: "break-all" }}>
-              {j.title || j.url || j.jobId}
-            </span>
-          </li>
-        ))}
+        {inflight.map((j) => {
+          const failed = j.status === "failed";
+          return (
+            <li
+              key={j.jobId}
+              className="row"
+              style={{ gap: 10, alignItems: "baseline", flexWrap: "wrap" }}
+            >
+              <span
+                className="receipt"
+                style={{ fontSize: 11, color: failed ? "var(--rust)" : "var(--accent)", minWidth: 64 }}
+              >
+                {failed ? "failed" : j.status === "processing" ? "working…" : "queued"}
+              </span>
+              <span style={{ fontSize: 13.5, color: "var(--ink-2)", wordBreak: "break-all" }}>
+                {j.title || j.url || j.jobId}
+              </span>
+              {failed && j.error && (
+                <span className="receipt" style={{ fontSize: 11.5, color: "var(--rust)" }}>
+                  {j.error}
+                </span>
+              )}
+            </li>
+          );
+        })}
         {history.map((e) => (
           <li
             key={e.ingest_id}

--- a/src/components/RecentIngests.tsx
+++ b/src/components/RecentIngests.tsx
@@ -5,75 +5,119 @@ import Link from "next/link";
 import { getRecentJobIds } from "@/lib/recent-ingests";
 import { commonsPath } from "@/lib/links";
 
-interface JobView {
+/** A queued/processing job submitted from THIS browser (live status). */
+interface InFlight {
   jobId: string;
-  status: "queued" | "processing" | "done" | "failed";
-  slug?: string;
-  error?: string;
+  status: "queued" | "processing";
   url?: string;
   title?: string;
 }
 
-const LABEL: Record<JobView["status"], { text: string; color: string }> = {
-  queued: { text: "queued", color: "var(--muted)" },
-  processing: { text: "working…", color: "var(--accent)" },
-  done: { text: "done", color: "var(--accent)" },
-  failed: { text: "failed", color: "var(--rust)" },
-};
+/** A completed ingest from the server ledger (durable, all sources). */
+interface LedgerEntry {
+  ingest_id: string;
+  source_url: string;
+  primary_slug: string;
+  finished_at: string;
+  status: string;
+  deduped?: boolean;
+}
+
+function ago(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  const s = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
 
 /**
- * The recently-submitted async ingest jobs (from localStorage), each with its
- * live status — so a user can see whether a queued ingest finished or failed,
- * even after navigating away or reloading.
+ * Recent ingest activity. The durable list comes from the SERVER ledger
+ * (`/api/ingest/history`) so it survives across domains/devices and includes
+ * EVERY ingest path — the form, the queue, MCP, and the "Save to yopedia"
+ * bookmarklet/share (which don't touch this browser's localStorage). On top of
+ * that, jobs this browser just submitted are polled by id for live status until
+ * they land in the ledger. Refreshes on tab focus so a bookmarklet save made in
+ * a popup appears when you come back.
  */
 export function RecentIngests() {
-  const [jobs, setJobs] = useState<JobView[]>([]);
+  const [inflight, setInflight] = useState<InFlight[]>([]);
+  const [history, setHistory] = useState<LedgerEntry[]>([]);
 
   useEffect(() => {
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
-    let refreshes = 0;
+    let polls = 0;
 
-    async function load() {
+    async function tick() {
+      // 1. Durable server history (the source of truth).
+      try {
+        const res = await fetch("/api/ingest/history?limit=20");
+        if (res.ok) {
+          const data = (await res.json()) as { entries?: LedgerEntry[] };
+          if (!cancelled) setHistory(Array.isArray(data.entries) ? data.entries : []);
+        }
+      } catch {
+        // Leave the last-known history in place on a transient failure.
+      }
+
+      // 2. This browser's in-flight jobs (live status until they land above).
       const ids = getRecentJobIds();
-      if (ids.length === 0) {
-        if (!cancelled) setJobs([]);
-        return;
-      }
-      const results = await Promise.all(
-        ids.map(async (id): Promise<JobView | null> => {
-          try {
-            const res = await fetch(`/api/ingest/status/${id}`);
-            if (!res.ok) return null; // gone / not owner — drop quietly
-            return { jobId: id, ...(await res.json()) };
-          } catch {
-            return null;
-          }
-        }),
-      );
+      const results = ids.length
+        ? await Promise.all(
+            ids.map(async (id) => {
+              try {
+                const r = await fetch(`/api/ingest/status/${id}`);
+                if (!r.ok) return null;
+                return { jobId: id, ...(await r.json()) } as InFlight & {
+                  status: string;
+                };
+              } catch {
+                return null;
+              }
+            }),
+          )
+        : [];
       if (cancelled) return;
-      const live = results.filter((j): j is JobView => j !== null);
-      setJobs(live);
-      // Keep refreshing while anything is still in flight, with a hard cap
-      // (~6min) so a stuck job can't drive an endless background refresh. The
-      // server also ages a stalled job to `failed`, so this rarely matters.
-      refreshes += 1;
-      if (
-        refreshes < 90 &&
-        live.some((j) => j.status === "queued" || j.status === "processing")
-      ) {
-        timer = setTimeout(load, 4000);
-      }
+      const live = results.filter(
+        (j): j is InFlight =>
+          j !== null && (j.status === "queued" || j.status === "processing"),
+      );
+      setInflight(live);
+
+      // Keep refreshing while a job is in flight (so its completion shows in the
+      // ledger), bounded so a stuck job can't drive an endless background loop.
+      polls += 1;
+      if (polls < 90 && live.length > 0) timer = setTimeout(tick, 4000);
     }
 
-    load();
+    tick();
+    // A bookmarklet/share save happens in another tab/popup — refresh on return.
+    const onFocus = () => {
+      polls = 0;
+      tick();
+    };
+    window.addEventListener("focus", onFocus);
     return () => {
       cancelled = true;
       if (timer) clearTimeout(timer);
+      window.removeEventListener("focus", onFocus);
     };
   }, []);
 
-  if (jobs.length === 0) return null;
+  if (inflight.length === 0 && history.length === 0) return null;
 
   return (
     <section style={{ marginTop: 36, paddingTop: 24, borderTop: "1px solid var(--rule)" }}>
@@ -81,37 +125,50 @@ export function RecentIngests() {
         Recent ingests
       </p>
       <ul className="stack" style={{ gap: 9, listStyle: "none", margin: 0, padding: 0 }}>
-        {jobs.map((j) => {
-          const label = LABEL[j.status];
-          return (
-            <li
-              key={j.jobId}
-              className="row"
-              style={{ gap: 10, alignItems: "baseline", flexWrap: "wrap" }}
-            >
-              <span
-                className="receipt"
-                style={{ fontSize: 11, color: label.color, minWidth: 60 }}
-              >
-                {label.text}
+        {inflight.map((j) => (
+          <li
+            key={j.jobId}
+            className="row"
+            style={{ gap: 10, alignItems: "baseline", flexWrap: "wrap" }}
+          >
+            <span className="receipt" style={{ fontSize: 11, color: "var(--accent)", minWidth: 64 }}>
+              {j.status === "processing" ? "working…" : "queued"}
+            </span>
+            <span style={{ fontSize: 13.5, color: "var(--ink-2)", wordBreak: "break-all" }}>
+              {j.title || j.url || j.jobId}
+            </span>
+          </li>
+        ))}
+        {history.map((e) => (
+          <li
+            key={e.ingest_id}
+            className="row"
+            style={{ gap: 10, alignItems: "baseline", flexWrap: "wrap" }}
+          >
+            <span className="receipt" style={{ fontSize: 11, color: "var(--muted)", minWidth: 64 }}>
+              {ago(e.finished_at)}
+            </span>
+            {e.primary_slug ? (
+              <Link href={commonsPath(e.primary_slug)} style={{ color: "var(--accent)", fontSize: 13.5 }}>
+                {e.primary_slug}
+              </Link>
+            ) : (
+              <span style={{ fontSize: 13.5, color: "var(--ink-2)", wordBreak: "break-all" }}>
+                {e.source_url}
               </span>
-              {j.status === "done" && j.slug ? (
-                <Link href={commonsPath(j.slug)} style={{ color: "var(--accent)", fontSize: 13.5 }}>
-                  {j.title || j.slug}
-                </Link>
-              ) : (
-                <span style={{ fontSize: 13.5, color: "var(--ink-2)", wordBreak: "break-all" }}>
-                  {j.title || j.url || j.jobId}
-                </span>
-              )}
-              {j.status === "failed" && j.error && (
-                <span className="receipt" style={{ fontSize: 11.5, color: "var(--rust)" }}>
-                  {j.error}
-                </span>
-              )}
-            </li>
-          );
-        })}
+            )}
+            {e.source_url && e.source_url !== "text-paste" && e.source_url !== "upload" && (
+              <span className="receipt" style={{ fontSize: 11, color: "var(--faint)" }}>
+                {hostOf(e.source_url)}
+              </span>
+            )}
+            {e.deduped && (
+              <span className="receipt" style={{ fontSize: 11, color: "var(--faint)" }}>
+                merged
+              </span>
+            )}
+          </li>
+        ))}
       </ul>
     </section>
   );


### PR DESCRIPTION
**Bug:** after the `yopedia.yolog.dev` custom-domain move, `/ingest` showed no recent ingests — and a bookmarklet save didn't appear either.

**Root cause (two compounding):**
1. `RecentIngests` read job ids from **localStorage**, which is **per-origin** — the old ids are stranded on `yopedia.yuanhao-li.workers.dev`; on the new domain that store is empty → "no recent ingests anymore."
2. The new **Save-to-yopedia** path (`/save` → `POST /api/ingest`) never wrote a job id to localStorage, so bookmarklet/share saves never showed in that list.

**Fix:** source the durable list from the **server ledger** (`GET /api/ingest/history` → `readLedger`), which records *every* ingest path (form, queue, MCP, bookmarklet/share) and is origin- and device-independent. The localStorage poll is kept only for **this browser's in-flight jobs** (live `queued`/`working` status until they land in the ledger). Refreshes on **tab focus**, so a bookmarklet save made in a popup appears when you switch back.

Render order: in-flight (live) on top, then completed ledger entries — slug → `/wiki/<slug>` link, source host, relative time, and a `merged` tag for dedup attaches.

Note: the ledger is commons-wide (not per-user), so "Recent ingests" reflects all recent commons ingest activity — which is the activity feed you'd want here, and it includes your own saves.

Lint 0 errors, full suite **3259 passed**, both builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)