### PR TITLE
yoyo: bookmarklet save flow — confirm-before-save + in-flight tracking on /ingest

### DIFF
--- a/src/components/SaveCapture.tsx
+++ b/src/components/SaveCapture.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { useUser, useClerk } from "@clerk/nextjs";
 import { IngestVaultPicker } from "./IngestVaultPicker";
 import { hostOf } from "@/lib/share-target";
+import { rememberRecentJob } from "@/lib/recent-ingests";
 
 type Status = "loading" | "signin" | "saving" | "saved" | "error";
 
@@ -40,12 +41,20 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
         setStatus("signin");
         return;
       }
+      const data = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        jobId?: string;
+      };
       if (!res.ok) {
-        const data = (await res.json().catch(() => ({}))) as { error?: string };
         setError(data.error ?? `Save failed (${res.status})`);
         setStatus("error");
         return;
       }
+      // Record the queued job so the /ingest "Recent ingests" strip shows this
+      // save IN FLIGHT. localStorage is shared across same-origin tabs and that
+      // page refreshes on focus, so a popup/bookmarklet save surfaces as a live
+      // "working…" row instead of only appearing once it lands in the ledger.
+      if (data.jobId) rememberRecentJob(data.jobId);
       setStatus("saved");
     } catch (e) {
       setError(e instanceof Error ? e.message : "Network error");

--- a/src/components/SaveCapture.tsx
+++ b/src/components/SaveCapture.tsx
@@ -8,9 +8,10 @@ import { rememberRecentJob } from "@/lib/recent-ingests";
 
 type Status = "loading" | "signin" | "confirm" | "saving" | "saved" | "error";
 
-/** Strip the "(3) " unread-count prefix browsers prepend to a page <title>. */
+/** Strip the "(3)"/"(99+)" unread-count prefix browsers prepend to a page
+ *  <title>, and trim surrounding whitespace. */
 function cleanTitle(t?: string): string {
-  return (t ?? "").replace(/^\(\d+\)\s*/, "").trim();
+  return (t ?? "").replace(/^\(\d+\+?\)\s*/, "").trim();
 }
 
 /**
@@ -30,6 +31,7 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
   const [error, setError] = useState<string | null>(null);
 
   async function save() {
+    if (status === "saving") return; // guard against double-submit / Enter-mash
     setStatus("saving");
     setError(null);
     try {
@@ -44,6 +46,10 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
         }),
       });
       if (res.status === 401) {
+        // Session expired between landing here and clicking Save. editTitle +
+        // vaultId are component state, so they survive the re-auth — but tell the
+        // user WHY they're back at sign-in so the dropped save isn't silent.
+        setError("Your session expired — sign in to finish saving.");
         setStatus("signin");
         return;
       }
@@ -61,6 +67,10 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
       // page refreshes on focus, so a popup/bookmarklet save surfaces as a live
       // "working…" row instead of only appearing once it lands in the ledger.
       if (data.jobId) rememberRecentJob(data.jobId);
+      // The URL path always returns a jobId; a 200 without one means a malformed
+      // (e.g. edge-proxied) response — the save shows "saved" but won't appear in
+      // Recent ingests, so leave a breadcrumb rather than failing silently.
+      else console.warn("[SaveCapture] ingest returned 200 without a jobId — not tracked in Recent ingests");
       setStatus("saved");
     } catch (e) {
       setError(e instanceof Error ? e.message : "Network error");
@@ -68,17 +78,25 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
     }
   }
 
+  // Dismiss the capture view. A bookmarklet popup is script-opened so
+  // window.close() works; the PWA-share / iOS-Shortcut surfaces open a normal
+  // tab where close() is a no-op — fall back to navigating so the button isn't
+  // dead.
+  function dismiss(fallback: string) {
+    window.close();
+    setTimeout(() => {
+      if (!window.closed) window.location.href = fallback;
+    }, 120);
+  }
+
   // Move to the confirm step once signed in (or the sign-in prompt if not) —
   // but never clobber an in-progress / finished save.
   useEffect(() => {
     if (!isLoaded) return;
-    setStatus((s) =>
-      s === "saving" || s === "saved" || s === "error"
-        ? s
-        : isSignedIn
-          ? "confirm"
-          : "signin",
-    );
+    setStatus((s) => {
+      if (s === "saving" || s === "saved" || s === "error") return s;
+      return isSignedIn ? "confirm" : "signin";
+    });
   }, [isLoaded, isSignedIn]);
 
   const host = hostOf(url);
@@ -107,6 +125,11 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
 
       {status === "signin" && (
         <div>
+          {error && (
+            <p style={{ fontSize: 13, color: "var(--danger, #dc2626)", marginBottom: 10 }}>
+              {error}
+            </p>
+          )}
           <p style={{ fontSize: 13.5, marginBottom: 12 }}>
             Sign in to save this page to yopedia.
           </p>
@@ -132,7 +155,7 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
         >
           <label
             className="receipt"
-            style={{ display: "block", fontSize: 11.5, color: "var(--muted)", marginBottom: 6 }}
+            style={labelStyle}
           >
             Title
           </label>
@@ -157,7 +180,7 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
 
           <label
             className="receipt"
-            style={{ display: "block", fontSize: 11.5, color: "var(--muted)", marginBottom: 6 }}
+            style={labelStyle}
           >
             Vault (optional)
           </label>
@@ -169,7 +192,7 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
             <button type="submit" className="receipt" style={btnPrimary}>
               Save
             </button>
-            <button type="button" className="receipt" onClick={() => window.close()} style={btnSecondary}>
+            <button type="button" className="receipt" onClick={() => dismiss("/")} style={btnSecondary}>
               Cancel
             </button>
           </div>
@@ -204,10 +227,10 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
           </p>
 
           <div style={{ marginTop: 22, display: "flex", gap: 10 }}>
-            {/* A popup's only post-save action is to close it. (No in-popup
-                "View activity" nav — it re-mounts this page and re-fires the
-                save; the server dedups it, but closing is the right action.) */}
-            <button type="button" className="receipt" onClick={() => window.close()} style={btnPrimary}>
+            {/* Post-save, the only action is to dismiss. (No in-popup "View
+                activity" nav — re-mounting drops back to the confirm step, which
+                is confusing right after a save; dismissing is the right action.) */}
+            <button type="button" className="receipt" onClick={() => dismiss("/ingest")} style={btnPrimary}>
               Close
             </button>
           </div>
