### PR TITLE
yoyo: guarantee HTML artifacts center + match the in-app light/dark theme

### DIFF
--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -38,6 +38,23 @@ export function HtmlPreview({
   // frame instead of auto-height; see the iframe below.
   const appStyle = usesViewportUnits(html);
 
+  // Match the artifact's paper/ink to the page's RESOLVED theme (yopedia toggles
+  // a `dark`/`light` class on <html> via localStorage; the sandboxed iframe can't
+  // read that, so we read it here and bake it into the srcDoc). Re-render when the
+  // user flips the toggle so the artifact follows.
+  // Start "light" (SSR-stable, avoids a srcDoc hydration mismatch); the effect
+  // below corrects to the real theme on mount before paint settles.
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+  useEffect(() => {
+    const root = document.documentElement;
+    const sync = () =>
+      setTheme(root.classList.contains("dark") ? "dark" : "light");
+    sync();
+    const obs = new MutationObserver(sync);
+    obs.observe(root, { attributes: true, attributeFilter: ["class"] });
+    return () => obs.disconnect();
+  }, []);
+
   // Lazy-load the (~200KB) Chart.js source ONLY for documents that actually use
   // it, so prose/table answers don't pay for it. The chartless render happens
   // immediately; a chart document re-renders once the library resolves.
@@ -119,7 +136,7 @@ export function HtmlPreview({
       // feedback-loops them to absurd heights — so we fix the frame and let
       // them scroll INSIDE it, with that inner scrollbar hidden. Full-screen
       // share (`bare`) fills the viewport; inline gets a tall contained frame.
-      srcDoc={composeSrcDoc(renderedHtml, chartLib, bare || appStyle)}
+      srcDoc={composeSrcDoc(renderedHtml, chartLib, bare || appStyle, theme)}
       sandbox={HTML_SANDBOX}
       title="HTML output"
       style={{

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -43,7 +43,8 @@ export function HtmlPreview({
   // read that, so we read it here and bake it into the srcDoc). Re-render when the
   // user flips the toggle so the artifact follows.
   // Start "light" (SSR-stable, avoids a srcDoc hydration mismatch); the effect
-  // below corrects to the real theme on mount before paint settles.
+  // below corrects to the real theme immediately on mount (one frame after first
+  // paint — useEffect, not useLayoutEffect, which would warn under SSR).
   const [theme, setTheme] = useState<"light" | "dark">("light");
   useEffect(() => {
     const root = document.documentElement;

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -155,24 +155,46 @@ describe("composeSrcDoc", () => {
     // it — so even un-wrapped content (no <main>/.doc) sits in a column whose
     // edges match the full-width yoyo illustrations.
     expect(out).toContain("--measure:50rem");
-    expect(out).toContain("body{max-width:var(--measure);margin-inline:auto}");
+    // The cap is plain `body{}` (overridable); the centering is `html body{}`
+    // (0,0,2) so a model `margin:0` reset can't cancel it.
+    expect(out).toContain("body{max-width:var(--measure)}");
+    expect(out).toContain("html body{margin-inline:auto}");
     // All three consumers share the token: the body column, the wrapper, and
     // the illustration figure — so they align whether or not content is wrapped.
     expect(out).toContain(".doc,main,article{max-width:var(--measure)");
     expect(out).toContain("figure.yoyo-illustration{max-width:var(--measure)");
   });
 
-  it("injects the body-column cap BEFORE the model's own <style> so the model can override it", () => {
+  it("keeps the body-column CAP overridable by the model (plain `body` specificity)", () => {
     const out = composeSrcDoc(
       "<html><head><style>body{max-width:1200px}</style></head><body><p>x</p></body></html>",
     );
-    // CSS is last-wins on source order (both are bare `body{}` selectors, no
-    // !important), so our injected cap MUST precede the model's style for the
-    // model to win. Guards against a refactor that appends head bits after the
-    // model markup and silently overrides every model/app layout.
+    // The injected `body{max-width}` is plain `body{}` and precedes the model's
+    // style, so the model's later `body{max-width:1200px}` wins (last on equal
+    // specificity) — a model can still widen its column.
     expect(
-      out.indexOf("body{max-width:var(--measure);margin-inline:auto}"),
+      out.indexOf("body{max-width:var(--measure)}"),
     ).toBeLessThan(out.indexOf("body{max-width:1200px}"));
+  });
+
+  it("centering survives a model `body{margin:0}` reset (the bug that pinned content left)", () => {
+    const out = composeSrcDoc(
+      "<html><head><style>body{margin:0}</style></head><body><div class='container'><p>x</p></div></body></html>",
+    );
+    // `html body{margin-inline:auto}` (0,0,2) beats the model's `body{margin:0}`
+    // (0,0,1) regardless of source order, so the column still centers.
+    expect(out).toContain("html body{margin-inline:auto}");
+  });
+
+  it("forces the resolved app theme (overrides the OS prefers-color-scheme default)", () => {
+    const dark = composeSrcDoc("<p>x</p>", undefined, false, "dark");
+    expect(dark).toContain(`:root{color-scheme:dark;--paper:#14130f`);
+    const light = composeSrcDoc("<p>x</p>", undefined, false, "light");
+    expect(light).toContain(`:root{color-scheme:light;--paper:#fbfaf6`);
+    // No theme → no override (the media-query default governs).
+    const none = composeSrcDoc("<p>x</p>");
+    expect(none).not.toContain("color-scheme:dark;--paper");
+    expect(none).not.toContain("color-scheme:light;--paper");
   });
 
   it("leaves app-style (viewport-unit) layouts full-bleed — no body column cap", () => {
@@ -191,7 +213,8 @@ describe("composeSrcDoc", () => {
       '<main><p>article</p><figure class="yoyo-illustration">' +
         '<img src="data:image/jpeg;base64,/9j/4AAQ/100vh/SkZJRg=="></figure></main>',
     );
-    expect(out).toContain("body{max-width:var(--measure);margin-inline:auto}");
+    expect(out).toContain("body{max-width:var(--measure)}");
+    expect(out).toContain("html body{margin-inline:auto}");
   });
 });
 

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -197,6 +197,25 @@ describe("composeSrcDoc", () => {
     expect(none).not.toContain("color-scheme:light;--paper");
   });
 
+  it("applies the theme override to app-style (viewport) docs too — not just the centered column", () => {
+    // themeOverride is independent of usesViewportUnits: a full-screen (100vh)
+    // dark artifact must still get dark paper, even though it gets NO body cap.
+    // Also exercises the real share path: hideScrollbar=true + a resolved theme.
+    const out = composeSrcDoc("<div style='height:100vh'>app</div>", undefined, true, "dark");
+    expect(out).toContain(`:root{color-scheme:dark;--paper:#14130f`);
+    expect(out).not.toContain("body{max-width:var(--measure)"); // no column for app-style
+    expect(out).toContain("scrollbar-width:none"); // hideScrollbar still applied
+  });
+
+  it("injects the theme override AFTER BASE_STYLE so its :root wins the source-order tie", () => {
+    const out = composeSrcDoc("<p>x</p>", undefined, false, "dark");
+    // Both :root rules have equal specificity (media queries add none), so the
+    // override only wins by coming later. Guards a refactor that reorders them.
+    expect(out.indexOf(":root{color-scheme:dark;--paper")).toBeGreaterThan(
+      out.indexOf(":root{color-scheme:light dark"),
+    );
+  });
+
   it("leaves app-style (viewport-unit) layouts full-bleed — no body column cap", () => {
     const out = composeSrcDoc("<div style='height:100vh'>full-screen app</div>");
     // App-style docs define their own full-screen width; don't impose a column.

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -66,9 +66,17 @@ const SANDBOX_CSP =
  * its content; app-style (viewport-unit) layouts are left full-bleed and manage
  * their own width.
  */
+// Folio color tokens, light + dark — factored out so the per-frame theme
+// override in `sandboxHead` can force the app's RESOLVED theme (matching
+// yopedia's in-app light/dark toggle, not just the OS `prefers-color-scheme`).
+const LIGHT_VARS =
+  "--paper:#fbfaf6;--paper-2:#f4f1e9;--ink:#1b1a16;--ink-2:#423f38;--muted:#756f62;--rule:#e2ddd0;--accent:#4d6bfe;--accent-soft:#e7ebff";
+const DARK_VARS =
+  "--paper:#14130f;--paper-2:#1c1b16;--ink:#efebdf;--ink-2:#c7c2b4;--muted:#948e7f;--rule:#2b281f;--accent:#90a4ff;--accent-soft:#20233a";
+
 const BASE_STYLE = `<style>
-:root{color-scheme:light dark;--paper:#fbfaf6;--paper-2:#f4f1e9;--ink:#1b1a16;--ink-2:#423f38;--muted:#756f62;--rule:#e2ddd0;--accent:#4d6bfe;--accent-soft:#e7ebff;--radius:12px;--measure:50rem;--head:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,ui-serif,serif}
-@media (prefers-color-scheme:dark){:root{--paper:#14130f;--paper-2:#1c1b16;--ink:#efebdf;--ink-2:#c7c2b4;--muted:#948e7f;--rule:#2b281f;--accent:#90a4ff;--accent-soft:#20233a}}
+:root{color-scheme:light dark;${LIGHT_VARS};--radius:12px;--measure:50rem;--head:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,ui-serif,serif}
+@media (prefers-color-scheme:dark){:root{${DARK_VARS}}}
 *{box-sizing:border-box}
 html{-webkit-text-size-adjust:100%}
 body{margin:0;background:var(--paper);color:var(--ink);font:17px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;padding:clamp(20px,5vw,56px) clamp(18px,5vw,28px)}
@@ -182,11 +190,19 @@ function sandboxHead(
   html: string,
   chartLibSource?: string,
   hideScrollbar?: boolean,
+  theme?: "light" | "dark",
 ): string {
   const chartLib =
     chartLibSource && usesChartLib(html)
       ? `<script>${chartLibSource}</script>`
       : "";
+  // Force the app's RESOLVED theme so the artifact's paper/ink matches the page
+  // around it — including yopedia's in-app dark TOGGLE, which the BASE_STYLE
+  // `@media (prefers-color-scheme)` default can't see. Injected AFTER BASE_STYLE
+  // so this `:root` wins over the media-query default at equal specificity.
+  const themeOverride = theme
+    ? `<style>:root{color-scheme:${theme};${theme === "dark" ? DARK_VARS : LIGHT_VARS}}</style>`
+    : "";
   // Full-screen share view: the frame is fixed to the viewport and the artifact
   // scrolls inside it — hide that inner scrollbar so the page reads clean.
   const hideBar = hideScrollbar
@@ -201,13 +217,21 @@ function sandboxHead(
   // also paint `html` with `--paper` so the gutters beside the narrowed body
   // column show the page background, not the bare iframe. App-style (100vh)
   // layouts manage their own full-bleed width, so they're left alone.
+  // Two rules, on purpose:
+  //  - `body{max-width}` stays at plain specificity so a model that WANTS a wider
+  //    column can still override it (the documented escape hatch), and a model
+  //    that removes the cap (`max-width:none`) goes full-bleed.
+  //  - `html body{margin-inline:auto}` (specificity 0,0,2) so the common reset
+  //    `body{margin:0}` can't ACCIDENTALLY cancel the centering — it's a no-op
+  //    when there's no width cap, and centers the column when there is.
   const centerColumn = usesViewportUnits(html)
     ? ""
-    : `<style>html{background:var(--paper)}body{max-width:var(--measure);margin-inline:auto}</style>`;
+    : `<style>html{background:var(--paper)}body{max-width:var(--measure)}html body{margin-inline:auto}</style>`;
   return (
     `<meta http-equiv="Content-Security-Policy" content="${SANDBOX_CSP}">` +
     `<base target="_blank">` +
     BASE_STYLE +
+    themeOverride +
     centerColumn +
     hideBar +
     chartLib +
@@ -242,12 +266,16 @@ export function stripHtmlFence(html: string): string {
  * actually uses charts; pass it from a lazy `import()` of `vendor/chartjs.generated`
  * so the heavy library stays out of the default client bundle. `hideScrollbar`
  * suppresses the document's own scrollbar (the full-screen share view, where the
- * frame is fixed to the viewport and scrolls internally).
+ * frame is fixed to the viewport and scrolls internally). `theme` forces the
+ * artifact's paper/ink to the app's RESOLVED light/dark theme so the iframe
+ * matches the page around it (pass the parent's current theme; omit to fall back
+ * to the OS `prefers-color-scheme` default).
  */
 export function composeSrcDoc(
   html: string,
   chartLibSource?: string,
   hideScrollbar?: boolean,
+  theme?: "light" | "dark",
 ): string {
   let src = stripHtmlFence(html);
   // Drop anything after the document's closing </html> — a self-contained
@@ -261,7 +289,7 @@ export function composeSrcDoc(
   if (lastClose?.index !== undefined) {
     src = src.slice(0, lastClose.index + lastClose[0].length);
   }
-  const head = sandboxHead(src, chartLibSource, hideScrollbar);
+  const head = sandboxHead(src, chartLibSource, hideScrollbar, theme);
 
   const headOpen = src.match(/<head[^>]*>/i);
   if (headOpen?.index !== undefined) {


### PR DESCRIPTION
## Problem

A shared HTML artifact (`/share/yuanhao/about-life-lessons-like-i-m-five`) rendered **left-aligned** and didn't track the in-app dark toggle. Root causes (both at the render chokepoint, not the generated markup):

1. **Centering lost the cascade.** `sandboxHead` injects `body{max-width;margin-inline:auto}` to center document-style artifacts, but it's injected *before* the model's own `<style>`. The model's `body{margin:0}` reset (equal specificity, later in source) cancelled `margin-inline:auto` → the column was 50rem wide but **pinned left**.
2. **Theme followed the OS, not the app.** Tokens switched via `@media (prefers-color-scheme:dark)`, so an artifact stayed light when yopedia's in-app **toggle** was dark → background mismatch.

## Fix (guarantees, at the `HtmlPreview`/`composeSrcDoc` chokepoint — covers existing + future artifacts)

**Centering** — split into two rules:
- `body{max-width:var(--measure)}` stays *plain* specificity → a model can still widen or remove the cap (full-bleed) on purpose.
- `html body{margin-inline:auto}` (specificity 0,0,2) → beats a `body{margin:0}` reset regardless of source order, so centering can't be *accidentally* cancelled. It's a no-op when there's no width cap.

**Theme** — `HtmlPreview` reads the resolved theme from `<html>`'s `dark`/`light` class, observes the toggle via `MutationObserver`, and passes it into `composeSrcDoc` (new optional `theme` arg). `composeSrcDoc` injects a `:root` token override *after* the media-query default, so the artifact's paper/ink matches the page exactly in both modes, and **re-renders when you flip the toggle**. Color tokens factored into `LIGHT_VARS`/`DARK_VARS` so base + override share one source.

Initial theme is SSR-stable `"light"` (the effect corrects on mount) to avoid a `srcDoc` hydration mismatch; the iframe element's own `background:var(--paper)` already matches the parent immediately.

## Tests (html.test.ts, +4)
- cap stays model-overridable (plain `body`)
- centering survives a model `body{margin:0}` reset (the exact bug)
- resolved-theme override present for `dark`/`light`, absent when no theme passed
- data-URI illustration doc still centers

## Scope note
`QueryResultPanel` (the transient inline query-answer preview) also calls `composeSrcDoc` and is left on the OS default for now — a separate, ephemeral path; can theme it in a follow-up if wanted.

## Gates
`pnpm lint` 0 errors · `vitest` 3274 passed · `pnpm build` + `pnpm build:cloudflare` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)