### PR TITLE
yoyo: redesign the /save guide — editorial field-guide (impeccable pass)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -558,3 +558,256 @@ body {
   content: "// ";
   color: var(--accent);
 }
+
+/* ---- Save-to-yopedia guide (/save with no ?url) ----------------------- */
+/* Refined editorial "field guide": big light numerals, a draggable bookmarklet
+   specimen, a two-up magazine pair with a column rule, staggered load. */
+.sg-title {
+  font-size: clamp(2rem, 5vw, 3rem);
+  margin: 14px 0 12px;
+}
+.sg-lede {
+  font-size: clamp(1rem, 1.4vw, 1.12rem);
+  line-height: 1.6;
+  color: var(--ink-2);
+  max-width: 48ch;
+  margin: 0;
+}
+
+/* A numbered method: big editorial numeral + body. */
+.sg-method {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: clamp(16px, 3vw, 30px);
+  padding: clamp(28px, 4vw, 40px) 0;
+  border-top: 1px solid var(--rule);
+  margin-top: clamp(28px, 5vw, 48px);
+}
+.sg-num {
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(2.4rem, 6vw, 3.4rem);
+  line-height: 0.82;
+  letter-spacing: -0.04em;
+  color: var(--rule-strong);
+  font-variant-numeric: tabular-nums;
+}
+.sg-method--hero .sg-num {
+  color: var(--accent);
+}
+.sg-body {
+  min-width: 0;
+}
+.sg-h {
+  font-size: 1.06rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 8px 0 6px;
+}
+.sg-p {
+  font-size: 0.92rem;
+  line-height: 1.6;
+  color: var(--ink-2);
+  margin: 0;
+}
+.sg-p + .sg-p {
+  margin-top: 10px;
+}
+.sg-note {
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--faint);
+  margin-top: 14px;
+}
+.sg-inline {
+  font-family: var(--font-mono);
+  font-size: 0.82em;
+  background: var(--paper-3);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+
+/* Bookmarklet specimen — a recessed tray that makes the chip feel grabbable. */
+.sg-specimen {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+  margin: 16px 0 2px;
+  padding: 18px 20px;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  border-radius: 14px;
+}
+.sg-bm {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 11px 17px;
+  border-radius: 11px;
+  background: var(--accent);
+  color: var(--on-accent);
+  text-decoration: none;
+  cursor: grab;
+  box-shadow: 0 6px 18px -10px color-mix(in oklab, var(--accent) 70%, transparent);
+  transition:
+    transform 0.16s cubic-bezier(0.2, 0.7, 0.2, 1),
+    box-shadow 0.16s;
+}
+.sg-bm:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 26px -10px color-mix(in oklab, var(--accent) 78%, transparent);
+}
+.sg-bm:active {
+  cursor: grabbing;
+  transform: translateY(0) scale(0.99);
+}
+.sg-draghint {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+  color: var(--muted);
+}
+
+/* Copy fallback */
+.sg-details {
+  margin-top: 14px;
+}
+.sg-details > summary {
+  cursor: pointer;
+  font-size: 0.82rem;
+  color: var(--muted);
+  list-style: none;
+}
+.sg-details > summary::-webkit-details-marker {
+  display: none;
+}
+.sg-details > summary::before {
+  content: "▸ ";
+  color: var(--accent);
+}
+.sg-details[open] > summary::before {
+  content: "▾ ";
+}
+.sg-code {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  line-height: 1.5;
+  margin: 10px 0;
+  padding: 12px 14px;
+  background: var(--paper-3);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--ink-2);
+}
+.sg-copy {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--rule);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
+}
+.sg-copy:hover {
+  border-color: var(--accent);
+  color: var(--ink);
+}
+
+/* Android + iOS — magazine two-up with a centered column rule. */
+.sg-pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  padding: clamp(28px, 4vw, 40px) 0;
+  border-top: 1px solid var(--rule);
+  margin-top: clamp(28px, 5vw, 48px);
+}
+.sg-pair > .sg-col:first-child {
+  padding-right: clamp(24px, 4vw, 44px);
+}
+.sg-pair > .sg-col:nth-child(2) {
+  padding-left: clamp(24px, 4vw, 44px);
+  border-left: 1px solid var(--rule);
+}
+.sg-num--sm {
+  font-size: clamp(1.8rem, 4vw, 2.3rem);
+  margin-bottom: 8px;
+}
+.sg-steps {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: sgstep;
+}
+.sg-steps li {
+  position: relative;
+  padding-left: 26px;
+  margin-bottom: 9px;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--ink-2);
+}
+.sg-steps li::before {
+  counter-increment: sgstep;
+  content: counter(sgstep);
+  position: absolute;
+  left: 0;
+  top: 0.1em;
+  width: 17px;
+  height: 17px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 50%;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  color: var(--accent);
+  display: grid;
+  place-items: center;
+  line-height: 1;
+}
+.sg-footnote {
+  margin-top: clamp(30px, 5vw, 52px);
+  padding-top: 20px;
+  border-top: 1px solid var(--rule);
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+/* Staggered entrance (pairs with the existing `.rise`; reduced-motion is
+   already neutralized globally above). */
+.sg-d1 {
+  animation-delay: 0s;
+}
+.sg-d2 {
+  animation-delay: 0.07s;
+}
+.sg-d3 {
+  animation-delay: 0.14s;
+}
+.sg-d4 {
+  animation-delay: 0.21s;
+}
+
+@media (max-width: 640px) {
+  .sg-pair {
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+  }
+  .sg-pair > .sg-col:nth-child(2) {
+    padding-left: 0;
+    border-left: none;
+  }
+  .sg-pair > .sg-col:first-child {
+    padding-right: 0;
+  }
+}

--- a/src/components/SaveGuide.tsx
+++ b/src/components/SaveGuide.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useRef, useState } from "react";
 import { buildBookmarklet } from "@/lib/share-target";
 
 /**
  * The "how to use Save to yopedia" page (rendered at /save with no ?url). Walks a
- * visitor through the three no-extension capture surfaces: a desktop bookmarklet,
- * the PWA share target (Android), and iOS. The bookmarklet is generated from the
- * live origin so it always points at wherever yopedia is served.
+ * visitor through the three no-extension capture surfaces — desktop bookmarklet,
+ * PWA share target (Android), and iOS — as a numbered editorial field guide. The
+ * bookmarklet is generated from the live origin so it always points at wherever
+ * yopedia is served.
  */
 export function SaveGuide() {
   const linkRef = useRef<HTMLAnchorElement>(null);
@@ -30,162 +31,130 @@ export function SaveGuide() {
     } catch {
       // Clipboard can fail (denied permission, insecure context, older browser).
       // This IS the fallback affordance, so tell the user to grab the visible code
-      // above rather than silently resetting to a no-op state.
+      // rather than silently resetting to a no-op state.
       setCopyState("fail");
     }
   }
 
   return (
-    <div className="shell" style={{ maxWidth: 640, margin: "0 auto" }}>
-      <h1 className="display" style={{ fontSize: 30, margin: "0 0 6px" }}>
-        Save to yopedia
-      </h1>
-      <p style={{ color: "var(--muted)", fontSize: 14.5, margin: "0 0 28px", lineHeight: 1.55 }}>
-        Send any page you’re reading to yopedia in one click — it fetches the link
-        and ingests it into the commons. No browser extension required. Pick the
-        method for your device.
-      </p>
-
-      {/* 1 — Desktop bookmarklet */}
-      <section style={sectionStyle}>
-        <h2 style={h2Style}>① Desktop — bookmarklet</h2>
-        <p style={pStyle}>
-          Drag this button up to your bookmarks bar. Then, on any page, click it —
-          a small window opens and saves the page.
+    <div>
+      <header className="rise sg-d1">
+        <p className="fmark">Capture · no extension</p>
+        <h1 className="display sg-title">Save to yopedia</h1>
+        <p className="sg-lede">
+          Send any page you’re reading to yopedia in one click — it fetches the
+          link and ingests it into the commons. No extension to install; pick the
+          method for your device.
         </p>
-        <div style={{ display: "flex", gap: 12, alignItems: "center", flexWrap: "wrap", margin: "14px 0" }}>
-          <a
-            ref={linkRef}
-            href="#"
-            onClick={(e) => e.preventDefault()}
-            draggable
-            title="Drag me to your bookmarks bar"
-            className="receipt"
-            style={{
-              display: "inline-block",
-              fontSize: 13.5,
-              fontWeight: 600,
-              padding: "9px 16px",
-              borderRadius: 8,
-              border: "1px solid var(--rule)",
-              background: "var(--accent-soft)",
-              color: "var(--accent)",
-              textDecoration: "none",
-              cursor: "grab",
-            }}
-          >
-            📑 Save to yopedia
-          </a>
-          <span style={{ fontSize: 12, color: "var(--faint)" }}>← drag me to the bookmarks bar</span>
+      </header>
+
+      {/* 01 — Desktop bookmarklet (the hero method) */}
+      <section className="sg-method sg-method--hero rise sg-d2">
+        <div className="sg-num" aria-hidden="true">
+          01
         </div>
-        <details style={{ fontSize: 12.5, color: "var(--muted)" }}>
-          <summary style={{ cursor: "pointer" }}>Can’t drag it? Copy the code instead</summary>
-          <p style={{ margin: "8px 0" }}>
-            Create a new bookmark and paste this as its URL/address:
+        <div className="sg-body">
+          <p className="fmark">Desktop · bookmarklet</p>
+          <h2 className="sg-h">Drag the button to your bookmarks bar</h2>
+          <p className="sg-p">
+            Then click it on any page — a small window opens and saves what you’re
+            reading.
           </p>
-          <pre style={preStyle}>{bookmarklet}</pre>
-          <button type="button" className="receipt" onClick={copy} style={btnSecondary}>
-            {copyState === "ok"
-              ? "Copied ✓"
-              : copyState === "fail"
-                ? "Copy failed — select the code above"
-                : "Copy code"}
-          </button>
-        </details>
-        <p style={{ ...noteStyle }}>
-          Works in any desktop browser. A few sites (e.g. GitHub, X) block
-          bookmarklets via their security policy — there it won’t run.
-        </p>
+
+          <div className="sg-specimen">
+            <a
+              ref={linkRef}
+              href="#"
+              onClick={(e) => e.preventDefault()}
+              draggable
+              title="Drag me to your bookmarks bar"
+              className="sg-bm"
+            >
+              <svg
+                width="15"
+                height="15"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M6 3h12a1 1 0 0 1 1 1v17l-7-4-7 4V4a1 1 0 0 1 1-1z" />
+              </svg>
+              Save to yopedia
+            </a>
+            <span className="sg-draghint">↑ drag me to the bookmarks bar</span>
+          </div>
+
+          <details className="sg-details">
+            <summary>Can’t drag it? Copy the code</summary>
+            <p className="sg-p" style={{ marginTop: 8 }}>
+              Create a new bookmark and paste this as its address:
+            </p>
+            <pre className="sg-code">{bookmarklet}</pre>
+            <button type="button" onClick={copy} className="sg-copy">
+              {copyState === "ok"
+                ? "Copied ✓"
+                : copyState === "fail"
+                  ? "Copy failed — select the code above"
+                  : "Copy code"}
+            </button>
+          </details>
+
+          <p className="sg-note">
+            Works in any desktop browser. A few sites (e.g. GitHub, X) block
+            bookmarklets via their security policy — there it won’t run.
+          </p>
+        </div>
       </section>
 
-      {/* 2 — Android / PWA share target */}
-      <section style={sectionStyle}>
-        <h2 style={h2Style}>② Android — install &amp; share</h2>
-        <ol style={olStyle}>
-          <li>
-            Open yopedia in Chrome → menu (⋮) → <strong>Install app</strong> (or
-            “Add to Home screen”).
-          </li>
-          <li>
-            Now in any app, tap <strong>Share</strong> → choose{" "}
-            <strong>yopedia</strong> from the share sheet. The link is saved.
-          </li>
-        </ol>
-        <p style={noteStyle}>
-          Uses the Web Share Target — yopedia registers as a share destination
-          once installed.
-        </p>
-      </section>
+      {/* 02 + 03 — Android & iOS, magazine two-up */}
+      <div className="sg-pair rise sg-d3">
+        <section className="sg-col">
+          <div className="sg-num sg-num--sm" aria-hidden="true">
+            02
+          </div>
+          <p className="fmark">Android · install &amp; share</p>
+          <ol className="sg-steps">
+            <li>
+              Open yopedia in Chrome → menu (⋮) → <strong>Install app</strong> (or
+              “Add to Home screen”).
+            </li>
+            <li>
+              In any app, tap <strong>Share</strong> → choose{" "}
+              <strong>yopedia</strong>. The link is saved.
+            </li>
+          </ol>
+          <p className="sg-note">
+            Uses the Web Share Target — yopedia registers as a share destination
+            once installed.
+          </p>
+        </section>
 
-      {/* 3 — iOS */}
-      <section style={{ ...sectionStyle, borderBottom: "none" }}>
-        <h2 style={h2Style}>③ iPhone / iPad</h2>
-        <p style={pStyle}>
-          iOS Safari doesn’t support share-to-web-app, so use one of these:
-        </p>
-        <p style={{ ...pStyle, marginTop: 10 }}>
-          <strong>Bookmarklet (simplest):</strong> in Safari, bookmark any page,
-          then edit that bookmark and replace its address with the copied code
-          above. Tap it from your bookmarks on any page to save.
-        </p>
-        <p style={{ ...pStyle, marginTop: 10 }}>
-          <strong>Share-sheet Shortcut:</strong> open the Shortcuts app → new
-          shortcut → enable <em>Use with Share Sheet</em> (accept URLs) → add an{" "}
-          <em>Open URLs</em> action with{" "}
-          <code style={codeStyle}>/save?url=</code> + the Shortcut input. Then{" "}
-          Share → your shortcut.
-        </p>
-      </section>
+        <section className="sg-col">
+          <div className="sg-num sg-num--sm" aria-hidden="true">
+            03
+          </div>
+          <p className="fmark">iPhone · iPad</p>
+          <p className="sg-p">iOS Safari can’t share to a web app, so use one of:</p>
+          <p className="sg-p">
+            <strong>Bookmarklet</strong> — in Safari, bookmark any page, then edit
+            it and paste the copied code as its address.
+          </p>
+          <p className="sg-p">
+            <strong>Shortcut</strong> — Shortcuts app → new → enable{" "}
+            <em>Use with Share Sheet</em> → an <em>Open URLs</em> action with{" "}
+            <code className="sg-inline">/save?url=</code> + the input.
+          </p>
+        </section>
+      </div>
 
-      <p style={{ marginTop: 28, fontSize: 13, color: "var(--muted)" }}>
-        Saving requires a signed-in yopedia account — the first save will prompt
-        you to sign in, then continue.
+      <p className="sg-footnote rise sg-d4">
+        Saving needs a signed-in account — the first save prompts you to sign in,
+        then continues.
       </p>
     </div>
   );
 }
