### PR TITLE
yoyo: HTML slide decks (visual-rich, replaces Marp slides)

### DIFF
--- a/src/app/share/[handle]/[slug]/page.tsx
+++ b/src/app/share/[handle]/[slug]/page.tsx
@@ -143,10 +143,14 @@ export default async function SharePage({ params }: ShareProps) {
         // 100dvh) so there's no page scrollbar; its sources stay one click away
         // via "Open in wiki" rather than forcing a scroll past the full frame.
         <HtmlPreview html={page.body} bare />
+      ) : pageType === "slides" &&
+        (/<section[^>]*class=["'][^"']*\bslide\b/i.test(page.body) ||
+          /^\s*<!doctype/i.test(page.body)) ? (
+        // A new HTML deck fills the viewport (full-screen deck with nav), same as
+        // an html artifact's share view.
+        <HtmlPreview html={page.body} bare deck />
       ) : pageType === "slides" ? (
-        // A shared deck renders as a paginated carousel (SlidePreview splits the
-        // body on `---`, each slide rendered as markdown) — not flattened markdown
-        // or raw text in the HTML iframe.
+        // Legacy Marp deck → the markdown carousel.
         <main
           style={{ maxWidth: 960, margin: "0 auto", padding: "40px 24px 80px" }}
         >

--- a/src/app/share/[handle]/[slug]/page.tsx
+++ b/src/app/share/[handle]/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { stripLeadingH1 } from "@/lib/markdown";
 import type { SourceEntry } from "@/lib/types";
 import { Colophon } from "@/components/folio/primitives";
 import { HtmlPreview } from "@/components/HtmlPreview";
+import { isHtmlDeck } from "@/lib/html";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { SlidePreview } from "@/components/SlidePreview";
 
@@ -143,9 +144,7 @@ export default async function SharePage({ params }: ShareProps) {
         // 100dvh) so there's no page scrollbar; its sources stay one click away
         // via "Open in wiki" rather than forcing a scroll past the full frame.
         <HtmlPreview html={page.body} bare />
-      ) : pageType === "slides" &&
-        (/<section[^>]*class=["'][^"']*\bslide\b/i.test(page.body) ||
-          /^\s*<!doctype/i.test(page.body)) ? (
+      ) : pageType === "slides" && isHtmlDeck(page.body) ? (
         // A new HTML deck fills the viewport (full-screen deck with nav), same as
         // an html artifact's share view.
         <HtmlPreview html={page.body} bare deck />

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -426,10 +426,15 @@ export async function ArticleView({
               // (isolated; no app cookie/DOM/network access) — never markdown.
               <HtmlPreview html={page.body} />
             ) : pageType === "slides" ? (
-              // A saved slide deck renders as a paginated carousel (SlidePreview
-              // splits the body on `---` and renders each slide as markdown), not
-              // one flattened markdown flow. (No Marp engine / Marp directives.)
-              <SlidePreview content={page.body} />
+              // A slide deck. New decks are self-contained HTML (rendered in the
+              // sandboxed iframe with the deck runtime); legacy decks are Marp
+              // markdown (the `<SlidePreview>` carousel) — sniff the body to pick.
+              /<section[^>]*class=["'][^"']*\bslide\b/i.test(page.body) ||
+              /^\s*<!doctype/i.test(page.body) ? (
+                <HtmlPreview html={page.body} deck />
+              ) : (
+                <SlidePreview content={page.body} />
+              )
             ) : (
               <MarkdownRenderer
                 content={articleBody}

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -14,6 +14,7 @@ import { Icon } from "@/components/folio/icons";
 import { Avatar, Mark, Confidence, Freshness } from "@/components/folio/primitives";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { HtmlPreview } from "@/components/HtmlPreview";
+import { isHtmlDeck } from "@/lib/html";
 import { SlidePreview } from "@/components/SlidePreview";
 import { SharePageButton } from "@/components/SharePageButton";
 import { ArticleActions } from "@/components/ArticleActions";
@@ -429,8 +430,7 @@ export async function ArticleView({
               // A slide deck. New decks are self-contained HTML (rendered in the
               // sandboxed iframe with the deck runtime); legacy decks are Marp
               // markdown (the `<SlidePreview>` carousel) — sniff the body to pick.
-              /<section[^>]*class=["'][^"']*\bslide\b/i.test(page.body) ||
-              /^\s*<!doctype/i.test(page.body) ? (
+              isHtmlDeck(page.body) ? (
                 <HtmlPreview html={page.body} deck />
               ) : (
                 <SlidePreview content={page.body} />

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -26,17 +26,21 @@ import { logger } from "@/lib/logger";
 export function HtmlPreview({
   html,
   bare = false,
+  deck = false,
 }: {
   html: string;
   /** Full-bleed share view: no border/radius, fills the viewport below the
    *  share header. The auto-height still drives growth; this only restyles. */
   bare?: boolean;
+  /** Render as a slide deck: inject the deck runtime (one `<section class="slide">`
+   *  at a time, ←/→ nav) and use a fixed full-viewport frame like an app-style doc. */
+  deck?: boolean;
 }) {
   const ref = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState(360);
-  // App-style artifacts (full-viewport 100vh layouts) get a fixed, scroll-hidden
-  // frame instead of auto-height; see the iframe below.
-  const appStyle = usesViewportUnits(html);
+  // App-style artifacts (full-viewport 100vh layouts) and decks get a fixed,
+  // scroll-hidden frame instead of auto-height; see the iframe below.
+  const appStyle = usesViewportUnits(html) || deck;
 
   // Match the artifact's paper/ink to the page's RESOLVED theme (yopedia toggles
   // a `dark`/`light` class on <html> via localStorage; the sandboxed iframe can't
@@ -137,7 +141,7 @@ export function HtmlPreview({
       // feedback-loops them to absurd heights — so we fix the frame and let
       // them scroll INSIDE it, with that inner scrollbar hidden. Full-screen
       // share (`bare`) fills the viewport; inline gets a tall contained frame.
-      srcDoc={composeSrcDoc(renderedHtml, chartLib, bare || appStyle, theme)}
+      srcDoc={composeSrcDoc(renderedHtml, chartLib, bare || appStyle, theme, deck)}
       sandbox={HTML_SANDBOX}
       title="HTML output"
       style={{

--- a/src/components/QueryResultPanel.tsx
+++ b/src/components/QueryResultPanel.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { SlidePreview } from "@/components/SlidePreview";
 import { HtmlPreview } from "@/components/HtmlPreview";
-import { stripHtmlFence, composeSrcDoc, usesChartLib } from "@/lib/html";
+import { stripHtmlFence, composeSrcDoc, usesChartLib, isHtmlDeck } from "@/lib/html";
 import { Alert } from "@/components/Alert";
 import { useSlugTenants } from "@/hooks/useSlugTenants";
 import { logger } from "@/lib/logger";
@@ -59,7 +59,11 @@ export function QueryResultPanel({
     return () => clearTimeout(timer);
   }, [copyState]);
 
-  const isHtml = format === "html";
+  // A slides answer is now a self-contained HTML deck (one `<section class="slide">`
+  // per slide). Detect it from the body so the live preview/copy use the deck
+  // runtime — without it the deck would render as a flat, navigation-less document.
+  const isDeck = isHtmlDeck(result.answer);
+  const isHtml = format === "html" || isDeck;
   const handleCopy = useCallback(async () => {
     // HTML copies the fully self-contained document (CSP + baseline styles +
     // inlined Chart.js) so a pasted/hosted copy renders standalone offline — the
@@ -74,7 +78,7 @@ export function QueryResultPanel({
         const chartLib = usesChartLib(result.answer)
           ? (await import("@/lib/vendor/chartjs.generated")).CHARTJS_SOURCE
           : undefined;
-        text = composeSrcDoc(result.answer, chartLib);
+        text = composeSrcDoc(result.answer, chartLib, undefined, undefined, isDeck);
       } else {
         const lines = [`# ${question.trim()}`, "", result.answer];
         if (result.sources.length > 0) {
@@ -89,7 +93,7 @@ export function QueryResultPanel({
       logger.error("query", "copy failed", err);
       setCopyState("error");
     }
-  }, [result, question, isHtml]);
+  }, [result, question, isHtml, isDeck]);
 
   function handleSaveClick() {
     setSaveTitle(question.trim());
@@ -157,6 +161,7 @@ export function QueryResultPanel({
   // is still recognized as HTML.
   const isHtmlAnswer =
     format === "html" ||
+    isDeck ||
     /^\s*(<!doctype html|<html)/i.test(stripHtmlFence(result.answer));
   const isMarp = result.answer.trimStart().startsWith("---\nmarp: true");
 
@@ -170,7 +175,7 @@ export function QueryResultPanel({
             {result.answer || "Rendering HTML…"}
           </pre>
         ) : isHtmlAnswer ? (
-          <HtmlPreview html={result.answer} />
+          <HtmlPreview html={result.answer} deck={isDeck} />
         ) : !streaming && isMarp ? (
           <SlidePreview content={result.answer} />
         ) : (

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -5,6 +5,7 @@ import {
   stripHtmlFence,
   usesChartLib,
   usesViewportUnits,
+  isHtmlDeck,
   HTML_SANDBOX,
   HTML_MAX_HEIGHT,
 } from "../html";
@@ -381,5 +382,38 @@ describe("htmlToPlainText", () => {
 
   it("collapses whitespace and trims", () => {
     expect(htmlToPlainText("<div>  a\n\n  b  </div>")).toBe("a b");
+  });
+});
+
+describe("isHtmlDeck", () => {
+  it("detects an HTML deck by its slide section marker", () => {
+    expect(
+      isHtmlDeck('<!doctype html><html><body><section class="slide"><h1>A</h1></section></body></html>'),
+    ).toBe(true);
+  });
+
+  it("matches regardless of attribute order, quoting, or extra classes", () => {
+    expect(isHtmlDeck("<section data-i='1' class='intro slide active'>")).toBe(true);
+    expect(isHtmlDeck('<SECTION CLASS="slide">')).toBe(true);
+  });
+
+  it("does not match a substring class like 'slides' or 'slider'", () => {
+    expect(isHtmlDeck('<section class="slides">')).toBe(false);
+    expect(isHtmlDeck('<section class="slider-track">')).toBe(false);
+  });
+
+  it("does not match a legacy Marp deck (frontmatter, no slide section)", () => {
+    expect(isHtmlDeck("---\nmarp: true\n---\n\n# Title\n\n---\n\n## Next")).toBe(false);
+  });
+
+  it("does not match a plain HTML artifact (no slide section)", () => {
+    expect(
+      isHtmlDeck("<!doctype html><html><body><h1>Article</h1><p>Prose.</p></body></html>"),
+    ).toBe(false);
+  });
+
+  it("does not match plain markdown prose or empty input", () => {
+    expect(isHtmlDeck("# Heading\n\nSome **markdown** body.")).toBe(false);
+    expect(isHtmlDeck("")).toBe(false);
   });
 });

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -186,6 +186,22 @@ describe("composeSrcDoc", () => {
     expect(out).toContain("html body{margin-inline:auto}");
   });
 
+  it("deck mode injects the slide runtime and skips the centered article column", () => {
+    const out = composeSrcDoc(
+      '<section class="slide"><h1>X</h1></section>',
+      undefined,
+      true,
+      undefined,
+      true,
+    );
+    expect(out).toContain(".slide.active{display:flex}"); // deck CSS
+    expect(out).toContain("ArrowRight"); // deck nav script
+    expect(out).not.toContain("body{max-width:var(--measure)}"); // no article column
+    // Non-deck doc gets neither the deck runtime.
+    const plain = composeSrcDoc("<p>x</p>");
+    expect(plain).not.toContain(".slide.active");
+  });
+
   it("forces the resolved app theme (overrides the OS prefers-color-scheme default)", () => {
     const dark = composeSrcDoc("<p>x</p>", undefined, false, "dark");
     expect(dark).toContain(`:root{color-scheme:dark;--paper:#14130f`);

--- a/src/lib/__tests__/query.test.ts
+++ b/src/lib/__tests__/query.test.ts
@@ -1080,19 +1080,16 @@ describe("saveAnswerToWiki", () => {
     expect(headingCount).toBe(1);
   });
 
-  it("saves a slides deck as an owner-attributed artifact (type slides, verbatim body, no data-URI in summary)", async () => {
+  it("saves a slides deck as an owner-attributed artifact (type slides, verbatim HTML body, no data-URI in summary)", async () => {
     await ensureDirectories();
+    // Slides answers are now self-contained HTML decks (one <section class="slide">
+    // per slide), processed like an html artifact.
     const deck = [
-      "---",
-      "marp: true",
-      "---",
-      "# My Deck",
-      "",
-      "A short opening line for the summary.",
-      "",
-      "---",
-      "",
-      "![an illustration](data:image/jpeg;base64,AAAAAAAA)",
+      "<!doctype html><html><body>",
+      '<section class="slide"><h1>My Deck</h1>',
+      '<p class="lead">A short opening line for the summary.</p></section>',
+      '<section class="slide"><figure><img src="data:image/jpeg;base64,AAAAAAAA"></figure></section>',
+      "</body></html>",
     ].join("\n");
 
     const { slug } = await saveAnswerToWiki(
@@ -1111,12 +1108,13 @@ describe("saveAnswerToWiki", () => {
     expect(page!.frontmatter.type).toBe("slides");
     expect(page!.frontmatter.owner).toBe("alice");
     expect(page!.frontmatter.authors).toEqual(["alice"]);
-    // Body stored verbatim — Marp markdown, no injected `# ` heading prepended.
-    expect(page!.body).toContain("marp: true");
-    expect(page!.body).toContain("![an illustration](data:image/jpeg;base64,AAAAAAAA)");
-    // The baked image's data URI never leaks into the index summary.
+    // Body stored verbatim — the HTML deck, no injected `# ` heading prepended.
+    expect(page!.body).toContain('<section class="slide">');
+    expect(page!.body).toContain('src="data:image/jpeg;base64,AAAAAAAA"');
+    // The image's data URI never leaks into the index summary (tags stripped).
     const entry = (await listWikiPages()).find((e) => e.slug === slug);
     expect(entry!.summary).not.toContain("data:image");
+    expect(entry!.summary).toContain("short opening line");
     expect(entry!.type).toBe("slides");
   });
 

--- a/src/lib/__tests__/query.test.ts
+++ b/src/lib/__tests__/query.test.ts
@@ -852,8 +852,12 @@ describe("query", () => {
     // XAI_API_KEY here, generation returns null and the directive is dropped —
     // proving the bake ran for format=slides (no leftover fence reaches the client).
     mockedHasLLMKey.mockReturnValue(true);
+    // A slides answer is now a self-contained HTML deck, so its illustration
+    // directive is an HTML <figure>, baked via the HTML path.
     mockedCallLLM.mockResolvedValue(
-      "# Deck\n\n```yoyo-illustration\nyoyo waving hello\n```\n",
+      '<!doctype html><html><body><section class="slide">' +
+        '<figure class="yoyo-illustration" data-scene="yoyo waving hello"></figure>' +
+        "</section></body></html>",
     );
     await writeWikiPage("alpha", "# Alpha\n\nAlpha content.");
     await updateIndex([{ slug: "alpha", title: "Alpha", summary: "Alpha page" }]);

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -195,11 +195,56 @@ export function usesViewportUnits(html: string): boolean {
  * runtime. The model's own markup is injected after this string, so its
  * `<style>` overrides the baseline.
  */
+// Slide-deck runtime — injected ONLY for `deck` documents. Each `<section
+// class="slide">` becomes a 16:9-ish full-viewport slide; one shows at a time,
+// navigated with ←/→/space/click. A slide that overflows scrolls inside itself
+// (graceful) rather than clipping. Reuses BASE_STYLE typography + components
+// (charts/cards/mermaid all work per slide), so a deck is as rich as an article.
+const DECK_STYLE = `<style>
+html,body{height:100%;margin:0;overflow:hidden}
+.slide{position:absolute;inset:0;display:none;flex-direction:column;justify-content:center;gap:.35em;padding:clamp(28px,4.5vh,56px) clamp(40px,6vw,84px);box-sizing:border-box;overflow:auto}
+.slide.active{display:flex}
+.slide>*{max-width:100%;margin-top:.25em;margin-bottom:.25em}
+.slide h1{font-size:clamp(2rem,5.2vw,3.4rem);margin:.1em 0;border:0;padding:0}
+.slide h2{font-size:clamp(1.4rem,3.4vw,2.1rem);margin:.1em 0;border:0;padding:0}
+.slide .lead{font-size:clamp(1.05rem,2vw,1.5rem);margin:.1em 0}
+.slide li{margin:.25em 0}
+.deck-bar{position:fixed;left:0;right:0;bottom:0;height:4px;background:var(--rule);z-index:20}
+.deck-bar>i{display:block;height:100%;background:var(--accent);transition:width .2s}
+.deck-count{position:fixed;bottom:12px;right:18px;font:600 12px/1 ui-sans-serif,system-ui,sans-serif;color:var(--muted);background:var(--paper-2);border:1px solid var(--rule);border-radius:999px;padding:5px 10px;z-index:20}
+.deck-arrow{position:fixed;bottom:10px;left:18px;display:flex;gap:6px;z-index:20}
+.deck-arrow button{font:15px/1 ui-sans-serif,system-ui,sans-serif;background:var(--paper-2);color:var(--ink-2);border:1px solid var(--rule);border-radius:8px;padding:6px 12px;cursor:pointer}
+</style>`;
+const DECK_SCRIPT = `<script>(function(){
+function slides(){return Array.prototype.slice.call(document.querySelectorAll('.slide'))}
+var i=0;
+function render(){var s=slides();if(!s.length)return;i=Math.max(0,Math.min(i,s.length-1));
+s.forEach(function(el,n){el.classList.toggle('active',n===i)});
+var c=document.getElementById('__dc');if(c)c.textContent=(i+1)+' / '+s.length;
+var b=document.getElementById('__db');if(b)b.style.width=((i+1)/s.length*100)+'%';
+try{s[i].scrollTop=0}catch(_){}}
+function go(d){i+=d;render()}
+function setup(){if(document.getElementById('__dc'))return;
+var bar=document.createElement('div');bar.className='deck-bar';bar.innerHTML='<i id="__db"></i>';
+var nav=document.createElement('div');nav.className='deck-arrow';
+var p=document.createElement('button');p.setAttribute('aria-label','Previous');p.textContent='‹';p.onclick=function(){go(-1)};
+var n=document.createElement('button');n.setAttribute('aria-label','Next');n.textContent='›';n.onclick=function(){go(1)};
+nav.appendChild(p);nav.appendChild(n);
+var count=document.createElement('div');count.className='deck-count';count.innerHTML='<span id="__dc"></span>';
+document.body.appendChild(bar);document.body.appendChild(nav);document.body.appendChild(count);
+document.addEventListener('keydown',function(e){
+if(e.key==='ArrowRight'||e.key==='PageDown'||e.key===' '){e.preventDefault();go(1)}
+else if(e.key==='ArrowLeft'||e.key==='PageUp'){e.preventDefault();go(-1)}});
+render();}
+if(document.readyState!=='loading')setup();else document.addEventListener('DOMContentLoaded',setup);
+})();</script>`;
+
 function sandboxHead(
   html: string,
   chartLibSource?: string,
   hideScrollbar?: boolean,
   theme?: "light" | "dark",
+  deck?: boolean,
 ): string {
   const chartLib =
     chartLibSource && usesChartLib(html)
@@ -233,9 +278,12 @@ function sandboxHead(
   //  - `html body{margin-inline:auto}` (specificity 0,0,2) so the common reset
   //    `body{margin:0}` can't ACCIDENTALLY cancel the centering — it's a no-op
   //    when there's no width cap, and centers the column when there is.
-  const centerColumn = usesViewportUnits(html)
-    ? ""
-    : `<style>html{background:var(--paper)}body{max-width:var(--measure)}html body{margin-inline:auto}</style>`;
+  // A deck owns its full-viewport layout, so skip the centered article column.
+  const centerColumn =
+    deck || usesViewportUnits(html)
+      ? ""
+      : `<style>html{background:var(--paper)}body{max-width:var(--measure)}html body{margin-inline:auto}</style>`;
+  const deckBits = deck ? DECK_STYLE + DECK_SCRIPT : "";
   return (
     `<meta http-equiv="Content-Security-Policy" content="${SANDBOX_CSP}">` +
     `<base target="_blank">` +
@@ -244,7 +292,8 @@ function sandboxHead(
     centerColumn +
     hideBar +
     chartLib +
-    BASE_SCRIPT
+    BASE_SCRIPT +
+    deckBits
   );
 }
 
@@ -278,13 +327,15 @@ export function stripHtmlFence(html: string): string {
  * frame is fixed to the viewport and scrolls internally). `theme` forces the
  * artifact's paper/ink to the app's RESOLVED light/dark theme so the iframe
  * matches the page around it (pass the parent's current theme; omit to fall back
- * to the OS `prefers-color-scheme` default).
+ * to the OS `prefers-color-scheme` default). `deck` injects the slide-deck runtime
+ * — `<section class="slide">` blocks become a navigable full-viewport deck.
  */
 export function composeSrcDoc(
   html: string,
   chartLibSource?: string,
   hideScrollbar?: boolean,
   theme?: "light" | "dark",
+  deck?: boolean,
 ): string {
   let src = stripHtmlFence(html);
   // Drop anything after the document's closing </html> — a self-contained
@@ -298,7 +349,7 @@ export function composeSrcDoc(
   if (lastClose?.index !== undefined) {
     src = src.slice(0, lastClose.index + lastClose[0].length);
   }
-  const head = sandboxHead(src, chartLibSource, hideScrollbar, theme);
+  const head = sandboxHead(src, chartLibSource, hideScrollbar, theme, deck);
 
   const headOpen = src.match(/<head[^>]*>/i);
   if (headOpen?.index !== undefined) {

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -196,13 +196,17 @@ export function usesViewportUnits(html: string): boolean {
  * `<style>` overrides the baseline.
  */
 // Slide-deck runtime — injected ONLY for `deck` documents. Each `<section
-// class="slide">` becomes a 16:9-ish full-viewport slide; one shows at a time,
-// navigated with ←/→/space/click. A slide that overflows scrolls inside itself
-// (graceful) rather than clipping. Reuses BASE_STYLE typography + components
-// (charts/cards/mermaid all work per slide), so a deck is as rich as an article.
+// class="slide">` becomes a full-viewport slide (the iframe's shape, not forced
+// 16:9); one shows at a time, navigated with the ←/→/space keys or the on-screen
+// ‹/› arrows. A slide that overflows scrolls inside itself (graceful) rather than
+// clipping — `safe` keeps the top reachable when content exceeds the slide.
+// Source `<a href="slug.md">` links inherit the head's `<base target="_blank">`,
+// so they open in a new tab instead of navigating the sandboxed deck — intended.
+// Reuses BASE_STYLE typography + components (charts/cards/mermaid all work per
+// slide), so a deck is as rich as an article.
 const DECK_STYLE = `<style>
 html,body{height:100%;margin:0;overflow:hidden}
-.slide{position:absolute;inset:0;display:none;flex-direction:column;justify-content:center;gap:.35em;padding:clamp(28px,4.5vh,56px) clamp(40px,6vw,84px);box-sizing:border-box;overflow:auto}
+.slide{position:absolute;inset:0;display:none;flex-direction:column;justify-content:safe center;gap:.35em;padding:clamp(28px,4.5vh,56px) clamp(40px,6vw,84px);box-sizing:border-box;overflow:auto}
 .slide.active{display:flex}
 .slide>*{max-width:100%;margin-top:.25em;margin-bottom:.25em}
 .slide h1{font-size:clamp(2rem,5.2vw,3.4rem);margin:.1em 0;border:0;padding:0}
@@ -314,6 +318,16 @@ export function stripHtmlFence(html: string): string {
   if (!lead) return out;
   const body = out.slice(lead[0].length).replace(/\r?\n```[ \t]*$/i, "");
   return body.trim();
+}
+
+/**
+ * True when a body is a self-contained HTML slide DECK — it has at least one
+ * `<section class="slide">`. Distinguishes a new HTML deck from a legacy Marp
+ * markdown deck (no such section) AND from a plain html artifact (also no slide
+ * section), so callers can pick the deck renderer / pass `deck` to composeSrcDoc.
+ */
+export function isHtmlDeck(body: string): boolean {
+  return /<section[^>]*class=["'][^"']*\bslide\b/i.test(body ?? "");
 }
 
 /**

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -73,21 +73,26 @@ export const TABLE_FORMAT_INSTRUCTION =
   "Format your answer as a markdown comparison table where possible. Include a short prose lead-in (1-2 sentences) before the table. Every column header should be meaningful. Cite sources as [Page Title](slug.md) in a final 'Sources' row or paragraph.";
 
 /**
- * Extra system-prompt instruction appended when the caller requests a
- * Marp slide deck answer format.
+ * Extra system-prompt instruction appended when the caller requests a slide-deck
+ * answer — a self-contained HTML deck rendered full-screen with slide navigation.
  */
-export const SLIDES_FORMAT_INSTRUCTION = `Format your answer as a Marp slide deck. Use \`---\` to separate slides.
-The first slide should be a title slide with \`# {question}\`.
-Each subsequent slide should cover one key point with a heading and 2-4 bullet points.
-Keep slides concise — aim for 5-8 slides total.
-When a point is structural — a flow, process, architecture, hierarchy, sequence, or relationship — prefer a **Mermaid diagram** over a wall of bullets. Put it in a fenced \`\`\`mermaid code block (e.g. \`graph TD\`, \`flowchart LR\`, \`sequenceDiagram\`); it renders as a diagram. Keep node labels short.
-Include **exactly one** hand-drawn **yoyo illustration** in the deck — on the single slide where a metaphor, a key judgment, a before/after, or a change-of-state lands better as a picture than text (often the title slide or the core-insight slide). Add it with a fenced \`\`\`yoyo-illustration block whose body is a short SCENE: what the yoyo octopus is doing with its tentacles to express that idea, plus 2-4 short labels. Use it for feeling/metaphor (not data, not structure) — keep it to one, never more than two.
-Include a final "Sources" slide citing wiki pages as [Page Title](slug.md).
-Use standard Marp markdown (no custom directives needed).
-Start the response with the Marp front matter:
----
-marp: true
----`;
+export const SLIDES_FORMAT_INSTRUCTION = `Format your answer as a SELF-CONTAINED HTML SLIDE DECK — visually rich, like a beautiful presentation a reader would want to share.
+
+OUTPUT
+- Output ONLY HTML: start with \`<!doctype html>\` and a full \`<html>\`/\`<head>\`/\`<body>\`. No markdown, no \`\`\`html fence, no prose before/after.
+- Each slide is ONE \`<section class="slide">…</section>\` element. A navigable deck runtime (one slide at a time, ←/→ keys, a slide counter and progress bar) is ALREADY injected — do NOT add your own slide/navigation script or CSS for it.
+- A polished baseline stylesheet AND the Chart.js library are ALREADY injected. Do NOT add any \`<link>\`, \`<script src>\`, CDN URL, or web font. You MAY add inline \`<style>\`.
+
+SLIDES — aim for 5-8 total, ONE idea per slide
+- First slide: a title — \`<h1>\` + a \`<p class="lead">\` one-line framing.
+- Each content slide: a short \`<h2>\` heading and ONE focused visual or a few bullets. Keep it light — a slide is fixed-size, so 3-5 short bullets or one component, NOT a wall of text. (Overflow scrolls within the slide, but prefer to fit.)
+- Last slide: "Sources" citing wiki pages as \`<a href="slug.md">Page Title</a>\`.
+
+VISUALS — make slides rich (all components are pre-styled — just use the class names)
+- \`<div class="grid"> <div class="card">…</div> … </div>\` — card grid; \`<div class="stat"><span class="num">87%</span><span class="label">caption</span></div>\` — big-number stats; \`<div class="callout">…</div>\`, \`<span class="badge">tag</span>\`, \`<blockquote>\`, \`<table>\`.
+- CHARTS (data): a Chart.js chart in \`<figure><div class="chart"><canvas id="c1"></canvas></div></figure>\` + an inline \`<script>new Chart(...)</script>\` with \`responsive:true, maintainAspectRatio:false\`. Palette: \`#4d6bfe,#11a36b,#e8893a,#9b59d0,#d24d6b,#3aa6c4\`.
+- DIAGRAMS (structure — flow/architecture/sequence): a Mermaid diagram in \`<pre class="mermaid">graph TD; A--&gt;B</pre>\` (no fence, no script). Keep node labels short.
+- Include **exactly one** hand-drawn **yoyo illustration**, on the single slide where a metaphor/judgment/before-after lands better as a picture. Add an EMPTY figure carrying the scene: \`<figure class="yoyo-illustration" data-scene="A short scene: what the yoyo octopus is doing with its tentacles to express the idea, plus 2-4 short labels"></figure>\` (leave it empty — no \`<img>\`). One only; for feeling/metaphor, not data/structure.`;
 
 /**
  * Extra system-prompt instruction appended when the caller requests an HTML
@@ -360,7 +365,10 @@ export async function saveAnswerToWiki(
     throw new Error("Title must produce a valid slug");
   }
 
-  const isHtml = contentType === "html";
+  // Both `html` and `slides` answers are now HTML bodies (a slides answer is a
+  // self-contained HTML deck) — processed identically. `contentType` still
+  // distinguishes them for the stored `type` (the renderer picks iframe vs deck).
+  const isHtml = contentType === "html" || contentType === "slides";
   // HTML and slides are personal rendered artifacts (owned, typed, kept out of
   // the commons/search corpus); plain markdown is a system-owned commons page.
   const isArtifact = contentType !== "markdown";
@@ -374,9 +382,8 @@ export async function saveAnswerToWiki(
   const content = await bakeYoyoIllustrations(rawContent, isHtml);
 
   // Body, by type:
-  //  - HTML: strip a wrapping ```html fence; store verbatim, no H1 (the title
-  //    shows via ArticleView's <h1> outside the iframe).
-  //  - slides: store the Marp markdown verbatim, no H1 (it renders as a deck).
+  //  - HTML / slides: strip a wrapping ```html fence; store the HTML verbatim, no
+  //    H1 (it renders in the sandboxed iframe — a document, or a deck for slides).
   //  - markdown: prepend an H1 if missing.
   const html = isHtml ? stripHtmlFence(content) : content;
   const needsH1 = !isArtifact && !content.trimStart().startsWith("# ");

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -320,7 +320,9 @@ export async function query(
     // with no per-view fetch. Prose/table carry no directives, so they skip it.
     const answer =
       format === "slides" || format === "html"
-        ? await bakeYoyoIllustrations(raw, format === "html")
+        ? // slides answers are HTML decks now, so bake via the HTML path too —
+          // else the live preview shows an un-baked empty <figure>.
+          await bakeYoyoIllustrations(raw, format === "html" || format === "slides")
         : raw;
 
     // All slugs in the wiki are valid citation targets


### PR DESCRIPTION
`format:"slides"` now produces a **self-contained HTML deck** — as visually rich as our HTML pages (charts, cards, mermaid, yoyo illustrations *per slide*) — instead of plain Marp markdown (which `SlidePreview` rendered as a stacked-markdown carousel).

## How
- **Deck runtime** (`composeSrcDoc(..., deck)`): each `<section class="slide">` is a full-viewport slide shown one at a time, with ←/→/space/click nav, a slide counter + progress bar. An overflowing slide scrolls within itself (graceful). It reuses `BASE_STYLE`, so cards/charts/mermaid/illustrations all work inside slides. **No external resources** (same sandboxed iframe + CSP).
- **`HtmlPreview`** gains a `deck` prop (fixed full-viewport frame + the runtime).
- **`query.ts`**: `SLIDES_FORMAT_INSTRUCTION` rewritten to ask for the HTML deck; a slides answer is now processed as an HTML body (fence-strip, `htmlToPlainText` summary, illustration baking). `type:"slides"` is preserved so the renderer picks the deck.
- **Rendering** (`ArticleView` + `/share`): a slides page renders via `HtmlPreview deck` when the body is HTML; **legacy Marp decks fall back to `SlidePreview`** (content sniff), so existing decks still render.

## Verified
Rendered a composed deck in **headless Chrome at 16:9**: title slide (centered serif + lead), a 2-card-grid content slide, working ←/→ nav, slide counter "n / total", progress bar — no clipping. (Screenshots captured during build.)

## Tests
`composeSrcDoc` deck-mode injection (deck CSS + nav script present, article column skipped, off by default); the slides-save test updated to an HTML deck (verbatim body, data-URI stripped from the summary).

## Note
Marp's easy PDF export is dropped (decks are shareable via `/share` + OG instead). Old Marp slide pages keep rendering via the legacy carousel.

## Gates
`pnpm lint` 0 errors · `vitest` 3341 passed · `pnpm build` + `pnpm build:cloudflare` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)