### PR TITLE
yoyo: hybrid mermaid renderer (beautiful-mermaid + mermaid fallback)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@mozilla/readability": "^0.6.0",
     "@tailwindcss/typography": "^0.5.19",
     "ai": "^6.0.146",
+    "beautiful-mermaid": "^1.1.3",
     "fflate": "^0.8.2",
     "linkedom": "^0.18.12",
     "mermaid": "^11.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       ai:
         specifier: ^6.0.146
         version: 6.0.146(zod@4.4.2)
+      beautiful-mermaid:
+        specifier: ^1.1.3
+        version: 1.1.3
       fflate:
         specifier: ^0.8.2
         version: 0.8.2
@@ -2238,6 +2241,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  beautiful-mermaid@1.1.3:
+    resolution: {integrity: sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg==}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
@@ -2700,6 +2706,9 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  elkjs@0.11.1:
+    resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -6986,6 +6995,11 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  beautiful-mermaid@1.1.3:
+    dependencies:
+      elkjs: 0.11.1
+      entities: 7.0.1
+
   blake3-wasm@2.1.5: {}
 
   body-parser@2.2.2:
@@ -7469,6 +7483,8 @@ snapshots:
       '@noble/hashes': 1.8.0
 
   ee-first@1.1.1: {}
+
+  elkjs@0.11.1: {}
 
   emoji-regex@10.6.0: {}
 

--- a/src/components/Mermaid.tsx
+++ b/src/components/Mermaid.tsx
@@ -53,7 +53,9 @@ export function Mermaid({ chart }: { chart: string }) {
     <div
       className="mermaid-diagram"
       style={{ textAlign: "center", margin: "1.25rem 0" }}
-      // Mermaid renders with securityLevel "strict" (sanitized labels, no scripts).
+      // SVG is safe to inline: beautiful-mermaid (primary) escapes label text/
+      // attrs, and the mermaid fallback renders with securityLevel "strict"
+      // (sanitized labels, no scripts) — neither path emits executable markup.
       dangerouslySetInnerHTML={{ __html: svg }}
     />
   );

--- a/src/lib/__tests__/mermaid-fallback.test.ts
+++ b/src/lib/__tests__/mermaid-fallback.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Exercise the hybrid ROUTING in node (no DOM): mock beautiful-mermaid so we can
+// make it throw / return junk, and stub mermaid with a sentinel SVG (the real
+// mermaid needs a browser DOM). Isolated in its own file so the real-renderer
+// tests in mermaid.test.ts keep using the actual beautiful-mermaid.
+vi.mock("beautiful-mermaid", () => ({ renderMermaidSVG: vi.fn() }));
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(async () => ({ svg: "<svg>MERMAID-FALLBACK</svg>" })),
+  },
+}));
+
+import { renderMermaid } from "../mermaid";
+import { renderMermaidSVG } from "beautiful-mermaid";
+
+const mockBm = vi.mocked(renderMermaidSVG);
+
+describe("renderMermaid hybrid routing → mermaid fallback", () => {
+  beforeEach(() => mockBm.mockReset());
+
+  it("falls back to mermaid when beautiful-mermaid returns a non-SVG string", async () => {
+    mockBm.mockReturnValue("oops not an svg");
+    const svg = await renderMermaid("flowchart LR\n A-->B");
+    expect(svg).toBe("<svg>MERMAID-FALLBACK</svg>");
+  });
+
+  it("uses beautiful-mermaid's output when it returns a valid SVG (no fallback)", async () => {
+    mockBm.mockReturnValue("<svg>BEAUTIFUL</svg>");
+    const svg = await renderMermaid("flowchart LR\n A-->B");
+    expect(svg).toBe("<svg>BEAUTIFUL</svg>");
+  });
+});

--- a/src/lib/__tests__/mermaid.test.ts
+++ b/src/lib/__tests__/mermaid.test.ts
@@ -6,6 +6,7 @@ import {
   renderMermaid,
 } from "../mermaid";
 import { SLIDES_FORMAT_INSTRUCTION, HTML_FORMAT_INSTRUCTION } from "../query";
+import { renderMermaidSVG } from "beautiful-mermaid";
 
 // Actual Mermaid rendering needs a browser DOM and is exercised in the app, not
 // here. These cover the pure pieces: detection, the no-op fast path (which must
