### PR TITLE
yoyo: allow artifacts to be curated into vaults (Browse-only)

### DIFF
--- a/src/app/api/vaults/[id]/pages/route.ts
+++ b/src/app/api/vaults/[id]/pages/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getPrincipal } from "@/lib/auth";
 import { addToVault, removeFromVault, vaultOwnedBy, getVault } from "@/lib/vault";
 import { readWikiPageWithFrontmatter } from "@/lib/wiki";
-import { belongsInCommons } from "@/lib/commons";
+import { isVaultEligible } from "@/lib/commons";
 
 interface Params {
   params: Promise<{ id: string }>;
@@ -110,16 +110,19 @@ export async function POST(req: Request, { params }: Params) {
   if (!page) {
     return NextResponse.json({ error: "Page not found." }, { status: 404 });
   }
-  const isCommons = belongsInCommons({
+  // Public, non-agent pages — INCLUDING artifacts (html/slides), which a vault
+  // can collect for Browse. Private pages are excluded (a vault references by
+  // slug, so a private page would leak).
+  const eligible = isVaultEligible({
     visibility:
       typeof page.frontmatter.visibility === "string"
         ? page.frontmatter.visibility
         : undefined,
     type: typeof page.frontmatter.type === "string" ? page.frontmatter.type : undefined,
   });
-  if (!isCommons) {
+  if (!eligible) {
     return NextResponse.json(
-      { error: "Only public commons pages can be added to a public vault." },
+      { error: "Only public, non-agent pages can be added to a vault." },
       { status: 400 },
     );
   }

--- a/src/components/ArticleActions.tsx
+++ b/src/components/ArticleActions.tsx
@@ -16,8 +16,11 @@ interface ArticleActionsProps {
   owner: string;
   /** Contributor handles. */
   contributors: string[];
-  /** Whether this is a PUBLIC, non-agent commons page (gates the curate button). */
+  /** Whether this is a PUBLIC, non-agent commons page (gates Delete realm). */
   isCommonsPage: boolean;
+  /** Whether the page may be curated into a vault: public + non-agent, INCLUDING
+   *  artifacts (gates the "Save to vault" button). */
+  isCuratable: boolean;
   /** Whether a raw source exists (gates the View-source link). */
   hasRawSource: boolean;
   /** Whether a source URL exists (gates the Reingest button). */
@@ -47,6 +50,7 @@ export function ArticleActions({
   owner,
   contributors,
   isCommonsPage,
+  isCuratable,
   hasRawSource,
   hasSourceUrl,
 }: ArticleActionsProps) {
@@ -74,10 +78,11 @@ export function ArticleActions({
   // owner / admin); a non-commons page (private / artifact / agent) is deletable
   // by its page owner. The site owner can delete either.
   const canDelete = isCommonsPage ? isSiteOwner : isOwner || isSiteOwner;
-  // Any signed-in user can curate a commons page into their vault — including
-  // owners and contributors (owned/contributed pages are NOT automatically in
-  // vaults, so excluding them created a curation gap for the most engaged users).
-  const canCurate = isLoaded && !!isSignedIn && isCommonsPage;
+  // Any signed-in user can curate a curatable page (public + non-agent, incl.
+  // artifacts) into their vault — including owners and contributors (owned/
+  // contributed pages are NOT automatically in vaults, so excluding them created
+  // a curation gap for the most engaged users).
+  const canCurate = isLoaded && !!isSignedIn && isCuratable;
 
   return (
     <div className="mt-12 border-t border-rule pt-6 flex flex-wrap items-center gap-3">

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -5,7 +5,7 @@ import type { Frontmatter } from "@/lib/frontmatter";
 import type { WikiPage } from "@/lib/types";
 import { findBacklinks, findSimilarPages, buildSlugTenantMap } from "@/lib/wiki";
 import { resolveSlugPath, profileHref } from "@/lib/links";
-import { getCommonsSlugSet, belongsInCommons } from "@/lib/commons";
+import { getCommonsSlugSet, belongsInCommons, isVaultEligible } from "@/lib/commons";
 import type { Principal } from "@/lib/auth";
 import { parseSources, dedupeSourcesForDisplay, sourceLabel } from "@/lib/sources";
 import { stripLeadingH1 } from "@/lib/markdown";
@@ -170,6 +170,18 @@ export async function ArticleView({
   // Whether this page is a commons (public, non-agent) page — gates the curate
   // action in the client action bar.
   const isCommonsPage = belongsInCommons({
+    visibility:
+      typeof page.frontmatter.visibility === "string"
+        ? page.frontmatter.visibility
+        : undefined,
+    type:
+      typeof page.frontmatter.type === "string"
+        ? page.frontmatter.type
+        : undefined,
+  });
+  // Curatable into a vault: public + non-agent, INCLUDING artifacts (which the
+  // commons gate above excludes). Gates the "Save to vault" button.
+  const isCuratable = isVaultEligible({
     visibility:
       typeof page.frontmatter.visibility === "string"
         ? page.frontmatter.visibility
@@ -491,6 +503,7 @@ export async function ArticleView({
             owner={pageOwner}
             contributors={pageContributors}
             isCommonsPage={isCommonsPage}
+            isCuratable={isCuratable}
             hasRawSource={hasRawSource}
             hasSourceUrl={hasSourceUrl}
           />

--- a/src/lib/__tests__/commons.test.ts
+++ b/src/lib/__tests__/commons.test.ts
@@ -4,6 +4,7 @@ import os from "os";
 import path from "path";
 import {
   belongsInCommons,
+  isVaultEligible,
   getCommonsIndex,
   upsertCommonsEntry,
   syncCommonsForPage,
@@ -47,6 +48,24 @@ describe("belongsInCommons", () => {
 
   it("excludes saved HTML artifacts (personal rendered outputs)", () => {
     expect(belongsInCommons({ type: "html" })).toBe(false);
+  });
+});
+
+describe("isVaultEligible", () => {
+  it("allows public pages INCLUDING artifacts (unlike belongsInCommons)", () => {
+    expect(isVaultEligible({})).toBe(true);
+    expect(isVaultEligible({ type: "wiki" })).toBe(true);
+    // The key difference: artifacts ARE curatable into a vault.
+    expect(isVaultEligible({ type: "html" })).toBe(true);
+    expect(isVaultEligible({ type: "slides" })).toBe(true);
+    expect(belongsInCommons({ type: "html" })).toBe(false); // contrast
+  });
+
+  it("excludes private pages (a vault references by slug → would leak) and agent-scoped", () => {
+    expect(isVaultEligible({ visibility: "private" })).toBe(false);
+    expect(isVaultEligible({ visibility: "private", type: "html" })).toBe(false);
+    expect(isVaultEligible({ type: "agent-knowledge" })).toBe(false);
+    expect(isVaultEligible({ type: "agent-identity" })).toBe(false);
   });
 });
 

--- a/src/lib/__tests__/mcp.test.ts
+++ b/src/lib/__tests__/mcp.test.ts
@@ -3991,6 +3991,21 @@ describe("vault_curate", () => {
     expect(vault?.slugs).toContain("machine-learning");
   });
 
+  it("curates a public ARTIFACT (html) into a vault — parity with the UI", async () => {
+    await writeTestPage(
+      "explainer",
+      "---\ntitle: Explainer\ntype: html\n---\n<h1>Explainer</h1>",
+    );
+    const result = await handleVaultCurate({
+      slug: "explainer",
+      owner: "alice",
+      vault: "Collection",
+    });
+    expect(result).toMatchObject({ curated: true, slug: "explainer" });
+    const vault = await getVault(vaultIdFor("alice", "Collection"));
+    expect(vault?.slugs).toContain("explainer");
+  });
+
   it("throws for a non-existent page", async () => {
     await expect(
       handleVaultCurate({ slug: "does-not-exist", owner: "alice", vault: "v" }),
@@ -4005,7 +4020,7 @@ describe("vault_curate", () => {
 
     await expect(
       handleVaultCurate({ slug: "private-notes", owner: "alice", vault: "v" }),
-    ).rejects.toThrow("Only public commons pages can be curated into a vault.");
+    ).rejects.toThrow("Only public, non-agent pages can be curated into a vault.");
   });
 
   it("throws for an agent-scoped page", async () => {
@@ -4016,7 +4031,7 @@ describe("vault_curate", () => {
 
     await expect(
       handleVaultCurate({ slug: "agent-identity", owner: "alice", vault: "v" }),
-    ).rejects.toThrow("Only public commons pages can be curated into a vault.");
+    ).rejects.toThrow("Only public, non-agent pages can be curated into a vault.");
   });
 
   it("is idempotent — curating twice keeps a single membership in the named vault", async () => {

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -189,17 +189,45 @@ describe("searchWikiContent", () => {
       ),
     );
     await writeWikiPage(
-      "index",
-      "# Index\n\n- [Note](note-x.md) — n\n- [Artifact](artifact-x.md) — a",
+      "deck-x",
+      serializeFrontmatter(
+        { type: "slides" },
+        "# Deck X\n\nAttention mechanisms explained here.",
+      ),
     );
-    // Both slugs are in the scope (as if a vault curated the artifact), but the
-    // artifact must still NOT surface as a search hit.
-    const scope = { agentId: "vault:v1", slugs: ["note-x", "artifact-x"] };
+    await writeWikiPage(
+      "index",
+      "# Index\n\n- [Note](note-x.md) — n\n- [Artifact](artifact-x.md) — a\n- [Deck](deck-x.md) — d",
+    );
+    // All slugs are in the scope (as if a vault curated the artifacts), but the
+    // artifacts (html AND slides) must still NOT surface as search hits.
+    const scope = { agentId: "vault:v1", slugs: ["note-x", "artifact-x", "deck-x"] };
     const slugs = (await searchWikiContent("attention", 10, scope)).map(
       (r) => r.slug,
     );
     expect(slugs).toContain("note-x");
     expect(slugs).not.toContain("artifact-x");
+    expect(slugs).not.toContain("deck-x");
+  });
+
+  it("an `agent:` scope STILL surfaces agent-typed pages (only unscoped excludes them)", async () => {
+    await ensureDirectories();
+    await writeWikiPage(
+      "ak",
+      serializeFrontmatter(
+        { type: "agent-knowledge" },
+        "# AK\n\nAttention mechanisms explained here.",
+      ),
+    );
+    await writeWikiPage("index", "# Index\n\n- [AK](ak.md) — a");
+    // Unscoped: agent-scoped page excluded.
+    expect((await searchWikiContent("attention")).map((r) => r.slug)).not.toContain("ak");
+    // Scoped (the agent's own lens): it MUST surface — guards the scope-aware
+    // includeAgentScoped:!scope refactor.
+    const scope = { agentId: "agent:x", slugs: ["ak"] };
+    expect(
+      (await searchWikiContent("attention", 10, scope)).map((r) => r.slug),
+    ).toContain("ak");
   });
 
   it("is case-insensitive", async () => {

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -175,6 +175,33 @@ describe("searchWikiContent", () => {
     expect(slugs).not.toContain("agent-note");
   });
 
+  it("excludes artifacts even WITHIN a scope (vault/owner) — markup is never query knowledge", async () => {
+    await ensureDirectories();
+    await writeWikiPage(
+      "note-x",
+      "# Note X\n\nAttention mechanisms explained here.",
+    );
+    await writeWikiPage(
+      "artifact-x",
+      serializeFrontmatter(
+        { type: "html" },
+        "# Artifact X\n\nAttention mechanisms explained here.",
+      ),
+    );
+    await writeWikiPage(
+      "index",
+      "# Index\n\n- [Note](note-x.md) — n\n- [Artifact](artifact-x.md) — a",
+    );
+    // Both slugs are in the scope (as if a vault curated the artifact), but the
+    // artifact must still NOT surface as a search hit.
+    const scope = { agentId: "vault:v1", slugs: ["note-x", "artifact-x"] };
+    const slugs = (await searchWikiContent("attention", 10, scope)).map(
+      (r) => r.slug,
+    );
+    expect(slugs).toContain("note-x");
+    expect(slugs).not.toContain("artifact-x");
+  });
+
   it("is case-insensitive", async () => {
     await ensureDirectories();
     await writeWikiPage("test-page", "# Test Page\n\nHello WORLD.");

--- a/src/lib/__tests__/vault-pages-route.test.ts
+++ b/src/lib/__tests__/vault-pages-route.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+// The vault is owned by the signed-in caller; mock only auth + vault membership
+// so the test exercises the real ELIGIBILITY gate (isVaultEligible via real
+// commons) against real pages on fs storage.
+vi.mock("@/lib/auth", () => ({
+  getPrincipal: vi.fn(async () => ({ id: "u1", handle: "alice" })),
+}));
+vi.mock("@/lib/vault", () => ({
+  vaultOwnedBy: vi.fn(() => true),
+  addToVault: vi.fn(async () => {}),
+  removeFromVault: vi.fn(async () => {}),
+  getVault: vi.fn(async () => ({ id: "v1", visibility: "public", slugs: [] })),
+}));
+
+import { POST } from "@/app/api/vaults/[id]/pages/route";
+import { addToVault } from "@/lib/vault";
+import { writeWikiPage, ensureDirectories, serializeFrontmatter } from "@/lib/wiki";
+import { _resetStorage } from "@/lib/storage";
+
+const mockedAdd = vi.mocked(addToVault);
+
+function post(slug: string) {
+  return POST(
+    new Request("http://localhost/api/vaults/v1/pages", {
+      method: "POST",
+      body: JSON.stringify({ slug }),
+    }),
+    { params: Promise.resolve({ id: "v1" }) },
+  );
+}
+
+let tmpDir: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-route-test-"));
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) saved[k] = process.env[k];
+  process.env.WIKI_DIR = path.join(tmpDir, "wiki");
+  process.env.RAW_DIR = path.join(tmpDir, "raw");
+  process.env.DATA_DIR = tmpDir;
+  _resetStorage();
+  await ensureDirectories();
+  mockedAdd.mockClear();
+});
+
+afterEach(async () => {
+  for (const k of ["WIKI_DIR", "RAW_DIR", "DATA_DIR"]) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetStorage();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("POST /api/vaults/[id]/pages — eligibility gate", () => {
+  it("rejects a PRIVATE page (400) and never references it", async () => {
+    await writeWikiPage(
+      "secret",
+      serializeFrontmatter({ visibility: "private" }, "# Secret\n\nshh"),
+    );
+    const res = await post("secret");
+    expect(res.status).toBe(400);
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it("rejects an agent-scoped page (400)", async () => {
+    await writeWikiPage(
+      "ak",
+      serializeFrontmatter({ type: "agent-knowledge" }, "# AK\n\nx"),
+    );
+    const res = await post("ak");
+    expect(res.status).toBe(400);
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it("accepts a PUBLIC artifact (html) — the headline feature", async () => {
+    await writeWikiPage(
+      "explainer",
+      serializeFrontmatter({ type: "html" }, "# Explainer\n\n<p>hi</p>"),
+    );
+    const res = await post("explainer");
+    expect(res.status).toBe(200);
+    expect(mockedAdd).toHaveBeenCalledWith("v1", "explainer");
+  });
+
+  it("accepts a plain public commons page (200)", async () => {
+    await writeWikiPage("note", "# Note\n\nknowledge");
+    const res = await post("note");
+    expect(res.status).toBe(200);
+    expect(mockedAdd).toHaveBeenCalledWith("v1", "note");
+  });
+});

--- a/src/lib/commons.ts
+++ b/src/lib/commons.ts
@@ -53,6 +53,20 @@ export function belongsInCommons(meta: {
 }
 
 /**
+ * A page may be CURATED into a vault iff it's public and not agent-scoped.
+ * Unlike {@link belongsInCommons}, artifacts (rendered `html`/`slides` outputs)
+ * ARE eligible — a vault can collect them for Browse (they remain excluded from
+ * Query/Graph retrieval, which is keyed on knowledge pages). Private pages stay
+ * excluded: a vault references pages by slug, so a private one would leak.
+ */
+export function isVaultEligible(meta: {
+  visibility?: string;
+  type?: string;
+}): boolean {
+  return meta.visibility !== "private" && !isAgentScopedType(meta.type);
+}
+
+/**
  * Read the full commons index (empty array when absent). Fail-soft: a missing
  * or corrupt index returns `[]` so reads fall back to deriving the public set
  * rather than crashing a page render.

--- a/src/lib/graph-build.ts
+++ b/src/lib/graph-build.ts
@@ -14,6 +14,7 @@ import {
   readWikiPageWithFrontmatter,
   listReadableWikiPages,
   isAgentScopedType,
+  isArtifactType,
 } from "./wiki";
 import { ownerToTenant } from "./links";
 import { listCommonsPages } from "./commons";
@@ -54,8 +55,14 @@ export async function buildWikiGraph(
   if (expanded) {
     const resolved = await resolveScope(expanded);
     const scopeSet = new Set(resolved?.slugs ?? []);
+    // Artifacts are excluded from the graph at every scope (incl. a vault that
+    // curated one) — they're rendered outputs, not knowledge nodes. The commons
+    // (unscoped) branch is already artifact-free via listCommonsPages.
     pages = (await listReadableWikiPages(principal)).filter(
-      (p) => scopeSet.has(p.slug) && !isAgentScopedType(p.type),
+      (p) =>
+        scopeSet.has(p.slug) &&
+        !isAgentScopedType(p.type) &&
+        !isArtifactType(p.type),
     );
   } else {
     pages = await listCommonsPages();

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -263,13 +263,14 @@ export async function query(
       return { answer: scopeError, sources: [] };
     }
 
-    // General (unscoped) query excludes agent-scoped pages (agent knowledge
-    // surfaces only via an `agent:` scope) and saved HTML artifacts (rendered
-    // outputs, not knowledge — their markup must never enter the LLM context).
+    // Artifacts (saved html/slides) are NEVER query knowledge — their markup
+    // must never enter the LLM context — so exclude them REGARDLESS of scope
+    // (incl. a vault that curated one, or the owner/"Mine" scope). Agent-scoped
+    // pages are excluded only from a GENERAL (unscoped) query — they surface via
+    // an `agent:` scope.
+    entries = entries.filter((e) => !isArtifactType(e.type));
     if (!scopeSlugs) {
-      entries = entries.filter(
-        (e) => !isAgentScopedType(e.type) && !isArtifactType(e.type),
-      );
+      entries = entries.filter((e) => !isAgentScopedType(e.type));
     }
 
     // Empty wiki — nothing to query

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -516,8 +516,8 @@ export async function searchWikiContent(
 
   const SKIP = new Set(["index.md", "log.md"]);
   const scopeSlugs = scope ? new Set(scope.slugs) : null;
-  // Without a scope, exclude agent-scoped pages from general search — they
-  // surface only via an `agent:` scope.
+  // Always excludes artifacts; agent-scoped pages too when UNSCOPED (they surface
+  // only via an `agent:` scope).
   const excludedSlugs = await searchExcludedSlugSet(/* includeAgentScoped */ !scope);
 
   const scored: Array<{
@@ -534,7 +534,7 @@ export async function searchWikiContent(
 
     // Scope filtering: skip pages not in the scope's slug set
     if (scopeSlugs && !scopeSlugs.has(slug)) continue;
-    // General search: skip agent-scoped pages
+    // Skip artifacts (always) and, when unscoped, agent-scoped pages.
     if (excludedSlugs.has(slug)) continue;
 
     let content: string;
@@ -662,7 +662,7 @@ export async function fuzzySearchWikiContent(
 
     // Scope filtering: skip pages not in the scope's slug set
     if (scopeSlugs && !scopeSlugs.has(slug)) continue;
-    // General search: skip agent-scoped pages
+    // Skip artifacts (always) and, when unscoped, agent-scoped pages.
     if (excludedSlugs.has(slug)) continue;
 
     // Skip pages already in exact results

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -470,15 +470,24 @@ export function fuzzyMatch(
  * are searched.
  */
 /**
- * Slugs excluded from general (unscoped) search: agent-scoped pages (`agent-*`,
- * surface only via an `agent:` scope) and saved artifacts (e.g. `html` query
- * outputs — personal rendered outputs whose markup shouldn't surface as hits).
+ * Slugs excluded from search. Artifacts (e.g. `html`/`slides` rendered outputs)
+ * are ALWAYS excluded — their markup is not knowledge and must never surface as a
+ * hit or enter the LLM context, even within a scope (e.g. a vault that curated
+ * one, or a user's own "Mine"/owner scope). Agent-scoped pages (`agent-*`) are
+ * excluded only from GENERAL (unscoped) search — they surface via an `agent:`
+ * scope — so pass `includeAgentScoped: false` when a scope is active.
  */
-async function searchExcludedSlugSet(): Promise<Set<string>> {
+async function searchExcludedSlugSet(
+  includeAgentScoped: boolean,
+): Promise<Set<string>> {
   const pages = await listWikiPages();
   return new Set(
     pages
-      .filter((p) => isAgentScopedType(p.type) || isArtifactType(p.type))
+      .filter(
+        (p) =>
+          isArtifactType(p.type) ||
+          (includeAgentScoped && isAgentScopedType(p.type)),
+      )
       .map((p) => p.slug),
   );
 }
@@ -509,7 +518,7 @@ export async function searchWikiContent(
   const scopeSlugs = scope ? new Set(scope.slugs) : null;
   // Without a scope, exclude agent-scoped pages from general search — they
   // surface only via an `agent:` scope.
-  const excludedSlugs = scope ? null : await searchExcludedSlugSet();
+  const excludedSlugs = await searchExcludedSlugSet(/* includeAgentScoped */ !scope);
 
   const scored: Array<{
     slug: string;
@@ -526,7 +535,7 @@ export async function searchWikiContent(
     // Scope filtering: skip pages not in the scope's slug set
     if (scopeSlugs && !scopeSlugs.has(slug)) continue;
     // General search: skip agent-scoped pages
-    if (excludedSlugs && excludedSlugs.has(slug)) continue;
+    if (excludedSlugs.has(slug)) continue;
 
     let content: string;
     try {
@@ -643,7 +652,7 @@ export async function fuzzySearchWikiContent(
   const SKIP = new Set(["index.md", "log.md"]);
   const exactSlugs = new Set(exactResults.map((r) => r.slug));
   const scopeSlugs = scope ? new Set(scope.slugs) : null;
-  const excludedSlugs = scope ? null : await searchExcludedSlugSet();
+  const excludedSlugs = await searchExcludedSlugSet(/* includeAgentScoped */ !scope);
 
   const fuzzyResults: ContentSearchResult[] = [];
 
@@ -654,7 +663,7 @@ export async function fuzzySearchWikiContent(
     // Scope filtering: skip pages not in the scope's slug set
     if (scopeSlugs && !scopeSlugs.has(slug)) continue;
     // General search: skip agent-scoped pages
-    if (excludedSlugs && excludedSlugs.has(slug)) continue;
+    if (excludedSlugs.has(slug)) continue;
 
     // Skip pages already in exact results
     if (exactSlugs.has(slug)) continue;

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -91,7 +91,7 @@ import { queryByFrontmatter, validateQuery, type DataviewFilter, type DataviewQu
 import { listRevisions, readRevision, readRevisionMeta, type Revision } from "./lib/revisions";
 import { vaultIdFor, getVault, findVaultByName, createVault, renameVault, deleteVault, addToVault, removeFromVault, listVaults, vaultSlugs } from "./lib/vault";
 import type { Vault } from "./lib/vault";
-import { belongsInCommons } from "./lib/commons";
+import { isVaultEligible } from "./lib/commons";
 import { reconcileFromTalk, type ReconcileFromTalkResult } from "./lib/reconcile";
 import { buildWikiGraph, type GraphNode, type GraphEdge } from "./lib/graph-build";
 import { mergePages, type MergePagesResult } from "./lib/merge";
@@ -1017,7 +1017,7 @@ export async function handleVaultCurate(args: {
     throw new Error(`Page not found: ${args.slug}`);
   }
   if (
-    !belongsInCommons({
+    !isVaultEligible({
       visibility:
         typeof page.frontmatter.visibility === "string"
           ? page.frontmatter.visibility
@@ -1029,7 +1029,7 @@ export async function handleVaultCurate(args: {
     })
   ) {
     throw new Error(
-      "Only public commons pages can be curated into a vault.",
+      "Only public, non-agent pages can be curated into a vault.",
     );
   }
   // Resolve the named vault, creating it (public) on first use.
@@ -3250,10 +3250,10 @@ export function createMcpServer(): McpServer {
   // vault_curate — Add a commons page to a user's vault
   server.registerTool("vault_curate", {
     description:
-      "Curate a public commons page into one of a user's named vaults. A vault is a personal " +
-      "reference lens over the commons — no copy is made; the page itself stays collective. The " +
-      "named vault is created (public) on first use. Only public, non-agent (commons) pages can " +
-      "be curated.",
+      "Curate a public page into one of a user's named vaults. A vault is a personal reference " +
+      "lens — no copy is made; the page itself stays where it is. The named vault is created " +
+      "(public) on first use. Public, non-agent pages are eligible, INCLUDING rendered artifacts " +
+      "(html/slides), which the vault collects for Browse (they stay out of Query/Graph).",
     inputSchema: {
       slug: z.string().describe("Slug of the commons page to curate"),
       owner: z


### PR DESCRIPTION
**Why:** artifacts (rendered `html`/`slides` query outputs) couldn't be added to a vault. Two gates blocked them: `POST /api/vaults/[id]/pages` checked `belongsInCommons` (which is `!isArtifactType`), and `ArticleActions` only showed "Save to vault" on commons pages.

**Change:** new `isVaultEligible(meta)` = **public + non-agent** (artifacts ALLOWED, unlike `belongsInCommons`). Private pages stay excluded — a vault references pages by slug, so a private one would leak.
- Route gates on `isVaultEligible` (error message updated).
- `ArticleView` computes `isCuratable` and passes it; `ArticleActions` shows the curate button for any curatable page including artifacts. Delete realm still keys on `isCommonsPage` (unchanged).

**Scope (per the chosen design — Browse-only):** an artifact added to a vault shows in the vault's **Browse** list as a collected item, but stays **excluded from Query/Graph** retrieval (those are keyed on knowledge pages, `query.ts`/search/graph already exclude `isArtifactType`). So it's bookmark/collection semantics, not a queryable knowledge page.

**Tests:** `isVaultEligible` unit tests (public artifact → eligible; private/agent → not; contrast with `belongsInCommons`).

## Gates
`pnpm lint` 0 errors · `vitest` 3288 passed · `pnpm build` + `pnpm build:cloudflare` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)