-
-const sectionStyle: CSSProperties = {
-  padding: "20px 0",
-  borderBottom: "1px solid var(--rule)",
-};
-const h2Style: CSSProperties = { fontSize: 16, margin: "0 0 8px" };
-const pStyle: CSSProperties = { fontSize: 13.5, color: "var(--ink)", margin: 0, lineHeight: 1.6 };
-const noteStyle: CSSProperties = {
-  fontSize: 12,
-  color: "var(--faint)",
-  margin: "12px 0 0",
-  lineHeight: 1.5,
-};
-const olStyle: CSSProperties = {
-  fontSize: 13.5,
-  color: "var(--ink)",
-  lineHeight: 1.7,
-  margin: 0,
-  paddingLeft: 20,
-};
-const preStyle: CSSProperties = {
-  fontSize: 11,
-  background: "var(--surface, #18181b0a)",
-  border: "1px solid var(--rule)",
-  borderRadius: 6,
-  padding: 10,
-  overflow: "auto",
-  whiteSpace: "pre-wrap",
-  wordBreak: "break-all",
-};
-const codeStyle: CSSProperties = {
-  fontSize: 12,
-  background: "var(--surface, #18181b0a)",
-  padding: "1px 5px",
-  borderRadius: 4,
-};
-const btnSecondary: CSSProperties = {
-  fontSize: 12.5,
-  padding: "6px 12px",
-  borderRadius: 8,
-  border: "1px solid var(--rule)",
-  background: "transparent",
-  color: "var(--muted)",
-  cursor: "pointer",
-};


### PR DESCRIPTION
Reworked the `/save` how-to page from plain stacked text into a refined **editorial field guide**, cohesive with the folio design system (warm paper, SF Pro display, indigo accent, the existing `.fmark` label + `.rise` keyframes).

**What changed (design only — no logic):**
- **Hero** — a `.fmark` kicker ("Capture · no extension"), large fluid title, tight lede.
- **01 Desktop** — a big light **accent numeral** as a left rail; the bookmarklet is now a prominent **draggable "specimen"** in a recessed tray (grab cursor, hover lift, drag hint, bookmark glyph) instead of a small mono chip; copy fallback tucked in a quiet `<details>`.
- **02 Android / 03 iOS** — a **magazine two-up with a centered column rule** (stacks on mobile); Android as circled numbered steps.
- **One orchestrated staggered fade-up** on load (reuses `.rise`; reduced-motion already neutralized globally).

Everything uses **theme tokens**, so light and dark both work. Scoped `.sg-*` styles added to `globals.css`; the component keeps the same bookmarklet generation, copy state, and `share-target` helpers.

Verified rendered on desktop + mobile via Playwright. Lint 0 errors, `pnpm build` clean. (The `share-target` tests are unchanged and still green.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)