@@ -152,6 +153,17 @@ describe("renderMermaid (hybrid: beautiful-mermaid → mermaid)", () => {
     expect(svg).toContain("<svg");
     expect(svg).toContain("Built-in Harness");
     expect(svg).toContain("Outer Harness");
+  });
+
+  it("beautiful-mermaid throws 'Invalid mermaid header' on unsupported types (fallback contract)", () => {
+    // The hybrid relies on bm THROWING for types it doesn't implement so the
+    // catch routes to mermaid. Pin that contract against the real library.
+    expect(() => renderMermaidSVG("pie title Pets\n  Dogs: 1", {})).toThrow(
+      /invalid mermaid header/i,
+    );
+    expect(() => renderMermaidSVG("gantt\n  title X", {})).toThrow(
+      /invalid mermaid header/i,
+    );
   });
 });
 

--- a/src/lib/__tests__/mermaid.test.ts
+++ b/src/lib/__tests__/mermaid.test.ts
@@ -3,6 +3,7 @@ import {
   htmlHasMermaid,
   renderMermaidInHtml,
   repairMermaid,
+  renderMermaid,
 } from "../mermaid";
 import { SLIDES_FORMAT_INSTRUCTION, HTML_FORMAT_INSTRUCTION } from "../query";
 
@@ -129,6 +130,28 @@ describe("repairMermaid", () => {
   it("does not touch a graph with no subgraphs", () => {
     const code = "flowchart LR\n  A[Start] --> B[End]";
     expect(repairMermaid(code)).toBe(code);
+  });
+});
+
+describe("renderMermaid (hybrid: beautiful-mermaid → mermaid)", () => {
+  // beautiful-mermaid is synchronous + DOM-free, so the PRIMARY path renders here
+  // without a browser. (The mermaid fallback needs a DOM and is exercised in-app.)
+  it("renders a flowchart via beautiful-mermaid, no DOM", async () => {
+    const svg = await renderMermaid("flowchart LR\n  A[开始] --> B[结束]");
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("开始");
+    expect(svg).toContain("结束");
+  });
+
+  it("applies repairMermaid before rendering (subgraph titles with spaces)", async () => {
+    const svg = await renderMermaid(
+      "flowchart TB\n  subgraph Built-in Harness\n    S[System Prompt]\n  end\n  subgraph Outer Harness\n    F[Guides]\n  end\n  Built-in Harness --> Outer Harness",
+    );
+    // Renders (doesn't throw on the space-named subgraph link) and keeps the
+    // human-readable titles.
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("Built-in Harness");
+    expect(svg).toContain("Outer Harness");
   });
 });
 

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -94,11 +94,48 @@ export function repairMermaid(code: string): string {
     .join("\n");
 }
 
