### PR TITLE
yoyo: repair mermaid subgraph errors + fix clipped CJK labels

### DIFF
--- a/src/lib/__tests__/mermaid.test.ts
+++ b/src/lib/__tests__/mermaid.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { htmlHasMermaid, renderMermaidInHtml } from "../mermaid";
+import {
+  htmlHasMermaid,
+  renderMermaidInHtml,
+  repairMermaid,
+} from "../mermaid";
 import { SLIDES_FORMAT_INSTRUCTION, HTML_FORMAT_INSTRUCTION } from "../query";
 
 // Actual Mermaid rendering needs a browser DOM and is exercised in the app, not
@@ -64,6 +68,47 @@ describe("renderMermaidInHtml", () => {
     });
     expect(out).toContain("<svg>good</svg>");
     expect(out).toContain('<pre class="mermaid">bad</pre>');
+  });
+});
+
+describe("repairMermaid", () => {
+  it("fixes a subgraph title with spaces + an edge that links subgraphs (the real bug)", () => {
+    const bad = [
+      "flowchart TB",
+      "  subgraph Built-in Harness",
+      "    S[System Prompt]",
+      "  end",
+      "  subgraph Outer Harness",
+      "    FG[Feedforward Guides]",
+      "  end",
+      "  Built-in Harness --> Outer Harness",
+    ].join("\n");
+    const out = repairMermaid(bad);
+    // Headers get an explicit id + quoted title…
+    expect(out).toContain('subgraph sg_1["Built-in Harness"]');
+    expect(out).toContain('subgraph sg_2["Outer Harness"]');
+    // …and the linking edge references the ids, not the space-containing titles.
+    expect(out).toContain("sg_1 --> sg_2");
+    expect(out).not.toMatch(/Built-in Harness\s*-->/);
+  });
+
+  it("leaves a valid graph unchanged (single-token + explicit-id subgraphs)", () => {
+    const ok = [
+      "flowchart TB",
+      "  subgraph backend",
+      "    A[API]",
+      "  end",
+      '  subgraph fe["Front End"]',
+      "    B[UI]",
+      "  end",
+      "  backend --> fe",
+    ].join("\n");
+    expect(repairMermaid(ok)).toBe(ok);
+  });
+
+  it("does not touch a graph with no subgraphs", () => {
+    const code = "flowchart LR\n  A[Start] --> B[End]";
+    expect(repairMermaid(code)).toBe(code);
   });
 });
 

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -22,6 +22,12 @@ const MERMAID_THEME: MermaidConfig = {
   theme: "base",
   fontFamily:
     'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+  // HTML (foreignObject) labels, not SVG <text>: the DOM measures multi-line
+  // (`<br/>`) and CJK labels correctly, so a two-line node sizes its box to fit
+  // instead of clipping the second line. securityLevel "strict" still runs the
+  // DOMPurify pass, and the CSP allows `style-src 'unsafe-inline'`, so the
+  // foreignObject renders inside the sandboxed iframe.
+  flowchart: { htmlLabels: true, padding: 10 },
   // Concrete hex (the SVG is standalone — CSS vars aren't available inside it),
   // matching the yopedia/yoyo palette (accent #4d6bfe on warm paper).
   themeVariables: {
@@ -48,11 +54,46 @@ function loadMermaid() {
 
 let seq = 0;
 
+/**
+ * Repair the most common model-authored mermaid mistake before parsing: a
+ * `subgraph` whose title has spaces/punctuation but NO explicit id. Mermaid then
+ * can't reference it in an edge, and a line like `Built-in Harness --> Outer
+ * Harness` is a hard syntax error (the whole diagram fails). Rewrite each such
+ * header to `id["Title"]` and rewrite edge lines that reference the bare title to
+ * that id. A graph with only valid single-token / `id[...]` subgraphs is returned
+ * unchanged.
+ */
+export function repairMermaid(code: string): string {
+  const lines = code.split("\n");
+  const titleToId = new Map<string, string>();
+  let n = 0;
+  const rewritten = lines.map((line) => {
+    const m = line.match(/^(\s*)subgraph\s+(.+?)\s*$/);
+    if (!m) return line;
+    const title = m[2].trim();
+    // Already valid: an explicit `id[...]` form, or a bare single-token id.
+    if (/^\S+\s*\[/.test(title) || /^[A-Za-z0-9_]+$/.test(title)) return line;
+    const clean = title.replace(/^["']|["']$/g, "");
+    const id = `sg_${++n}`;
+    titleToId.set(clean, id);
+    return `${m[1]}subgraph ${id}["${clean}"]`;
+  });
+  if (titleToId.size === 0) return code; // nothing to repair
+  return rewritten
+    .map((line) => {
+      if (!/--|==|-\.|<--|-->/.test(line)) return line; // only edge lines
+      let l = line;
+      for (const [title, id] of titleToId) l = l.split(title).join(id);
+      return l;
+    })
+    .join("\n");
+}
+
 /** Render one Mermaid graph definition to an SVG string. Rejects on a syntax error. */
 export async function renderMermaid(code: string): Promise<string> {
   const mermaid = await loadMermaid();
   const id = `mmd-${seq++}-${Math.floor(performance.now())}`;
-  const { svg } = await mermaid.render(id, code.trim());
+  const { svg } = await mermaid.render(id, repairMermaid(code.trim()));
   return svg;
 }
 


### PR DESCRIPTION
Fixes the mermaid issues on `/share/yuanhao/deepseek-harness-团队面试准备` (and systemically).

## Root causes (from the page's actual mermaid source)
1. **The error** — block 3 had `subgraph Built-in Harness` (title with space/hyphen, no id) and `Built-in Harness --> Outer Harness`. Subgraph names with spaces used as node IDs are invalid mermaid → the diagram throws → we leave the raw `<pre>` source, which reads as broken.
2. **The clipped text** — block 1's two-line `<br/>` CJK labels (`🧠 Model<br/>大脑：推理、语言`) overflow the node: SVG `<text>` sizing under-measures the box height, so the Chinese second line is cut off at the bottom border.

## Fixes (at the render chokepoint — covers HTML artifacts AND markdown)
1. **`repairMermaid()` pre-pass** rewrites a space/punctuation subgraph title to `id["Title"]` and repoints linking edges to the id; a valid graph passes through unchanged. This **self-heals the affected page at render time — no prod re-save needed** — and prevents the whole error class recurring.
2. **`flowchart.htmlLabels: true`** — HTML (foreignObject) labels are DOM-measured, so a multi-line / CJK node sizes its box to fit. `securityLevel: "strict"` still runs DOMPurify; the iframe CSP allows `style-src 'unsafe-inline'`.

## Tests
`repairMermaid`: the real bug pattern → valid output; a valid graph → unchanged; no-subgraph → unchanged. (Actual mermaid rendering needs a browser and isn't unit-tested here, per the existing file's note.)

## Verification note
The **label-sizing fix can't be verified headlessly** (mermaid needs a browser) — please eyeball a CJK-label diagram after deploy. The `repairMermaid` fix is fully unit-tested and deterministic. Easy revert if `htmlLabels` regresses anything.

## Gates
`pnpm lint` 0 errors · `vitest` 3279 passed · `pnpm build` + `pnpm build:cloudflare` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)