### PR TITLE
yoyo: fix clipped multi-line/CJK mermaid labels (iframe line-height leak)

### DIFF
--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -120,6 +120,14 @@ summary{cursor:pointer;padding:14px 0;font-family:var(--head);font-weight:600;co
 input[type=range]{width:100%;accent-color:var(--accent)}
 button.btn{font:inherit;font-weight:600;background:var(--accent);color:#fff;border:0;border-radius:8px;padding:8px 14px;cursor:pointer}
 .sources{font-size:.9rem;color:var(--muted)}
+/* Mermaid renders its diagram in the PARENT app (HtmlPreview) and we inline the
+   SVG here — so this document's body line-height (1.65) leaks into mermaid's
+   foreignObject HTML labels, inflating them past the height mermaid measured in
+   the parent → a two-line / CJK node label clips. Reset the label typography to
+   what mermaid measured (tight, no <p> margin), and let any residual overflow
+   show within the node's (taller) rect rather than being clipped. */
+.mermaid-diagram foreignObject{overflow:visible;line-height:normal}
+.mermaid-diagram foreignObject p{margin:0}
 </style>`;
 
 /**

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -120,12 +120,13 @@ summary{cursor:pointer;padding:14px 0;font-family:var(--head);font-weight:600;co
 input[type=range]{width:100%;accent-color:var(--accent)}
 button.btn{font:inherit;font-weight:600;background:var(--accent);color:#fff;border:0;border-radius:8px;padding:8px 14px;cursor:pointer}
 .sources{font-size:.9rem;color:var(--muted)}
-/* Mermaid renders its diagram in the PARENT app (HtmlPreview) and we inline the
-   SVG here — so this document's body line-height (1.65) leaks into mermaid's
-   foreignObject HTML labels, inflating them past the height mermaid measured in
-   the parent → a two-line / CJK node label clips. Reset the label typography to
-   what mermaid measured (tight, no <p> margin), and let any residual overflow
-   show within the node's (taller) rect rather than being clipped. */
+/* Mermaid measures + renders in the PARENT app (HtmlPreview, body line-height
+   1.5) and we inline the SVG here, where body line-height is 1.65. That MISMATCH
+   inflates mermaid's foreignObject HTML labels past the box it measured, so a
+   two-line / CJK node label clips. Force the labels to line-height:normal —
+   tighter than both, so the content can't exceed the measured box — and drop the
+   inherited <p> margin; overflow:visible lets any residual show within the node's
+   (taller) rect instead of clipping. */
 .mermaid-diagram foreignObject{overflow:visible;line-height:normal}
 .mermaid-diagram foreignObject p{margin:0}
 </style>`;


### PR DESCRIPTION
The CJK second line of mermaid nodes was still clipping after #712. I rendered the page in headless Chrome and **measured the real cause**.

## Root cause
Mermaid renders in the **parent app** (HtmlPreview), and we inline the resulting SVG into the artifact **iframe**. The iframe's `BASE_STYLE` has `body{font:17px/1.65}`, and that **line-height leaks into mermaid's `foreignObject` HTML labels**, inflating them past the height mermaid measured in the parent.

Measured on prod (`g.node foreignObject`):
```
node0: rectH=53  foH=33 (measured)  innerScrollH=45 (displayed)  → 2nd line clips
```
So it was never a mermaid config/quality issue (a library swap like beautiful-mermaid wouldn't help) — it's our own iframe typography distorting the labels. #712's `htmlLabels` switch was effectively a no-op for this symptom.

## Fix
Reset the mermaid label typography inside the iframe to match what mermaid measured:
```css
.mermaid-diagram foreignObject{overflow:visible;line-height:normal}
.mermaid-diagram foreignObject p{margin:0}
```
**Verified on the live prod page** — injected this exact CSS into the rendered iframe and the clipped second line rendered fully (before/after screenshots captured).

## Scope
Render-time, in `BASE_STYLE` → fixes **every** HTML artifact (existing + future) on next view, no re-generation. (The markdown `<Mermaid>` path renders into the live page, not this iframe; if diagrams clip there too it's a one-line follow-up in globals.css.)

## Gates
`pnpm lint` 0 errors · `vitest` (html + mermaid) green · `pnpm build` + `pnpm build:cloudflare` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)