### PR TITLE
yoyo: landscape (16:10) frame for inline slide decks

### DIFF
--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -140,7 +140,9 @@ export function HtmlPreview({
       // viewport (100vh) define their own scroll viewport — auto-sizing
       // feedback-loops them to absurd heights — so we fix the frame and let
       // them scroll INSIDE it, with that inner scrollbar hidden. Full-screen
-      // share (`bare`) fills the viewport; inline gets a tall contained frame.
+      // share (`bare`) fills the viewport. An inline DECK gets a landscape,
+      // slide-shaped frame (aspect-ratio, capped to the viewport) instead of a
+      // flat tall box; other inline app-style docs get a tall contained frame.
       srcDoc={composeSrcDoc(renderedHtml, chartLib, bare || appStyle, theme, deck)}
       sandbox={HTML_SANDBOX}
       title="HTML output"
@@ -148,9 +150,14 @@ export function HtmlPreview({
         width: "100%",
         height: bare
           ? "calc(100dvh - 56px)"
-          : appStyle
-            ? "80vh"
-            : height,
+          : deck
+            ? undefined // height comes from aspectRatio below
+            : appStyle
+              ? "80vh"
+              : height,
+        // Inline deck: a 16:10 slide shape, but never taller than the viewport.
+        aspectRatio: !bare && deck ? "16 / 10" : undefined,
+        maxHeight: !bare && deck ? "78vh" : undefined,
         border: bare ? "none" : "1px solid var(--rule)",
         borderRadius: bare ? 0 : 10,
         background: "var(--paper)",

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -33,7 +33,8 @@ export function HtmlPreview({
    *  share header. The auto-height still drives growth; this only restyles. */
   bare?: boolean;
   /** Render as a slide deck: inject the deck runtime (one `<section class="slide">`
-   *  at a time, ←/→ nav) and use a fixed full-viewport frame like an app-style doc. */
+   *  at a time, ←/→ nav). Inline, the frame is a landscape 16:10 slide capped to
+   *  the viewport; the full-screen (`bare`) share view fills the viewport instead. */
   deck?: boolean;
 }) {
   const ref = useRef<HTMLIFrameElement>(null);


### PR DESCRIPTION
Follow-up to #753. The deck now navigates correctly, but the **inline preview frame was a tall portrait box** (flat `height: 80vh`) — on a tall window the slide content floated in the vertical middle with big empty margins, instead of looking like a slide.

## Change
`HtmlPreview` inline deck frame: `aspect-ratio: 16 / 10` + `width: 100%`, capped at `max-height: 78vh` (never taller than the viewport). So an inline deck is landscape/slide-shaped.

- Non-deck app-style docs (100vh artifacts) keep their `80vh` frame.
- The full-screen `bare` share view still fills the viewport.

## Verification
Headless (sandboxed iframe, the real inline-deck style) on a tall 1400×1700 window: iframe box **1302×815, ratio 1.60** — landscape, capped to the viewport, instead of the previous portrait box.

Gates: lint 0 errors · `pnpm build` + `pnpm build:cloudflare` clean. (Pure presentational JSX — no unit test; verified via headless screenshot.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)