### PR TITLE
docs(agent-api): canonical base URL (yopedia.yolog.dev)

### DIFF
--- a/public/agent-api.md
+++ b/public/agent-api.md
@@ -9,7 +9,7 @@ a **token** for it, and an external runtime uses that token to **ingest content
 into the agent's knowledge**. Reading is open to everyone, so the same runtime
 can **consume** the agent's knowledge over the public API too.
 
-> Base URL in these examples: `https://yopedia.yuanhao-li.workers.dev`
+> Base URL in these examples: `https://yopedia.yolog.dev`
 
 ---
 


### PR DESCRIPTION
The `/agent-api` guide's example base URL still pointed at the raw Workers domain (`yopedia.yuanhao-li.workers.dev`). Point it at the canonical custom domain `yopedia.yolog.dev`.

One-line change in `public/agent-api.md` (static asset, no code path). All documented endpoints/auth/types verified current against the code; this was the only stale detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)