### PR TITLE
yoyo: save popup — single "Close" button (drop in-popup "View activity")

### DIFF
--- a/src/components/SaveCapture.tsx
+++ b/src/components/SaveCapture.tsx
@@ -150,12 +150,12 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
           </div>
 
           <div style={{ marginTop: 22, display: "flex", gap: 10 }}>
+            {/* A popup's only post-save action is to close it. (No in-popup
+                "View activity" nav — it re-mounts this page and re-fires the
+                save; the server dedups it, but closing is the right action.) */}
             <button type="button" className="receipt" onClick={() => window.close()} style={btnPrimary}>
-              Done
+              Close
             </button>
-            <a href="/ingest" className="receipt" style={{ ...btnSecondary, textDecoration: "none", lineHeight: "1.9" }}>
-              View activity
-            </a>
           </div>
         </div>
       )}


### PR DESCRIPTION
After a save, the popup's only sensible action is to close it. The old "View activity" button navigated `/ingest` *inside* the popup (clunky) and was the one path that re-mounted `SaveCapture` and re-fired `/api/ingest` on back-navigation.

That re-fire is harmless — the server dedups a same-URL ingest, short-circuiting **before fetch/LLM/embedding** (zero tokens; surfaces as the "merged" tag) — but closing is the right action. So: replace the two buttons (`Done` + `View activity`) with a single **Close**.

Lint 0 errors, `pnpm build` clean. No logic change to the save itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)