### PR TITLE
yoyo: auto-upgrade a stuck X Article teaser on re-ingest

### DIFF
--- a/src/lib/__tests__/x-article-teaser-upgrade.test.ts
+++ b/src/lib/__tests__/x-article-teaser-upgrade.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+// No LLM key → ingest stores content as-is (no synthesis). Keeps this test about
+// the dedup teaser-upgrade CONTROL FLOW (re-fetch + re-ingest vs plain attach),
+// not about LLM distillation.
+vi.mock("../llm", () => ({
+  hasLLMKey: vi.fn(() => false),
+  callLLM: vi.fn(),
+}));
+
+// Partial-mock x-post: keep the REAL teaser detection (isXArticleTeaser,
+// X_ARTICLE_TEASER_NOTE) so we test the actual contract, but control whether a
+// URL is treated as an X post and what the fetch returns (teaser vs full body).
+vi.mock("../x-post", async (orig) => {
+  const actual = await orig<typeof import("../x-post")>();
+  return {
+    ...actual,
+    isXPostUrl: vi.fn(),
+    fetchXPostContent: vi.fn(),
+  };
+});
+
+import { ingestUrl } from "../ingest";
+import { readWikiPageWithFrontmatter, listWikiPages } from "../wiki";
+import { resetSourceIndex } from "../source-index";
+import {
+  isXPostUrl,
+  fetchXPostContent,
+  X_ARTICLE_TEASER_NOTE,
+} from "../x-post";
+
+const mockedIsXPostUrl = vi.mocked(isXPostUrl);
+const mockedFetch = vi.mocked(fetchXPostContent);
+
+const X_URL = "https://x.com/richardzphotoz/status/2068368840891994142";
+const TITLE = "Richard's Photography Essay";
+
+// A teaser body carries the real sentinel line (so the REAL isXArticleTeaser
+// recognizes it); the full body does not.
+const TEASER_BODY = [
+  `# ${TITLE}`,
+  "",
+  "This is just the first sentence of the essay…",
+  "",
+  X_ARTICLE_TEASER_NOTE,
+  "",
+  `**Source:** [${X_URL}](${X_URL})`,
+].join("\n");
+
+const FULL_BODY = [
+  `# ${TITLE}`,
+  "",
+  "This is the complete article body with several paragraphs of real",
+  "content that the X API returned once the bearer token was in place.",
+  "It covers composition, light, and the craft of street photography.",
+  "",
+  `**Source:** [${X_URL}](${X_URL})`,
+].join("\n");
+
+let tmpDir: string;
+let originalWikiDir: string | undefined;
+let originalRawDir: string | undefined;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "x-teaser-test-"));
+  originalWikiDir = process.env.WIKI_DIR;
+  originalRawDir = process.env.RAW_DIR;
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  resetSourceIndex();
+  mockedIsXPostUrl.mockReset();
+  mockedFetch.mockReset();
+});
+
+afterEach(async () => {
+  if (originalWikiDir === undefined) delete process.env.WIKI_DIR;
+  else process.env.WIKI_DIR = originalWikiDir;
+  if (originalRawDir === undefined) delete process.env.RAW_DIR;
+  else process.env.RAW_DIR = originalRawDir;
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  resetSourceIndex();
+});
+
+describe("X Article teaser auto-upgrade on re-ingest", () => {
+  it("re-saving a teaser page rewrites it in place once the full body is available", async () => {
+    mockedIsXPostUrl.mockReturnValue(true);
+
+    // First save: API can't serve the body yet → a teaser page lands.
+    mockedFetch.mockResolvedValueOnce({ title: TITLE, content: TEASER_BODY });
+    const first = await ingestUrl(X_URL);
+    const slug = first.primarySlug;
+    const teaserPage = await readWikiPageWithFrontmatter(slug);
+    expect(teaserPage?.body).toContain("Article preview only");
+
+    // Second save of the SAME url: dedup would normally freeze the teaser, but
+    // now the fetch returns the full body → the page upgrades in place.
+    mockedFetch.mockResolvedValueOnce({ title: TITLE, content: FULL_BODY });
+    const second = await ingestUrl(X_URL);
+
+    // Same canonical page (pinSlug), no second page created.
+    expect(second.primarySlug).toBe(slug);
+    const pages = await listWikiPages();
+    expect(pages.filter((p) => p.slug === slug)).toHaveLength(1);
+
+    // Body is now the full article, teaser sentinel gone.
+    const upgraded = await readWikiPageWithFrontmatter(slug);
+    expect(upgraded?.body).not.toContain("Article preview only");
+    expect(upgraded?.body).toContain("complete article body");
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-saving a perma-teaser leaves the page as a teaser (plain attach, no rewrite)", async () => {
+    mockedIsXPostUrl.mockReturnValue(true);
+
+    // First save → teaser.
+    mockedFetch.mockResolvedValueOnce({ title: TITLE, content: TEASER_BODY });
+    const first = await ingestUrl(X_URL);
+    const slug = first.primarySlug;
+
+    // Second save: still a teaser (out-of-window / token rejected). The dedup
+    // re-fetches (cheap) but, finding no full body, falls through to attach —
+    // the page is NOT rewritten.
+    mockedFetch.mockResolvedValueOnce({ title: TITLE, content: TEASER_BODY });
+    const second = await ingestUrl(X_URL);
+
+    expect(second.primarySlug).toBe(slug);
+    const page = await readWikiPageWithFrontmatter(slug);
+    expect(page?.body).toContain("Article preview only");
+    // It DID re-fetch (the upgrade probe), it just didn't find a full body.
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not probe non-teaser X pages on re-ingest (already full → plain attach)", async () => {
+    mockedIsXPostUrl.mockReturnValue(true);
+
+    // First save lands a FULL page.
+    mockedFetch.mockResolvedValueOnce({ title: TITLE, content: FULL_BODY });
+    const first = await ingestUrl(X_URL);
+    const slug = first.primarySlug;
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+
+    // Re-save: dedup sees a non-teaser page → attaches without a re-fetch.
+    const second = await ingestUrl(X_URL);
+    expect(second.primarySlug).toBe(slug);
+    expect(mockedFetch).toHaveBeenCalledTimes(1); // no upgrade probe
+  });
+});

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -15,7 +15,7 @@ import { callLLM, hasLLMKey } from "./llm";
 import { fetchUrlContent, fetchImageBytes, storeImageBytes, pdfToText } from "./fetch";
 import { describeImage } from "./vision";
 import { isYouTubeUrl, fetchYouTubeContent } from "./youtube";