@@ -225,6 +248,13 @@ const btnPrimary: CSSProperties = {
   background: "var(--accent-soft)",
   color: "var(--accent)",
   cursor: "pointer",
+};
+
+const labelStyle: CSSProperties = {
+  display: "block",
+  fontSize: 11.5,
+  color: "var(--muted)",
+  marginBottom: 6,
 };
 
 const btnSecondary: CSSProperties = {

--- a/src/components/SaveCapture.tsx
+++ b/src/components/SaveCapture.tsx
@@ -1,40 +1,46 @@
 "use client";
 
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import { useUser, useClerk } from "@clerk/nextjs";
 import { IngestVaultPicker } from "./IngestVaultPicker";
 import { hostOf } from "@/lib/share-target";
 import { rememberRecentJob } from "@/lib/recent-ingests";
 
-type Status = "loading" | "signin" | "saving" | "saved" | "error";
+type Status = "loading" | "signin" | "confirm" | "saving" | "saved" | "error";
+
+/** Strip the "(3) " unread-count prefix browsers prepend to a page <title>. */
+function cleanTitle(t?: string): string {
+  return (t ?? "").replace(/^\(\d+\)\s*/, "").trim();
+}
 
 /**
  * The capture target for all three surfaces (bookmarklet popup, PWA share, iOS
  * Shortcut). It runs on yopedia's own origin, so the user's session cookie
- * authenticates the save automatically. When signed in it fires `POST /api/ingest`
- * immediately (the click/share WAS the intent), shows status, and offers to also
- * file the page into a vault. Signed-out → a sign-in prompt; the save fires once
- * the session lands.
+ * authenticates the save. When signed in it shows a CONFIRM step — the captured
+ * URL, an editable title (the raw page <title> is often noisy), and a vault
+ * picker — and nothing is ingested until the user clicks Save. Signed-out → a
+ * sign-in prompt, then the confirm step once the session lands.
  */
 export function SaveCapture({ url, title }: { url: string; title?: string }) {
   const { isSignedIn, isLoaded } = useUser();
   const { openSignIn } = useClerk();
   const [status, setStatus] = useState<Status>("loading");
+  const [editTitle, setEditTitle] = useState(cleanTitle(title));
   const [vaultId, setVaultId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const firedRef = useRef(false);
 
-  async function save(vault: string | null) {
+  async function save() {
     setStatus("saving");
     setError(null);
     try {
+      const trimmed = editTitle.trim();
       const res = await fetch("/api/ingest", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           url,
-          ...(title ? { title } : {}),
-          ...(vault ? { vaultId: vault } : {}),
+          ...(trimmed ? { title: trimmed } : {}),
+          ...(vaultId ? { vaultId } : {}),
         }),
       });
       if (res.status === 401) {
@@ -62,19 +68,17 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
     }
   }
 
-  // Auto-fire once when signed in. The bookmarklet/share click is itself the
-  // intent to save, so we don't make the user click again. Re-ingesting the same
-  // URL is deduped server-side, so a refresh is harmless.
+  // Move to the confirm step once signed in (or the sign-in prompt if not) —
+  // but never clobber an in-progress / finished save.
   useEffect(() => {
     if (!isLoaded) return;
-    if (!isSignedIn) {
-      setStatus("signin");
-      return;
-    }
-    if (firedRef.current) return;
-    firedRef.current = true;
-    void save(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setStatus((s) =>
+      s === "saving" || s === "saved" || s === "error"
+        ? s
+        : isSignedIn
+          ? "confirm"
+          : "signin",
+    );
   }, [isLoaded, isSignedIn]);
 
   const host = hostOf(url);
@@ -94,8 +98,6 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
         }}
         title={url}
       >
-        {title ? <strong style={{ color: "var(--ink)" }}>{title}</strong> : null}
-        {title ? <br /> : null}
         {url}
       </p>
 
@@ -112,13 +114,66 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
             type="button"
             className="receipt"
             // Modal sign-in keeps us on this page; once the session lands,
-            // isSignedIn flips and the auto-save effect fires. No redirect needed.
+            // isSignedIn flips and the effect advances to the confirm step.
             onClick={() => openSignIn()}
             style={btnPrimary}
           >
-            Sign in & save
+            Sign in
           </button>
         </div>
+      )}
+
+      {status === "confirm" && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void save();
+          }}
+        >
+          <label
+            className="receipt"
+            style={{ display: "block", fontSize: 11.5, color: "var(--muted)", marginBottom: 6 }}
+          >
+            Title
+          </label>
+          <input
+            type="text"
+            value={editTitle}
+            onChange={(e) => setEditTitle(e.target.value)}
+            autoFocus
+            placeholder={host}
+            style={{
+              width: "100%",
+              fontSize: 14,
+              padding: "8px 10px",
+              borderRadius: 8,
+              border: "1px solid var(--rule)",
+              background: "var(--paper)",
+              color: "var(--ink)",
+              marginBottom: 14,
+              boxSizing: "border-box",
+            }}
+          />
+
+          <label
+            className="receipt"
+            style={{ display: "block", fontSize: 11.5, color: "var(--muted)", marginBottom: 6 }}
+          >
+            Vault (optional)
+          </label>
+          <div style={{ marginBottom: 22 }}>
+            <IngestVaultPicker value={vaultId} onChange={setVaultId} />
+          </div>
+
+          <div style={{ display: "flex", gap: 10 }}>
+            <button type="submit" className="receipt" style={btnPrimary}>
+              Save
+            </button>
+            <button type="button" className="receipt" onClick={() => window.close()} style={btnSecondary}>
+              Cancel
+            </button>
+          </div>
+        </form>
       )}
 
       {status === "saving" && (
@@ -130,9 +185,14 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
           <p style={{ fontSize: 13.5, color: "var(--danger, #dc2626)", marginBottom: 12 }}>
             {error}
           </p>
-          <button type="button" className="receipt" onClick={() => save(vaultId)} style={btnPrimary}>
-            Retry
-          </button>
+          <div style={{ display: "flex", gap: 10 }}>
+            <button type="button" className="receipt" onClick={() => save()} style={btnPrimary}>
+              Retry
+            </button>
+            <button type="button" className="receipt" onClick={() => setStatus("confirm")} style={btnSecondary}>
+              Edit
+            </button>
+          </div>
         </div>
       )}
 
