### PR TITLE
yoyo: robust landscape frame for inline decks (aspect-ratio wrapper)

### DIFF
--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -133,7 +133,15 @@ export function HtmlPreview({
     return () => window.removeEventListener("message", onMessage);
   }, []);
 
-  return (
+  // An inline deck is framed as a landscape slide. We put the aspect-ratio on a
+  // wrapper <div> and let the iframe fill it absolutely, rather than on the
+  // iframe itself: `aspect-ratio` on a replaced element (iframe) is unreliable
+  // (its intrinsic 300x150 size interferes), so a deck would otherwise fall back
+  // to a tall/odd box. The bare (full-screen share) deck keeps its own viewport
+  // sizing and is NOT wrapped.
+  const inlineDeck = !bare && deck;
+
+  const iframe = (
     <iframe
       ref={ref}
       // Document-style artifacts auto-size to content (the page scrolls, no
@@ -141,29 +149,43 @@ export function HtmlPreview({
       // viewport (100vh) define their own scroll viewport — auto-sizing
       // feedback-loops them to absurd heights — so we fix the frame and let
       // them scroll INSIDE it, with that inner scrollbar hidden. Full-screen
-      // share (`bare`) fills the viewport. An inline DECK gets a landscape,
-      // slide-shaped frame (aspect-ratio, capped to the viewport) instead of a
-      // flat tall box; other inline app-style docs get a tall contained frame.
+      // share (`bare`) fills the viewport. An inline deck fills its slide-shaped
+      // wrapper (below). Other inline app-style docs get a tall contained frame.
       srcDoc={composeSrcDoc(renderedHtml, chartLib, bare || appStyle, theme, deck)}
       sandbox={HTML_SANDBOX}
       title="HTML output"
       style={{
         width: "100%",
-        height: bare
-          ? "calc(100dvh - 56px)"
-          : deck
-            ? undefined // height comes from aspectRatio below
+        height: inlineDeck
+          ? "100%" // fills the aspect-ratio wrapper
+          : bare
+            ? "calc(100dvh - 56px)"
             : appStyle
               ? "80vh"
               : height,
-        // Inline deck: a 16:10 slide shape, but never taller than the viewport.
-        aspectRatio: !bare && deck ? "16 / 10" : undefined,
-        maxHeight: !bare && deck ? "78vh" : undefined,
+        position: inlineDeck ? "absolute" : undefined,
+        inset: inlineDeck ? 0 : undefined,
         border: bare ? "none" : "1px solid var(--rule)",
         borderRadius: bare ? 0 : 10,
         background: "var(--paper)",
         display: "block",
       }}
     />
+  );
+
+  if (!inlineDeck) return iframe;
+
+  // Inline deck: a 16:10 slide shape, capped so it's never taller than the viewport.
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        aspectRatio: "16 / 10",
+        maxHeight: "78vh",
+      }}
+    >
+      {iframe}
+    </div>
   );
 }


### PR DESCRIPTION
Follow-up to #755 — the inline deck was **still rendering as a tall box**.

## Why #755 wasn't enough
#755 set `aspect-ratio: 16/10` directly on the deck `<iframe>`. But `aspect-ratio` on a **replaced element** (an iframe has an intrinsic 300×150 size) is unreliable — the browser doesn't consistently compute a width-driven height, so the frame fell back to a tall/odd box.

## Fix
Move the aspect-ratio to a **wrapper `<div>`** (a normal block element, where `aspect-ratio` + `max-height` are deterministic) and let the iframe fill it absolutely (`position:absolute; inset:0; height:100%`). 

- Inline deck only; the `bare` full-screen share view is untouched.
- Other inline app-style docs keep their `80vh` frame; document-style still auto-sizes.

## Verification
Headless (the real wrapper + absolute-iframe markup) on a tall 1500×1960 window: wrapper **1400×875** (ratio 1.60, under the 78vh cap), iframe fills it exactly — a proper landscape slide instead of the portrait box.

Gates: lint 0 errors · `pnpm build` + `pnpm build:cloudflare` clean.

Note: if the earlier box persisted after #755 deployed, a stale client bundle may have contributed — but this wrapper fix is the durable correction regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)