-import { isXPostUrl, fetchXPostContent } from "./x-post";
+import { isXPostUrl, fetchXPostContent, isXArticleTeaser } from "./x-post";
 import type { IngestResult, SourceEntry } from "./types";
 import {
   serializeSources,
@@ -218,6 +218,28 @@ export async function ingestUrl(
   {
     const dupSlug = await resolveSourceUrl(url);
     if (dupSlug) {
+      // Exception: an X Article that previously landed as a truncated TEASER
+      // (no X_BEARER_TOKEN at first ingest, or briefly out of the ~7-day window)
+      // must NOT be frozen by dedup. Re-fetch — cheap: syndication + at most one
+      // API call, no LLM yet — and ONLY if the full body is now available do we
+      // re-synthesize it in place (pinSlug). A still-teaser result falls through
+      // to a plain attach, so a perma-teaser (genuinely old article) spends no
+      // extra LLM tokens. Net: a re-save self-heals a teaser the moment the token
+      // / window allow the full body, with no manual reingest.
+      if (isXPostUrl(url)) {
+        const existing = await readWikiPageWithFrontmatter(dupSlug);
+        if (existing && isXArticleTeaser(existing.body)) {
+          const fresh = await fetchXPostContent(url);
+          if (!isXArticleTeaser(fresh.content)) {
+            return ingest(fresh.title, fresh.content, {
+              ...options,
+              sourceUrl: url,
+              sourceType: options?.sourceType ?? "x-mention",
+              pinSlug: dupSlug,
+            });
+          }
+        }
+      }
       const result = await attachIngestTrigger(dupSlug, {
         url,
         type: options?.sourceType ?? "url",

--- a/src/lib/x-post.ts
+++ b/src/lib/x-post.ts
@@ -334,6 +334,24 @@ async function fetchArticleViaApi(id: string, url: string): Promise<XPostContent
 }
 
 /**
+ * Sentinel line stamped onto a teaser-only X Article page (full body NOT
+ * fetched). Lets the ingest dedup recognize a page that's still a teaser and
+ * auto-upgrade it on a later re-ingest once the API can serve the full body —
+ * see {@link isXArticleTeaser}.
+ */
+export const X_ARTICLE_TEASER_NOTE =
+  "_Article preview only — see the source for the full article._";
+
+/**
+ * True when `content` is a teaser-only X Article (the full body wasn't fetched).
+ * Substring match on the stable part of {@link X_ARTICLE_TEASER_NOTE} so light
+ * edits to the surrounding punctuation don't defeat detection.
+ */
+export function isXArticleTeaser(content: string): boolean {
+  return content.includes("Article preview only");
+}
+
+/**
  * Build an article page from the syndication CDN's truncated `preview_text` +
  * cover — the fallback when the API can't serve the full body (no token, an
  * article older than the recent-search window, or a rate-limit hiccup). Returns
@@ -358,8 +376,8 @@ function formatSyndicationArticle(
   if (cover) lines.push(`![${title}](${cover})`, "");
   lines.push(preview, "");
   // Be honest this is the truncated teaser, not the full body, so the page (and
-  // anyone reviewing it) can tell it's partial and re-ingest once available.
-  lines.push("_Article preview only — see the source for the full article._", "");
+  // the ingest dedup) can tell it's partial and auto-upgrade once available.
+  lines.push(X_ARTICLE_TEASER_NOTE, "");
   lines.push(`**Source:** [${url}](${url})`);
   return { title, content: lines.join("\n").trim() };
 }


### PR DESCRIPTION
## Problem

Saving an X **Article** sometimes lands a truncated **teaser** (~199-char preview) instead of the full body. This happens when the full body isn't available at ingest time — no `X_BEARER_TOKEN` yet, or the post is briefly outside the recent-search ~7-day window. The real failure was that the teaser then got **frozen forever**: re-saving the same link hit URL dedup (`resolveSourceUrl` → `attachIngestTrigger`), which "skips the fetch + LLM + embedding entirely", so the full body could never backfill without a manual `reingest`.

The motivating case: `x.com/richardzphotoz/status/2068368840891994142` was ingested as a teaser *before* the token was set, and dedup kept re-serving the teaser on every re-save.

## Fix

`ingestUrl`'s dedup branch now recognizes a teaser X page and auto-upgrades it:

1. A teaser page carries a stable sentinel line stamped by the syndication fallback — `X_ARTICLE_TEASER_NOTE` / `isXArticleTeaser()` (substring match, edit-tolerant).
2. On re-ingest of an X URL whose deduped page is a teaser, re-fetch **once** — cheap (syndication + at most one API call, **no LLM**).
3. **Only** if the full body is now available, re-synthesize in place (`pinSlug` → same slug, no second page).
4. A still-teaser result falls through to the normal attach — a genuinely-old perma-teaser spends **zero extra LLM tokens**.

Net: re-saving the link **self-heals** the page the moment the token/window allow the full body — no manual reingest, and token-efficient on the common path.

## Tests

New `src/lib/__tests__/x-article-teaser-upgrade.test.ts` (real teaser detection, mocked X fetch, no LLM key → pure control-flow):
- teaser → re-save with full body now available → page rewritten in place, same slug, one page, sentinel gone
- teaser → re-save still teaser → plain attach, page unchanged (re-fetch probe happened, no rewrite)
- full page → re-save → attach with **no** upgrade probe (no wasted fetch)

## Gates

- `pnpm lint` — 0 errors
- `vitest` — 3265 passed
- `pnpm build` + `pnpm build:cloudflare` — clean

## Verify after deploy

Re-save the article link once. It should upgrade to the full body (token is set). If it *stays* a teaser, the token is being rejected — visible as 401/403 in `wrangler tail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)