### PR TITLE
yoyo: show agent token status after reload (rotate/revoke discoverable)

### DIFF
--- a/src/app/api/agents/[id]/token/route.ts
+++ b/src/app/api/agents/[id]/token/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import {
   generateAgentToken,
   revokeAgentToken,
+  agentTokenInfo,
   assertCanMutateAgent,
   AgentOwnershipError,
 } from "@/lib/agents";
@@ -10,6 +11,38 @@ import { logger } from "@/lib/logger";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/agents/[id]/token — report whether a credential is currently set
+ * (and when it was created), so the owner UI can show Rotate/Revoke after a
+ * reload. Owner-gated. NEVER returns the secret — it's shown once at generation.
+ */
+export async function GET(_req: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const principal = await getPrincipal();
+    if (!principal) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    const existing = await assertCanMutateAgent(id, principal.handle);
+    if (!existing) {
+      return NextResponse.json(
+        { error: `Agent "${id}" not found` },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(await agentTokenInfo(id));
+  } catch (err) {
+    if (err instanceof AgentOwnershipError) {
+      return NextResponse.json({ error: err.message }, { status: 403 });
+    }
+    logger.error("agents", "token info read failed:", err);
+    return NextResponse.json(
+      { error: "Failed to read token status." },
+      { status: 500 },
+    );
+  }
 }
 
 /**

--- a/src/components/AgentTokenPanel.tsx
+++ b/src/components/AgentTokenPanel.tsx
@@ -1,18 +1,51 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 /**
  * Owner-only panel to manage an agent's credential (per-agent token). The token
  * is shown **once** when generated/rotated — only its hash is stored server-side
  * — so the owner copies it then into an external runtime (e.g. openclaw) to
  * ingest as the agent. Lost it? Rotate for a new one.
+ *
+ * The secret is unrecoverable, but on mount we fetch whether a token EXISTS (and
+ * when it was created) so that after a reload the panel still shows the active
+ * credential with Rotate/Revoke — instead of looking like no token was ever made.
  */
 export function AgentTokenPanel({ agentId }: { agentId: string }) {
   const [token, setToken] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  // Server-known credential state (survives reload; never includes the secret).
+  const [exists, setExists] = useState(false);
+  const [createdAt, setCreatedAt] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/agents/${agentId}/token`);
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          exists?: boolean;
+          createdAt?: string;
+        };
+        if (!cancelled) {
+          setExists(Boolean(data.exists));
+          setCreatedAt(data.createdAt ?? null);
+        }
+      } catch {
+        // Status is best-effort — the action buttons still work without it.
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId]);
 
   async function call(method: "POST" | "DELETE") {
     setBusy(true);
@@ -27,8 +60,12 @@ export function AgentTokenPanel({ agentId }: { agentId: string }) {
         const data = (await res.json()) as { token: string };
         setToken(data.token);
         setCopied(false);
+        setExists(true);
+        setCreatedAt(new Date().toISOString());
       } else {
         setToken(null);
+        setExists(false);
+        setCreatedAt(null);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
@@ -60,6 +97,29 @@ export function AgentTokenPanel({ agentId }: { agentId: string }) {
         </a>
       </p>
 
+      {/* Credential status — survives reload. Hidden while a freshly generated
+          token is on screen (that block already says it all). */}
+      {loaded && !token && (
+        <p className="mt-3 text-sm">
+          {exists ? (
+            <span className="text-foreground/70">
+              <span className="text-green-600 dark:text-green-400">●</span>{" "}
+              Active token
+              {createdAt
+                ? ` · created ${new Date(createdAt).toLocaleDateString()}`
+                : ""}{" "}
+              <span className="text-foreground/50">
+                — the secret is shown only once; rotate if you&rsquo;ve lost it.
+              </span>
+            </span>
+          ) : (
+            <span className="text-foreground/50">
+              No token yet — generate one to connect an external runtime.
+            </span>
+          )}
+        </p>
+      )}
+
       {token && (
         <div className="mt-3 flex flex-wrap items-center gap-2">
           <code className="break-all rounded bg-foreground/5 px-2 py-1 text-xs">
@@ -82,12 +142,12 @@ export function AgentTokenPanel({ agentId }: { agentId: string }) {
           disabled={busy}
           className="rounded-md border border-foreground/20 px-3 py-1.5 text-sm font-medium hover:bg-foreground/5 disabled:opacity-50"
         >
-          {token ? "Rotate token" : "Generate token"}
+          {exists ? "Rotate token" : "Generate token"}
         </button>
         <button
           type="button"
           onClick={() => call("DELETE")}
-          disabled={busy}
+          disabled={busy || !exists}
           className="rounded-md border border-foreground/20 px-3 py-1.5 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:hover:bg-red-900/20"
         >
           Revoke

--- a/src/components/AgentTokenPanel.tsx
+++ b/src/components/AgentTokenPanel.tsx
@@ -21,13 +21,21 @@ export function AgentTokenPanel({ agentId }: { agentId: string }) {
   const [exists, setExists] = useState(false);
   const [createdAt, setCreatedAt] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
+  // The status fetch FAILED (couldn't determine existence). Tracked separately
+  // from `exists`: we must NOT fall back to "No token yet"/"Generate" on an
+  // unknown status, or the owner could click Generate and silently rotate away a
+  // live token. Unknown ≠ none.
+  const [statusError, setStatusError] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
         const res = await fetch(`/api/agents/${agentId}/token`);
-        if (!res.ok) return;
+        if (!res.ok) {
+          if (!cancelled) setStatusError(true);
+          return;
+        }
         const data = (await res.json()) as {
           exists?: boolean;
           createdAt?: string;
@@ -37,7 +45,9 @@ export function AgentTokenPanel({ agentId }: { agentId: string }) {
           setCreatedAt(data.createdAt ?? null);
         }
       } catch {
-        // Status is best-effort — the action buttons still work without it.
+        // Network/parse failure → status unknown (not "none"); warn rather than
+        // present Generate as the safe default.
+        if (!cancelled) setStatusError(true);
       } finally {
         if (!cancelled) setLoaded(true);
       }
@@ -56,6 +66,7 @@ export function AgentTokenPanel({ agentId }: { agentId: string }) {
         const body = (await res.json().catch(() => ({}))) as { error?: string };
         throw new Error(body.error ?? `request failed (${res.status})`);
       }
+      setStatusError(false); // the action gives us authoritative state again
       if (method === "POST") {
         const data = (await res.json()) as { token: string };
         setToken(data.token);
@@ -98,10 +109,17 @@ export function AgentTokenPanel({ agentId }: { agentId: string }) {
       </p>
 
       {/* Credential status — survives reload. Hidden while a freshly generated
-          token is on screen (that block already says it all). */}
+          token is on screen (that block already says it all). On an unknown
+          status (fetch failed) we warn rather than claim "no token", so the
+          owner isn't lured into Generate (which would rotate a live token). */}
       {loaded && !token && (
         <p className="mt-3 text-sm">
-          {exists ? (
+          {statusError ? (
+            <span className="text-amber-600 dark:text-amber-400">
+              Couldn&rsquo;t check token status — reload before generating, so you
+              don&rsquo;t rotate an active token by mistake.
+            </span>
+          ) : exists ? (
             <span className="text-foreground/70">
               <span className="text-green-600 dark:text-green-400">●</span>{" "}
               Active token
@@ -142,7 +160,11 @@ export function AgentTokenPanel({ agentId }: { agentId: string }) {
           disabled={busy}
           className="rounded-md border border-foreground/20 px-3 py-1.5 text-sm font-medium hover:bg-foreground/5 disabled:opacity-50"
         >
-          {exists ? "Rotate token" : "Generate token"}
+          {statusError
+            ? "Generate / rotate token"
+            : exists
+              ? "Rotate token"
+              : "Generate token"}
         </button>
         <button
           type="button"

--- a/src/lib/__tests__/agent-token-route.test.ts
+++ b/src/lib/__tests__/agent-token-route.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/agents", () => {
   return {
     generateAgentToken: vi.fn(),
     revokeAgentToken: vi.fn(),
+    agentTokenInfo: vi.fn(),
     assertCanMutateAgent: vi.fn(),
     AgentOwnershipError,
   };
@@ -22,15 +23,17 @@ vi.mock("@/lib/auth", () => ({
 import {
   generateAgentToken,
   revokeAgentToken,
+  agentTokenInfo,
   assertCanMutateAgent,
   AgentOwnershipError,
 } from "@/lib/agents";
 import { getPrincipal } from "@/lib/auth";
-import { POST, DELETE } from "@/app/api/agents/[id]/token/route";
+import { GET, POST, DELETE } from "@/app/api/agents/[id]/token/route";
 import type { AgentProfile } from "@/lib/types";
 
 const mockedGen = vi.mocked(generateAgentToken);
 const mockedRevoke = vi.mocked(revokeAgentToken);
+const mockedInfo = vi.mocked(agentTokenInfo);
 const mockedAssert = vi.mocked(assertCanMutateAgent);
 const mockedGetPrincipal = vi.mocked(getPrincipal);
 
@@ -43,6 +46,31 @@ beforeEach(() => {
   mockedAssert.mockResolvedValue(ownedAgent);
   mockedGen.mockResolvedValue("alice--yoyo.secret123");
   mockedRevoke.mockResolvedValue();
+  mockedInfo.mockResolvedValue({ exists: true, createdAt: "2026-06-27T00:00:00.000Z" });
+});
+
+describe("GET /api/agents/[id]/token", () => {
+  it("returns token status to the owner (never the secret)", async () => {
+    const res = await GET(new Request("http://localhost"), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ exists: true, createdAt: "2026-06-27T00:00:00.000Z" });
+    expect(mockedInfo).toHaveBeenCalledWith("alice--yoyo");
+  });
+
+  it("401 when signed out", async () => {
+    mockedGetPrincipal.mockResolvedValue(null);
+    const res = await GET(new Request("http://localhost"), { params });
+    expect(res.status).toBe(401);
+    expect(mockedInfo).not.toHaveBeenCalled();
+  });
+
+  it("403 when not the owner", async () => {
+    mockedAssert.mockRejectedValue(new AgentOwnershipError("not owner"));
+    const res = await GET(new Request("http://localhost"), { params });
+    expect(res.status).toBe(403);
+    expect(mockedInfo).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST /api/agents/[id]/token", () => {

--- a/src/lib/__tests__/agent-token-route.test.ts
+++ b/src/lib/__tests__/agent-token-route.test.ts
@@ -71,6 +71,13 @@ describe("GET /api/agents/[id]/token", () => {
     expect(res.status).toBe(403);
     expect(mockedInfo).not.toHaveBeenCalled();
   });
+
+  it("404 when the agent doesn't exist", async () => {
+    mockedAssert.mockResolvedValue(null);
+    const res = await GET(new Request("http://localhost"), { params });
+    expect(res.status).toBe(404);
+    expect(mockedInfo).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST /api/agents/[id]/token", () => {

--- a/src/lib/__tests__/agents.test.ts
+++ b/src/lib/__tests__/agents.test.ts
@@ -22,6 +22,7 @@ import {
   generateAgentToken,
   verifyAgentToken,
   revokeAgentToken,
+  agentTokenInfo,
   addAgentLearningPage,
 } from "../agents";
 import type { UpdateAgentPage } from "../agents";
@@ -1369,6 +1370,30 @@ describe("per-agent credentials", () => {
     const token = await generateAgentToken("alice--yoyo");
     await revokeAgentToken("alice--yoyo");
     expect(await verifyAgentToken(token)).toBeNull();
+  });
+
+  it("agentTokenInfo reports existence + createdAt, never the secret", async () => {
+    await seedAgentRecord();
+    // None yet.
+    expect(await agentTokenInfo("alice--yoyo")).toEqual({ exists: false });
+
+    // After generate: exists, with an ISO createdAt, and no secret leaked.
+    const token = await generateAgentToken("alice--yoyo");
+    const info = await agentTokenInfo("alice--yoyo");
+    expect(info.exists).toBe(true);
+    expect(typeof info.createdAt).toBe("string");
+    expect(Number.isNaN(Date.parse(info.createdAt!))).toBe(false);
+    expect(JSON.stringify(info)).not.toContain(token.split(".")[1]);
+    expect(JSON.stringify(info)).not.toContain("tokenHash");
+
+    // After revoke: gone again.
+    await revokeAgentToken("alice--yoyo");
+    expect(await agentTokenInfo("alice--yoyo")).toEqual({ exists: false });
+  });
+
+  it("agentTokenInfo treats a corrupt secret file as existing (rotate fixes it)", async () => {
+    await getStorage().writeFile("agent-secrets/alice--yoyo.json", "not json{{{");
+    expect(await agentTokenInfo("alice--yoyo")).toEqual({ exists: true });
   });
 
   it("deleting an agent revokes its credential and removes the secret file", async () => {

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -240,21 +240,23 @@ export async function agentTokenInfo(
     if (isEnoent(err)) return { exists: false };
     throw err; // a real storage failure is OUR problem — let the caller 500
   }
+  let stored: { tokenHash?: unknown; createdAt?: unknown };
   try {
-    const stored = JSON.parse(raw) as {
-      tokenHash?: unknown;
-      createdAt?: unknown;
-    };
-    if (typeof stored.tokenHash !== "string") return { exists: false };
-    return {
-      exists: true,
-      createdAt:
-        typeof stored.createdAt === "string" ? stored.createdAt : undefined,
-    };
-  } catch {
-    // Corrupt secret file: a credential effectively exists (rotating fixes it).
+    stored = JSON.parse(raw);
+  } catch (err) {
+    // A corrupt secret file is OUR data-integrity problem. A credential is
+    // effectively present (rotating fixes it), so report exists:true — but LOG
+    // it, exactly as verifyAgentToken does for the same file, so the corruption
+    // is observable instead of silently shown as a healthy active token.
+    logger.error("agents", `agentTokenInfo: corrupt secret file for "${id}":`, err);
     return { exists: true };
   }
+  if (typeof stored.tokenHash !== "string") return { exists: false };
+  return {
+    exists: true,
+    createdAt:
+      typeof stored.createdAt === "string" ? stored.createdAt : undefined,
+  };
 }
 
 /**

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -217,10 +217,44 @@ export async function generateAgentToken(id: string): Promise<string> {
   const tokenHash = await sha256Hex(secret);
   await getStorage().writeFile(
     agentSecretPath(id),
-    JSON.stringify({ tokenHash }),
+    JSON.stringify({ tokenHash, createdAt: new Date().toISOString() }),
   );
 
   return `${id}.${secret}`;
+}
+
+/**
+ * Non-secret metadata about an agent's credential: whether one is currently set
+ * and when it was created. NEVER returns the secret or its hash (the secret is
+ * shown once at generation and is unrecoverable). The owner UI uses this so that
+ * after a reload it can show "a token is active" and offer Rotate/Revoke, rather
+ * than looking like no token exists.
+ */
+export async function agentTokenInfo(
+  id: string,
+): Promise<{ exists: boolean; createdAt?: string }> {
+  let raw: string;
+  try {
+    raw = await getStorage().readFile(agentSecretPath(id));
+  } catch (err) {
+    if (isEnoent(err)) return { exists: false };
+    throw err; // a real storage failure is OUR problem — let the caller 500
+  }
+  try {
+    const stored = JSON.parse(raw) as {
+      tokenHash?: unknown;
+      createdAt?: unknown;
+    };
+    if (typeof stored.tokenHash !== "string") return { exists: false };
+    return {
+      exists: true,
+      createdAt:
+        typeof stored.createdAt === "string" ? stored.createdAt : undefined,
+    };
+  } catch {
+    // Corrupt secret file: a credential effectively exists (rotating fixes it).
+    return { exists: true };
+  }
 }
 
 /**


### PR DESCRIPTION
**Bug:** after generating an agent token and reloading, the credential panel showed only "Generate token" with no indication a token already existed — so you couldn't tell there was one to rotate or revoke. (The secret is correctly one-time/unrecoverable, but the panel kept *no* server-known existence state.)

## Fix
- `generateAgentToken` now records `createdAt` next to the hash (still nothing secret on the profile).
- New `agentTokenInfo(id)` → `{ exists, createdAt? }` (never the secret/hash); exposed via a new **owner-gated `GET /api/agents/[id]/token`**.
- `AgentTokenPanel` fetches status on mount and now shows:
  - **● Active token · created \<date\>** (or "No token yet"),
  - button labelled **Rotate** vs **Generate** based on real existence,
  - **Revoke** disabled when there's no token.

Security unchanged: the secret is still shown once and never re-fetchable; the GET returns only existence + creation date, owner-gated identically to POST/DELETE.

## Tests
- `agentTokenInfo`: none → generate (exists + ISO `createdAt`, no secret leaked) → revoke (gone); corrupt-file → treated as existing.
- GET route: owner gets status; 401 signed-out; 403 non-owner.

Gates: lint 0 errors · vitest 3394 passed · `pnpm build` + `pnpm build:cloudflare` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)