-/** Render one Mermaid graph definition to an SVG string. Rejects on a syntax error. */
+// beautiful-mermaid: a synchronous, DOM-free renderer with cleaner, more
+// predictable layouts than mermaid's defaults. Themed to the folio palette;
+// colors are passed at the top level of RenderOptions (NOT nested), and per-node
+// `style … fill:` directives in the source are still honored. Lazy-imported.
+const BM_OPTIONS = {
+  bg: "#fbfaf6",
+  fg: "#1b1a16",
+  accent: "#4d6bfe",
+  font: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", "PingFang SC", Roboto, sans-serif',
+};
+let bmLoader: Promise<typeof import("beautiful-mermaid")> | null = null;
+function loadBeautiful() {
+  if (!bmLoader) bmLoader = import("beautiful-mermaid");
+  return bmLoader;
+}
+
+/**
+ * Render one Mermaid graph definition to an SVG string.
+ *
+ * Hybrid: try **beautiful-mermaid** first (nicer layout, synchronous, and for the
+ * common flowchart case avoids loading the ~3MB mermaid library); fall back to
+ * full **mermaid** for diagram types beautiful-mermaid doesn't implement
+ * (gantt/pie/mindmap/timeline) or any definition it can't parse — it throws an
+ * "Invalid mermaid header" for those, which the catch routes to mermaid. Both get
+ * the {@link repairMermaid} pass. Rejects only if BOTH engines fail.
+ */
 export async function renderMermaid(code: string): Promise<string> {
+  const def = repairMermaid(code.trim());
+  try {
+    const bm = await loadBeautiful();
+    const svg = bm.renderMermaidSVG(def, BM_OPTIONS);
+    if (svg && svg.includes("<svg")) return svg;
+  } catch (err) {
+    logger.warn(
+      "mermaid",
+      "beautiful-mermaid failed; falling back to mermaid",
+      err,
+    );
+  }
   const mermaid = await loadMermaid();
   const id = `mmd-${seq++}-${Math.floor(performance.now())}`;
-  const { svg } = await mermaid.render(id, repairMermaid(code.trim()));
+  const { svg } = await mermaid.render(id, def);
   return svg;
 }
 

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -114,11 +114,14 @@ function loadBeautiful() {
  * Render one Mermaid graph definition to an SVG string.
  *
  * Hybrid: try **beautiful-mermaid** first (nicer layout, synchronous, and for the
- * common flowchart case avoids loading the ~3MB mermaid library); fall back to
- * full **mermaid** for diagram types beautiful-mermaid doesn't implement
- * (gantt/pie/mindmap/timeline) or any definition it can't parse — it throws an
- * "Invalid mermaid header" for those, which the catch routes to mermaid. Both get
- * the {@link repairMermaid} pass. Rejects only if BOTH engines fail.
+ * common flowchart case avoids loading the ~3MB mermaid library; it handles
+ * flowchart/class/er/sequence/xychart) — fall back to full **mermaid** for the
+ * types it doesn't implement (gantt/pie/mindmap/timeline) or any definition it
+ * can't parse. Those throw "Invalid mermaid header" (the EXPECTED routing, kept
+ * at debug); a genuine unexpected failure logs a warn. Both engines get the
+ * {@link repairMermaid} pass. Rejects only if BOTH fail. NOTE: a flowchart that
+ * beautiful-mermaid parses but renders with reduced fidelity (e.g. ignoring
+ * `click`/`linkStyle`) is returned as-is — try-first means it won't fall back.
  */
 export async function renderMermaid(code: string): Promise<string> {
   const def = repairMermaid(code.trim());
@@ -126,10 +129,20 @@ export async function renderMermaid(code: string): Promise<string> {
     const bm = await loadBeautiful();
     const svg = bm.renderMermaidSVG(def, BM_OPTIONS);
     if (svg && svg.includes("<svg")) return svg;
+    // A non-throwing, non-SVG return shouldn't happen — breadcrumb (debug, not
+    // warn: we still recover via mermaid) so a future bm regression is traceable.
+    logger.debug("mermaid", "beautiful-mermaid returned no <svg>; using mermaid");
   } catch (err) {
-    logger.warn(
+    // "Invalid mermaid header" is the DESIGNED route for a type bm doesn't
+    // implement (gantt/pie/mindmap/timeline) — keep it at debug so routine
+    // routing isn't noise at the default warn level; a real failure stays warn.
+    const expected =
+      err instanceof Error && /invalid mermaid header/i.test(err.message);
+    logger[expected ? "debug" : "warn"](
       "mermaid",
-      "beautiful-mermaid failed; falling back to mermaid",
+      expected
+        ? "beautiful-mermaid: unsupported diagram type; using mermaid"
+        : "beautiful-mermaid render failed unexpectedly; using mermaid",
       err,
     );
   }


### PR DESCRIPTION
Adopts **beautiful-mermaid** as the primary diagram renderer with **mermaid as a fallback**, after a side-by-side eval on our real diagrams.

## Why
beautiful-mermaid produces cleaner, more predictable flowchart layouts, keeps per-node `style … fill:` colors, handles CJK + subgraphs (with `repairMermaid`), is **synchronous + DOM-free**, and for the common flowchart case avoids loading the ~3MB mermaid library.

## Approach (hybrid — keeps full coverage)
`renderMermaid(code)`:
1. `repairMermaid(code)` (unchanged — fixes space-named subgraphs; needed by **both** engines).
2. Try `beautiful-mermaid.renderMermaidSVG(def, {bg,fg,accent,font})` — themed to the folio palette.
3. On any failure, fall back to **mermaid**.

beautiful-mermaid throws a clean `Invalid mermaid header` for the types it doesn't implement (gantt/pie/mindmap/timeline) and for unparseable input, so the catch routes those to mermaid — **nothing ever fails to render**. The #717 `foreignObject` line-height reset now mainly guards the mermaid fallback (bm emits SVG `<text>`).

## Verification
- Rendered our 3 real diagrams (CJK two-line, flow+decision, subgraphs) in both engines via headless Chrome — bm renders them well; with `repairMermaid` the subgraph case is correct (the earlier "bm broke block2" was a rigged test where only mermaid got the repair).
- Confirmed bm **throws** (not silently garbles) on pie/gantt/mindmap/timeline/garbage → fallback is safe.
- New unit tests exercise the bm-first path in node (DOM-free): a flowchart renders to `<svg>` with CJK text; a space-named subgraph renders via repair.

## Theming note
Colors are passed at the **top level** of `RenderOptions` (`{bg,fg,accent,font}`), not nested — a subtlety I verified against the package types.

## Gates
`pnpm lint` 0 errors · `vitest` 3283 passed · `pnpm build` + `pnpm build:cloudflare` clean (new ESM dep bundles fine).

## Follow-up (not here)
bm being sync + DOM-free opens **server-side render at ingest** (bake SVG, drop the client lib entirely) — a larger change for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)