### PR TITLE
yoyo: vault name as the Browse H1

### DIFF
--- a/src/components/BrowseClient.tsx
+++ b/src/components/BrowseClient.tsx
@@ -320,7 +320,7 @@ export function BrowseClient({
       <section className="shell" style={{ paddingTop: 64 }}>
         <p className="fmark" style={{ marginBottom: 20 }}>
           {activeVault
-            ? `vault · ${activeVault.name}`
+            ? `vault · ${activeVault.visibility}`
             : "the commons · public"}
         </p>
         <div
@@ -336,7 +336,7 @@ export function BrowseClient({
             className="display"
             style={{ fontSize: "clamp(38px,5vw,62px)", margin: 0 }}
           >
-            Browse the commons
+            {activeVault ? activeVault.name : "Browse the commons"}
           </h1>
           <p
             className="receipt"


### PR DESCRIPTION
On a vault lens the page header still read **Browse the commons** as the large H1, and the vault's name only showed in the tiny mono eyebrow (`VAULT · EXPLAIN LIKE I'M FIVE`) — too small.

## Change
- **H1** now shows the vault name when a vault lens is active (`activeVault.name`), else `Browse the commons` for the commons.
- **Eyebrow** reduced to `vault · <visibility>` (e.g. `vault · public`) so the name isn't duplicated in the small label.
- Commons view unchanged.

## Verification
`pnpm lint` 0 errors · `pnpm build` clean · `pnpm build:cloudflare` clean · vitest unaffected (no test pins the static title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)