### PR TITLE
yoyo: fix slide decks — real yoyo illustration + robust deck layout

### DIFF
--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -195,12 +195,40 @@ describe("composeSrcDoc", () => {
       undefined,
       true,
     );
-    expect(out).toContain(".slide.active{display:flex}"); // deck CSS
+    expect(out).toContain(".slide.active{display:flex!important}"); // deck CSS
     expect(out).toContain("ArrowRight"); // deck nav script
     expect(out).not.toContain("body{max-width:var(--measure)}"); // no article column
     // Non-deck doc gets neither the deck runtime.
     const plain = composeSrcDoc("<p>x</p>");
     expect(plain).not.toContain(".slide.active");
+  });
+
+  it("deck layout uses !important so a model's own .slide CSS can't stack slides", () => {
+    // A model that redefines `.slide{display:flex}` would otherwise win at equal
+    // specificity (its <style> is injected after ours), showing every slide at once.
+    const out = composeSrcDoc(
+      '<head><style>.slide{display:flex;min-height:80vh}</style></head>' +
+        '<section class="slide"><h1>A</h1></section>',
+      undefined,
+      false,
+      undefined,
+      true,
+    );
+    expect(out).toContain("display:none!important");
+    expect(out).toContain("position:absolute!important");
+    expect(out).toContain("inset:0!important");
+  });
+
+  it("neutralizes model-authored ::before/::after art on the yoyo figure", () => {
+    // The yoyo illustration is a baked <img>; some models layer emoji/CSS art via
+    // pseudo-elements. The baseline kills those (with !important) on both decks and
+    // articles, so only the real generated image shows.
+    for (const deck of [true, false]) {
+      const out = composeSrcDoc("<p>x</p>", undefined, false, undefined, deck);
+      expect(out).toContain(
+        "figure.yoyo-illustration::before,figure.yoyo-illustration::after{content:none!important",
+      );
+    }
   });
 
   it("forces the resolved app theme (overrides the OS prefers-color-scheme default)", () => {

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -206,17 +206,28 @@ describe("composeSrcDoc", () => {
   it("deck layout uses !important so a model's own .slide CSS can't stack slides", () => {
     // A model that redefines `.slide{display:flex}` would otherwise win at equal
     // specificity (its <style> is injected after ours), showing every slide at once.
+    const modelSlide = ".slide{display:flex;min-height:80vh}";
     const out = composeSrcDoc(
-      '<head><style>.slide{display:flex;min-height:80vh}</style></head>' +
+      `<head><style>${modelSlide}</style></head>` +
         '<section class="slide"><h1>A</h1></section>',
       undefined,
       false,
       undefined,
       true,
     );
-    expect(out).toContain("display:none!important");
-    expect(out).toContain("position:absolute!important");
-    expect(out).toContain("inset:0!important");
+    // The make-or-break props are !important ON the .slide selector itself
+    // (not just present somewhere — `display:none!important` also appears on the
+    // yoyo ::before/::after rule).
+    expect(out).toMatch(
+      /\.slide\{position:absolute!important;inset:0!important;display:none!important;/,
+    );
+    expect(out).toContain(".slide.active{display:flex!important}");
+    // The whole premise: our baseline .slide rule must precede the model's, so
+    // !important (not source order) is what wins. Assert the source ordering the
+    // fix depends on.
+    expect(out.indexOf(".slide{position:absolute!important")).toBeLessThan(
+      out.indexOf(modelSlide),
+    );
   });
 
   it("neutralizes model-authored ::before/::after art on the yoyo figure", () => {

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -109,6 +109,11 @@ tr:hover td{background:var(--paper-2)}
 .stat .label{font-size:.8rem;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)}
 .badge{display:inline-block;font-size:.78rem;font-weight:600;padding:2px 9px;border-radius:999px;background:var(--accent-soft);color:var(--accent);border:1px solid var(--rule)}
 figure{margin:1.6em 0}figure.yoyo-illustration{max-width:var(--measure);margin-left:auto;margin-right:auto;text-align:center}figure>figcaption{font-size:.85rem;color:var(--muted);margin-top:.5em;text-align:center}
+/* The yoyo illustration is a BAKED img (generated server-side); the class is
+   ours. Some models try to "draw" it themselves with emoji + CSS gradient
+   pseudo-elements layered on the figure — kill those so only the real image
+   shows. The important flag beats the model's own style, injected after this. */
+figure.yoyo-illustration::before,figure.yoyo-illustration::after{content:none!important;display:none!important}
 .chart{position:relative;height:340px}
 details{border:1px solid var(--rule);border-radius:var(--radius);padding:0 16px;margin:1em 0;background:var(--paper-2)}
 details[open]{padding-bottom:8px}
@@ -206,8 +211,12 @@ export function usesViewportUnits(html: string): boolean {
 // slide), so a deck is as rich as an article.
 const DECK_STYLE = `<style>
 html,body{height:100%;margin:0;overflow:hidden}
-.slide{position:absolute;inset:0;display:none;flex-direction:column;justify-content:safe center;gap:.35em;padding:clamp(28px,4.5vh,56px) clamp(40px,6vw,84px);box-sizing:border-box;overflow:auto}
-.slide.active{display:flex}
+/* The important flag on the make-or-break layout props (full-viewport, one at a
+   time) so the deck still works if the model emits its own .slide rule — its
+   style is injected after this one and would otherwise win at equal
+   specificity, stacking every slide on top of each other. */
+.slide{position:absolute!important;inset:0!important;display:none!important;flex-direction:column;justify-content:safe center;gap:.35em;padding:clamp(28px,4.5vh,56px) clamp(40px,6vw,84px);box-sizing:border-box;overflow:auto}
+.slide.active{display:flex!important}
 .slide>*{max-width:100%;margin-top:.25em;margin-bottom:.25em}
 .slide h1{font-size:clamp(2rem,5.2vw,3.4rem);margin:.1em 0;border:0;padding:0}
 .slide h2{font-size:clamp(1.4rem,3.4vw,2.1rem);margin:.1em 0;border:0;padding:0}

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -80,8 +80,8 @@ export const SLIDES_FORMAT_INSTRUCTION = `Format your answer as a SELF-CONTAINED
 
 OUTPUT
 - Output ONLY HTML: start with \`<!doctype html>\` and a full \`<html>\`/\`<head>\`/\`<body>\`. No markdown, no \`\`\`html fence, no prose before/after.
-- Each slide is ONE \`<section class="slide">…</section>\` element. A navigable deck runtime (one slide at a time, ←/→ keys, a slide counter and progress bar) is ALREADY injected — do NOT add your own slide/navigation script or CSS for it.
-- A polished baseline stylesheet AND the Chart.js library are ALREADY injected. Do NOT add any \`<link>\`, \`<script src>\`, CDN URL, or web font. You MAY add inline \`<style>\`.
+- Each slide is ONE \`<section class="slide">…</section>\` element. A navigable deck runtime (one slide at a time, full-viewport, ←/→ keys, a slide counter and progress bar) is ALREADY injected — do NOT add your own slide/navigation script, and do NOT write any CSS that targets \`.slide\` or sizes \`html\`/\`body\` (the runtime owns slide layout; redefining \`.slide\` breaks the deck so every slide stacks at once).
+- A polished baseline stylesheet AND the Chart.js library are ALREADY injected. Do NOT add any \`<link>\`, \`<script src>\`, CDN URL, or web font. You MAY add a small inline \`<style>\` for per-element accents only (NOT slide layout).
 
 SLIDES — aim for 5-8 total, ONE idea per slide
 - First slide: a title — \`<h1>\` + a \`<p class="lead">\` one-line framing.
@@ -92,7 +92,7 @@ VISUALS — make slides rich (all components are pre-styled — just use the cla
 - \`<div class="grid"> <div class="card">…</div> … </div>\` — card grid; \`<div class="stat"><span class="num">87%</span><span class="label">caption</span></div>\` — big-number stats; \`<div class="callout">…</div>\`, \`<span class="badge">tag</span>\`, \`<blockquote>\`, \`<table>\`.
 - CHARTS (data): a Chart.js chart in \`<figure><div class="chart"><canvas id="c1"></canvas></div></figure>\` + an inline \`<script>new Chart(...)</script>\` with \`responsive:true, maintainAspectRatio:false\`. Palette: \`#4d6bfe,#11a36b,#e8893a,#9b59d0,#d24d6b,#3aa6c4\`.
 - DIAGRAMS (structure — flow/architecture/sequence): a Mermaid diagram in \`<pre class="mermaid">graph TD; A--&gt;B</pre>\` (no fence, no script). Keep node labels short.
-- Include **exactly one** hand-drawn **yoyo illustration**, on the single slide where a metaphor/judgment/before-after lands better as a picture. Add an EMPTY figure carrying the scene: \`<figure class="yoyo-illustration" data-scene="A short scene: what the yoyo octopus is doing with its tentacles to express the idea, plus 2-4 short labels"></figure>\` (leave it empty — no \`<img>\`). One only; for feeling/metaphor, not data/structure.`;
+- Include **exactly one** hand-drawn **yoyo illustration**, on the single slide where a metaphor/judgment/before-after lands better as a picture. Request it EXACTLY as on an HTML article page: an EMPTY figure carrying the scene — \`<figure class="yoyo-illustration" data-scene="A short scene: what the yoyo octopus is doing with its tentacles to express the idea, plus 2-4 short labels"></figure>\` — which is replaced by a generated image automatically. Leave it empty: NO \`<img>\`, and NEVER draw the illustration yourself with emoji, CSS gradients, or \`::before\`/\`::after\` art. One only; for feeling/metaphor, not data/structure.`;
 
 /**
  * Extra system-prompt instruction appended when the caller requests an HTML


### PR DESCRIPTION
The slides you generated showed two bugs (screenshot): all 8 slides stacked at once, and a hand-drawn octopus emoji blob floating over the "Sources" text instead of the real baked yoyo image.

**Root cause:** both came from the model emitting its own `<style>`, which `composeSrcDoc` injects *after* the deck runtime — so it won at equal CSS specificity.

## Fixes
1. **Deck layout immune to model CSS** — `!important` on the make-or-break props (`position`/`inset`/`display`) in `DECK_STYLE`, so the one-slide-at-a-time runtime wins even if the model redefines `.slide`. (Was: a model `.slide{display:flex}` stacked every slide.)
2. **Real yoyo, not fake art** — the baseline now kills `::before`/`::after` on `figure.yoyo-illustration` (with `!important`), on both decks and articles. The branded figure is a baked `<img>`; the model can no longer layer emoji/gradient art over it. Slides now use the yoyo **exactly like an HTML article page**.
3. **Prompt hardening** — the slides instruction forbids `.slide`/`html`/`body` layout CSS and hand-drawn (emoji / gradient / pseudo-element) illustrations; the only illustration is the empty `<figure data-scene>` that auto-generates an image.

## Verification
Headless (sandboxed iframe, the real `HtmlPreview` path) on a deliberately-rogue model deck (own `.slide` CSS + fake `::after` octopus):
- 1 slide visible on load **and** after ArrowRight (not stacked)
- counter advances `1 / 3` → `2 / 3`
- the fake `::after` octopus resolves to `content: none`

Gates: lint 0 errors · vitest 3349 passed (incl. 2 new robustness tests) · `pnpm build` + `pnpm build:cloudflare` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)