### PR TITLE
yoyo: PostHog page-view analytics (cookieless, pageviews-only)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,11 @@ DEEPSEEK_API_KEY=sk-...
 # Needs a tier with recent-search/article access, and the body is only reachable
 # within ~7 days of posting (X's recent-search window).
 # X_BEARER_TOKEN=...
+
+# --- Analytics (PostHog page views) ---
+# Page-view tracking is ON by default with a built-in PUBLIC project key.
+# Override the key/host here (NEXT_PUBLIC_* are inlined at BUILD time, so set
+# them in the deploy build env, not just at runtime). Pageviews only — cookieless
+# (memory persistence, no consent banner), no autocapture, no session replay.
+# NEXT_PUBLIC_POSTHOG_KEY=phc_...
+# NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mermaid": "^11.15.0",
     "next": "15.5.18",
     "ollama-ai-provider-v2": "^3.5.0",
+    "posthog-js": "^1.392.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-markdown": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       ollama-ai-provider-v2:
         specifier: ^3.5.0
         version: 3.5.0(ai@6.0.146(zod@4.4.2))(zod@4.4.2)
+      posthog-js:
+        specifier: ^1.392.0
+        version: 1.392.0
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -1349,6 +1352,12 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@posthog/core@1.35.4':
+    resolution: {integrity: sha512-DowOjN83tGtg4NPv0tmExjXiIWapHDDTv0ZZHg70XBjH5o/AB3DkMVMvj5ODIi1Y5bw7eMETidGvRwWH0/g3wA==}
+
+  '@posthog/types@1.390.2':
+    resolution: {integrity: sha512-WcfKz2GNn2vfDX8vXmJYbKxegPxVWHuDQ/pHdAn0HoZDXDFnEp/+x3qBQA+fEvtbPjjtjgAt2wIgJMlM7asx7g==}
+
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
     cpu: [arm]
@@ -2400,6 +2409,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -3003,6 +3015,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
@@ -4035,6 +4050,12 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.392.0:
+    resolution: {integrity: sha512-dOZMzav59dRzI4SNmF+ZoRWj6evUVNxTMuHgbQWt+vTJzVl9UvdsUPFBBa13Skcw8eTwXpB54089yaCrEv11Ew==}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4056,6 +4077,9 @@ packages:
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4622,6 +4646,9 @@ packages:
   web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -6085,6 +6112,12 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@posthog/core@1.35.4':
+    dependencies:
+      '@posthog/types': 1.390.2
+
+  '@posthog/types@1.390.2': {}
+
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
 
@@ -7140,6 +7173,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-js@3.49.0: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -7999,6 +8034,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.4.8: {}
 
   fflate@0.8.2: {}
 
@@ -9219,6 +9256,19 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.392.0:
+    dependencies:
+      '@posthog/core': 1.35.4
+      '@posthog/types': 1.390.2
+      core-js: 3.49.0
+      dompurify: 3.4.9
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
+  preact@10.29.2: {}
+
   prelude-ls@1.2.1: {}
 
   prop-types@15.8.1:
@@ -9239,6 +9289,8 @@ snapshots:
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -9979,6 +10031,8 @@ snapshots:
       - yaml
 
   web-streams-polyfill@4.0.0-beta.3: {}
+
+  web-vitals@5.3.0: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -3,10 +3,13 @@
 import { useEffect } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import type { PostHog } from "posthog-js";
+import { logger } from "@/lib/logger";
 
 // PostHog project API key is a PUBLIC client key (`phc_…`) — it ships in the
 // browser regardless, so embedding it is fine (no secret-rotation concern).
-// Env overrides the default so it can be changed without a code edit.
+// Env overrides the default; setting NEXT_PUBLIC_POSTHOG_KEY="" explicitly
+// DISABLES analytics (?? keeps "", which the guard below treats as off), while
+// leaving it unset keeps tracking on with the built-in key.
 const POSTHOG_KEY =
   process.env.NEXT_PUBLIC_POSTHOG_KEY ??
   "phc_l1jtx4tZRSCf0wcwuvPgC6fXGpyvOxus4bsqOS4BOI2";
@@ -14,23 +17,35 @@ const POSTHOG_HOST =
   process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com";
 
 // Lazy-load + init posthog-js once (only when a key is configured), so it stays