@@ -142,21 +202,6 @@ export function SaveCapture({ url, title }: { url: string; title?: string }) {
             <span style={{ color: "var(--accent)" }}>✓ Saved.</span> yopedia is reading{" "}
             <strong>{host}</strong> now — it’ll appear in the commons shortly.
           </p>
-
-          <label
-            className="receipt"
-            style={{ display: "block", fontSize: 11.5, color: "var(--muted)", marginBottom: 6 }}
-          >
-            Also file it in a vault (optional)
-          </label>
-          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-            <IngestVaultPicker value={vaultId} onChange={setVaultId} />
-            {vaultId && (
-              <button type="button" className="receipt" onClick={() => save(vaultId)} style={btnSecondary}>
-                Add to vault
-              </button>
-            )}
-          </div>
 
           <div style={{ marginTop: 22, display: "flex", gap: 10 }}>
             {/* A popup's only post-save action is to close it. (No in-popup


### PR DESCRIPTION
Reworks the "Save to yopedia" capture popup (`SaveCapture`, used by the bookmarklet / PWA share / iOS shortcut). Two related changes:

## 1. Confirm-before-save (replaces auto-ingest)

Previously the popup fired `POST /api/ingest` automatically on open. Now it shows a **confirm step**:
- the captured **URL** (read-only),
- an **editable title** — prefilled from the page `<title>` with the `"(3) "` unread-count prefix stripped (the raw title is often noisy, e.g. `(2) richard on X: "18 lessons…" / X`),
- a **vault picker**,
- **Save** / **Cancel**.

Nothing ingests until Save. This fixes two rough edges of auto-save: a junky `<title>` became the page title with no chance to correct it, and vault choice was a second write *after* the save. Sign-in now lands on the confirm step instead of auto-firing.

## 2. In-flight tracking on /ingest

`SaveCapture` now records the queued `jobId` (`rememberRecentJob`). localStorage is shared same-origin and `/ingest` refreshes its "Recent ingests" strip on focus, so a bookmarklet save shows a live "working…" row, then transitions to the completed ledger row — previously a capture-surface save only appeared after completion.

## Gates
`pnpm lint` 0 errors · `pnpm build` + `pnpm build:cloudflare` clean.

(No unit test — `SaveCapture` is a Clerk-wired client component.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)