-// out of the initial chunk and is a no-op when analytics is disabled.
+// out of the initial chunk and is a no-op when analytics is disabled. The cached
+// promise ALWAYS resolves (to the client or null) — never rejects — so callers
+// can't trip an unhandled rejection, and a transient chunk-load failure nulls the
+// cache so the next navigation retries instead of being dead for the session.
 let phPromise: Promise<PostHog | null> | null = null;
 function getPostHog(): Promise<PostHog | null> {
   if (!POSTHOG_KEY) return Promise.resolve(null);
   if (!phPromise) {
-    phPromise = import("posthog-js").then(({ default: posthog }) => {
-      posthog.init(POSTHOG_KEY, {
-        api_host: POSTHOG_HOST,
-        persistence: "memory", // cookieless → no consent banner required
-        autocapture: false, // pageviews only — no click/interaction capture
-        capture_pageview: false, // fired manually on route change (App Router)
-        capture_pageleave: false,
-        disable_session_recording: true, // no session replay
-        person_profiles: "identified_only",
+    phPromise = import("posthog-js")
+      .then(({ default: posthog }) => {
+        posthog.init(POSTHOG_KEY, {
+          api_host: POSTHOG_HOST,
+          persistence: "memory", // cookieless → no consent banner required
+          autocapture: false, // pageviews only — no click/interaction capture
+          capture_pageview: false, // fired manually on route change (App Router)
+          capture_pageleave: false,
+          disable_session_recording: true, // no session replay
+          person_profiles: "identified_only",
+        });
+        return posthog;
+      })
+      .catch((err) => {
+        // Non-critical: the page works without analytics. Evict so a transient
+        // failure can recover next nav, and log (per HtmlPreview/RegisterSW
+        // convention) rather than leaving an invisible unhandled rejection.
+        phPromise = null;
+        logger.warn("analytics", "posthog load/init failed; skipping", err);
+        return null;
       });
-      return posthog;
-    });
   }
   return phPromise;
 }
@@ -52,7 +67,9 @@ export function Analytics() {
     let url = window.location.origin + pathname;
     const qs = searchParams?.toString();
     if (qs) url += `?${qs}`;
-    void getPostHog().then((ph) => ph?.capture("$pageview", { $current_url: url }));
+    void getPostHog()
+      .then((ph) => ph?.capture("$pageview", { $current_url: url }))
+      .catch((err) => logger.warn("analytics", "pageview capture failed", err));
   }, [pathname, searchParams]);
 
   return null;

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import type { PostHog } from "posthog-js";
+
+// PostHog project API key is a PUBLIC client key (`phc_…`) — it ships in the
+// browser regardless, so embedding it is fine (no secret-rotation concern).
+// Env overrides the default so it can be changed without a code edit.
+const POSTHOG_KEY =
+  process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+  "phc_l1jtx4tZRSCf0wcwuvPgC6fXGpyvOxus4bsqOS4BOI2";
+const POSTHOG_HOST =
+  process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com";
+
+// Lazy-load + init posthog-js once (only when a key is configured), so it stays
+// out of the initial chunk and is a no-op when analytics is disabled.
+let phPromise: Promise<PostHog | null> | null = null;
+function getPostHog(): Promise<PostHog | null> {
+  if (!POSTHOG_KEY) return Promise.resolve(null);
+  if (!phPromise) {
+    phPromise = import("posthog-js").then(({ default: posthog }) => {
+      posthog.init(POSTHOG_KEY, {
+        api_host: POSTHOG_HOST,
+        persistence: "memory", // cookieless → no consent banner required
+        autocapture: false, // pageviews only — no click/interaction capture
+        capture_pageview: false, // fired manually on route change (App Router)
+        capture_pageleave: false,
+        disable_session_recording: true, // no session replay
+        person_profiles: "identified_only",
+      });
+      return posthog;
+    });
+  }
+  return phPromise;
+}
+
+/**
+ * Page-view analytics (PostHog). App Router client navigation does NOT fire
+ * pageviews, so we capture `$pageview` on every pathname/searchParams change
+ * (plus the initial mount). Cookieless (memory persistence) so no consent banner
+ * is needed; pageviews only — no autocapture, no session replay. Renders nothing.
+ *
+ * Must be mounted inside a <Suspense> boundary (useSearchParams requirement).
+ */
+export function Analytics() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (!pathname) return;
+    let url = window.location.origin + pathname;
+    const qs = searchParams?.toString();
+    if (qs) url += `?${qs}`;
+    void getPostHog().then((ph) => ph?.capture("$pageview", { $current_url: url }));
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { Suspense, type ReactNode } from "react";
 import { KeyboardShortcutsProvider } from "@/hooks/useKeyboardShortcuts";
 import { ShortcutsHelp } from "@/components/ShortcutsHelp";
 import { ToastProvider } from "@/hooks/useToast";
 import { ToastContainer } from "@/components/ToastContainer";
-import type { ReactNode } from "react";
+import { Analytics } from "@/components/Analytics";
 
 export function ClientProviders({ children }: { children: ReactNode }) {
   return (
@@ -13,6 +14,10 @@ export function ClientProviders({ children }: { children: ReactNode }) {
         {children}
         <ToastContainer />
         <ShortcutsHelp />
+        {/* PostHog page-view tracking; Suspense satisfies useSearchParams. */}
+        <Suspense fallback={null}>
+          <Analytics />
+        </Suspense>
       </ToastProvider>
     </KeyboardShortcutsProvider>
   );


### PR DESCRIPTION
Adds page-view analytics via PostHog, per the chosen config: **US Cloud · pageviews only · cookieless (no banner)**.

## What
- `<Analytics>` (client) captures `$pageview` on every route change — App Router client nav doesn't fire pageviews, so it watches `usePathname`/`useSearchParams` (+ initial mount). Mounted in `ClientProviders` inside a `<Suspense>` (required by `useSearchParams`).
- `posthog.init` config: `persistence: "memory"` (cookieless → **no consent banner**), `autocapture: false`, `capture_pageview: false` (manual), `capture_pageleave: false`, `disable_session_recording: true`. So it's strictly page views — no clicks, no inputs, no replay.
- posthog-js is **lazy-imported** and inited once, so it stays out of the initial chunk.

## Key / config
- The `phc_…` key is a **public** PostHog client key (it ships in browser JS regardless), used as the built-in default so it works out of the box.
- `NEXT_PUBLIC_POSTHOG_KEY` / `NEXT_PUBLIC_POSTHOG_HOST` override it — documented in `.env.example`. **Note:** `NEXT_PUBLIC_*` are inlined at **build** time, so to change them set them in the deploy build env (GitHub Actions), not just at runtime.

## Note on your snippet
Your pasted snippet used `defaults: '2026-05-30'` + `person_profiles`, which would enable autocapture/pageview/etc. I instead honored your earlier explicit choices (pageviews-only + cookieless). Easy to flip to full autocapture if you change your mind.

## Scope
Deliberately separate from the mermaid hybrid (#718) — unrelated concern.

## Gates
`pnpm lint` 0 errors · `vitest` 3281 passed · `pnpm build` + `pnpm build:cloudflare` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)