### PR TITLE
yoyo: agent ingests go through the queue (async, fire-and-forget)

### DIFF
--- a/public/agent-api.md
+++ b/public/agent-api.md
@@ -45,6 +45,12 @@ short while later, once processing finishes. So fire off your ingests and move
 on; you don't need to wait, and you can send several without holding a connection
 open for each.
 
+The `jobId` is for correlation in your own logs — it identifies this ingest. (The
+job's progress is visible to the **owner** in the web UI; the status endpoint is
+owner-session-gated, so it's not pollable with the agent token. To confirm a
+result programmatically, read it back via the agent profile / `agent:` scope
+once it lands — see §4.)
+
 ```
 POST /api/agents/<agent-id>/ingest
 Authorization: Bearer <token>

--- a/public/agent-api.md
+++ b/public/agent-api.md
@@ -38,6 +38,13 @@ becomes the **agent's own knowledge** (`type: agent-knowledge`): browsable under
 the agent profile and searchable via the `agent:` scope, but kept out of the
 public feed and general search.
 
+**Ingestion is asynchronous.** The request enqueues the work and returns
+immediately with `{ "queued": true, "jobId": "…" }` — it does **not** block on
+the fetch/LLM. The page appears under the agent profile (and any target vault) a
+short while later, once processing finishes. So fire off your ingests and move
+on; you don't need to wait, and you can send several without holding a connection
+open for each.
+
 ```
 POST /api/agents/<agent-id>/ingest
 Authorization: Bearer <token>
@@ -63,12 +70,12 @@ curl -X POST "$BASE/api/agents/alice--yoyo/ingest" \
   -H "Authorization: Bearer $YOYO_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"url":"https://example.com/post"}'
-# → { "slug": "the-ingested-page", "deduped": false }
+# → { "queued": true, "jobId": "f1e2…" }
 ```
 
-Responses: `200` with `{ slug, deduped }`; `401` (missing/invalid token);
-`403` (token is for a different agent); `400` (no url/text); `500` (ingest
-failed — retry).
+Responses: `200` with `{ queued: true, jobId }` (the ingest was accepted and is
+processing); `401` (missing/invalid token); `403` (token is for a different
+agent); `400` (no url/text); `500` (couldn't enqueue — retry).
 
 ---
 

--- a/src/app/api/agents/[id]/ingest/route.ts
+++ b/src/app/api/agents/[id]/ingest/route.ts
@@ -196,7 +196,19 @@ export async function POST(req: Request, { params }: RouteParams) {
           ? body.vaultId.trim()
           : undefined;
       if (!agentRecord) {
-        try { agentRecord = await getAgent(id); } catch { agentRecord = null; }
+        // Same discrimination as the auth paths above: a malformed id → null
+        // (no vault, no owner), but a real storage error must NOT be swallowed —
+        // it would silently misattribute the job's owner (→ agent id, so the
+        // human can't see it in the UI). Surface it as a 500.
+        try {
+          agentRecord = await getAgent(id);
+        } catch (err) {
+          if (err instanceof Error && err.message.includes("Invalid agent ID")) {
+            agentRecord = null;
+          } else {
+            throw err;
+          }
+        }
       }
       const effectiveVault = explicitVault || agentRecord?.defaultVault || undefined;
       if (effectiveVault) {
@@ -255,7 +267,9 @@ export async function POST(req: Request, { params }: RouteParams) {
     }
 
     // Enqueue (Workers) or run inline (off-Workers: local dev / tests). The inline
-    // path mirrors the executor's agent post-steps (learning page + vault filing).
+    // closure re-runs the same agent post-steps the executor does (learning-page
+    // attach + vault filing), with the same fail-soft posture so the two paths
+    // don't diverge.
     const opts: IngestOptions = {
       author,
       owner,
@@ -269,7 +283,10 @@ export async function POST(req: Request, { params }: RouteParams) {
         : url
           ? await ingestUrl(url, opts)
           : await ingest(title || "Untitled", text, { ...opts, sourceUrl });
-      if (learningFor) await addAgentLearningPage(learningFor, result.primarySlug);
+      if (learningFor) {
+        try { await addAgentLearningPage(learningFor, result.primarySlug); }
+        catch (e) { logger.error("agents", `learning-page attach failed for ${learningFor}:`, e); }
+      }
       if (validatedVault) {
         try { await addToVault(validatedVault, result.primarySlug); }
         catch (e) { logger.warn("agents", `vault filing failed for ${validatedVault}:`, e); }

--- a/src/app/api/agents/[id]/ingest/route.ts
+++ b/src/app/api/agents/[id]/ingest/route.ts
@@ -1,7 +1,17 @@
 import { NextResponse } from "next/server";
 import { verifyAgentToken, addAgentLearningPage, getAgent } from "@/lib/agents";
 import { getServicePrincipal } from "@/lib/auth";
-import { ingestUrl, ingest, ingestImage, type IngestOptions } from "@/lib/ingest";
+import {
+  ingestUrl,
+  ingest,
+  ingestImage,
+  deriveTitleFromContent,
+  type IngestOptions,
+} from "@/lib/ingest";
+import { type Task } from "@/lib/tasks";
+import { createIngestJob } from "@/lib/ingest-jobs";
+import { enqueueOrInline } from "@/lib/ingest-async";
+import { stageText } from "@/lib/ingest-staging";
 import { logger } from "@/lib/logger";
 import { addToVault, vaultOwnedBy } from "@/lib/vault";
 
@@ -12,19 +22,16 @@ interface RouteParams {
 /** Page `type` that marks ingested content as the agent's scoped knowledge. */
 const AGENT_KNOWLEDGE_TYPE = "agent-knowledge";
 
+/** Text larger than this is staged to R2 instead of riding in the queue message
+ *  (Cloudflare Queues cap a message at 128 KB). Matches the interactive route. */
+const MAX_INLINE_CONTENT_CHARS = 96000;
+
 /** Pattern matching x.com or twitter.com post URLs. */
 const X_URL_PATTERN = /^https?:\/\/(www\.)?(x\.com|twitter\.com)\//i;
 
-/**
- * Derive `sourceType` from the request inputs.
- * - X/Twitter URLs → "x-mention"
- * - Other URLs → "url"
- * - Text-only (no URL) → "text"
- */
-function deriveSourceType(url: string, _text: string): "x-mention" | "url" | "text" {
-  if (url) {
-    return X_URL_PATTERN.test(url) ? "x-mention" : "url";
-  }
+/** Derive `sourceType`: X/Twitter URL → "x-mention", other URL → "url", else "text". */
+function deriveSourceType(url: string): "x-mention" | "url" | "text" {
+  if (url) return X_URL_PATTERN.test(url) ? "x-mention" : "url";
   return "text";
 }
 
@@ -41,6 +48,12 @@ function deriveSourceType(url: string, _text: string): "x-mention" | "url" | "te
  *     EXIST (404 otherwise), which is how "only ingest for a registered user"
  *     is enforced — a mention from a non-user hits a 404 and is skipped.
  * This route is exempt from the middleware write-gate because it uses a token.
+ *
+ * ASYNC: the ingest is enqueued (Cloudflare Queue) and processed in the
+ * background — the request does NOT block on fetch/LLM. It returns
+ * `{ queued: true, jobId }` immediately (off-Workers it runs inline and also
+ * returns `slug`). The resulting page appears under the agent profile / its vault
+ * once processing finishes; the owner can watch progress in the UI.
  *
  * Body: { url } or { text, title? }, plus an optional `asOwner` flag.
  *   - Default (per-agent token, e.g. openclaw): the page is scoped
@@ -152,72 +165,116 @@ export async function POST(req: Request, { params }: RouteParams) {
       }
     }
 
-    let opts: IngestOptions;
-    if (asOwner) {
-      // Save into the owner's wiki — owned by the human, authored by the agent.
-      const owner = agentRecord!.owner;
-      opts = { author: id, owner, triggeredBy: owner, sourceType: deriveSourceType(url, text) };
-    } else {
-      // Ingest as the agent: scoped type, attributed to the agent.
-      opts = {
-        author: id,
-        owner: id,
-        triggeredBy: id,
-        pageType: AGENT_KNOWLEDGE_TYPE,
-      };
-    }
+    // Attribution: asOwner → the human owner's own page (authored by the agent);
+    // default → agent-scoped knowledge attributed to the agent.
+    const owner = asOwner ? agentRecord!.owner : id;
+    const author = id;
+    const triggeredBy = asOwner ? agentRecord!.owner : id;
+    const pageType: "agent-knowledge" | undefined = asOwner
+      ? undefined
+      : AGENT_KNOWLEDGE_TYPE;
+    const learningFor = asOwner ? undefined : id; // attach to agent learnings
+    // asOwner pages record an explicit sourceType (matches the prior behavior,
+    // incl. x-mention detection); agent-knowledge ingests let the pipeline derive it.
+    const sourceType = asOwner ? deriveSourceType(url) : undefined;
+
     // A caller-provided source URL (e.g. the original X article) is recorded as
-    // the page's provenance so the wiki page links back to it. The `url`/
-    // `imageUrl` paths set their own source, so this only applies to text.
+    // the page's provenance. Only the text path uses it (url/imageUrl carry their
+    // own source).
     const sourceUrl =
       typeof body.sourceUrl === "string" && /^https?:\/\//.test(body.sourceUrl.trim())
         ? body.sourceUrl.trim()
         : undefined;
 
-    const result = imageUrl
-      ? await ingestImage({ imageUrl }, { ...opts, title: title || undefined })
-      : url
-        ? await ingestUrl(url, opts)
-        : await ingest(title || "Untitled", text, { ...opts, sourceUrl });
-
-    // Agent-knowledge ingests attach to the agent's learnings; owner-content
-    // ingests do not (they live in the owner's normal content space).
-    if (!asOwner) {
-      await addAgentLearningPage(id, result.primarySlug);
-    }
-
-    // Vault filing: explicit vaultId → agent's defaultVault → none.
-    const explicitVault =
-      typeof body.vaultId === "string" && body.vaultId.trim().length > 0
-        ? body.vaultId.trim()
-        : undefined;
-    let effectiveVault = explicitVault;
-    if (!effectiveVault) {
-      // Resolve the agent record if not yet loaded (per-agent-token, no asOwner).
+    // Resolve + validate the target vault BEFORE enqueue (ownership is a cheap,
+    // synchronous prefix check): explicit vaultId → agent's defaultVault → none,
+    // and only a vault the agent's owner OWNS is passed to the job (else skipped).
+    let validatedVault: string | undefined;
+    {
+      const explicitVault =
+        typeof body.vaultId === "string" && body.vaultId.trim().length > 0
+          ? body.vaultId.trim()
+          : undefined;
       if (!agentRecord) {
         try { agentRecord = await getAgent(id); } catch { agentRecord = null; }
       }
-      if (agentRecord?.defaultVault) {
-        effectiveVault = agentRecord.defaultVault;
-      }
-    }
-    if (effectiveVault) {
-      // Resolve agent record for ownership check if still missing.
-      if (!agentRecord) {
-        try { agentRecord = await getAgent(id); } catch { agentRecord = null; }
-      }
-      const ownerHandle = agentRecord?.owner;
-      if (ownerHandle && vaultOwnedBy(effectiveVault, ownerHandle)) {
-        try { await addToVault(effectiveVault, result.primarySlug); }
-        catch (e) { logger.warn("agents", `vault filing failed for ${effectiveVault}:`, e); }
-      } else {
-        logger.warn("agents", `skipping vault filing: owner "${ownerHandle}" does not own vault "${effectiveVault}"`);
+      const effectiveVault = explicitVault || agentRecord?.defaultVault || undefined;
+      if (effectiveVault) {
+        const ownerHandle = agentRecord?.owner;
+        if (ownerHandle && vaultOwnedBy(effectiveVault, ownerHandle)) {
+          validatedVault = effectiveVault;
+        } else {
+          logger.warn(
+            "agents",
+            `skipping vault filing: owner "${ownerHandle}" does not own vault "${effectiveVault}"`,
+          );
+        }
       }
     }
 
-    return NextResponse.json({
-      slug: result.primarySlug,
-      deduped: result.deduped ?? false,
+    // The job OWNER (who sees it in the UI) is the human owner when known, else
+    // the agent id (legacy ownerless agent).
+    const jobOwner = agentRecord?.owner ?? id;
+    const displayTitle =
+      (title && title.trim()) ||
+      (text ? deriveTitleFromContent(text) : "") ||
+      url ||
+      imageUrl ||
+      "Untitled";
+    const jobUrl = url || imageUrl || undefined;
+    const jobId = crypto.randomUUID();
+    await createIngestJob({
+      jobId,
+      owner: jobOwner,
+      ...(jobUrl ? { url: jobUrl } : {}),
+      title: displayTitle,
+    });
+
+    // Shared task attribution. Text rides inline if small, else stage to R2.
+    const attribution = {
+      owner,
+      author,
+      triggeredBy,
+      ...(pageType ? { pageType } : {}),
+      ...(sourceType ? { sourceType } : {}),
+      ...(learningFor ? { learningFor } : {}),
+      ...(validatedVault ? { vaultId: validatedVault } : {}),
+      ...(title && title.trim() ? { title: title.trim() } : {}),
+      jobId,
+    };
+    let task: Task;
+    if (imageUrl) {
+      task = { kind: "ingest", source: "image", url: imageUrl, ...attribution };
+    } else if (url) {
+      task = { kind: "ingest", url, ...attribution };
+    } else if (text.length <= MAX_INLINE_CONTENT_CHARS) {
+      task = { kind: "ingest", content: text, ...(sourceUrl ? { sourceUrl } : {}), ...attribution };
+    } else {
+      const key = await stageText(jobId, text);
+      task = { kind: "ingest", staged: { key, kind: "text" }, ...(sourceUrl ? { sourceUrl } : {}), ...attribution };
+    }
+
+    // Enqueue (Workers) or run inline (off-Workers: local dev / tests). The inline
+    // path mirrors the executor's agent post-steps (learning page + vault filing).
+    const opts: IngestOptions = {
+      author,
+      owner,
+      triggeredBy,
+      ...(pageType ? { pageType } : {}),
+      ...(sourceType ? { sourceType } : {}),
+    };
+    return await enqueueOrInline(jobId, task, async () => {
+      const result = imageUrl
+        ? await ingestImage({ imageUrl }, { ...opts, title: title || undefined })
+        : url
+          ? await ingestUrl(url, opts)
+          : await ingest(title || "Untitled", text, { ...opts, sourceUrl });
+      if (learningFor) await addAgentLearningPage(learningFor, result.primarySlug);
+      if (validatedVault) {
+        try { await addToVault(validatedVault, result.primarySlug); }
+        catch (e) { logger.warn("agents", `vault filing failed for ${validatedVault}:`, e); }
+      }
+      return result;
     });
   } catch (err) {
     logger.error("agents", "agent ingest failed:", err);

--- a/src/app/api/tasks/run/route.ts
+++ b/src/app/api/tasks/run/route.ts
@@ -6,7 +6,7 @@ import { ingest, ingestUrl, ingestPdf, ingestImage, reingest } from "@/lib/inges
 import { fixLintIssue } from "@/lib/lint-fix";
 import { updateIngestJob } from "@/lib/ingest-jobs";
 import { readStagedBytes, readStagedText, deleteStaged } from "@/lib/ingest-staging";
-import { agentIdFor, DEFAULT_AGENT_NAME } from "@/lib/agents";
+import { agentIdFor, addAgentLearningPage, DEFAULT_AGENT_NAME } from "@/lib/agents";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 import { addToVault } from "@/lib/vault";
@@ -93,9 +93,17 @@ export async function POST(req: Request) {
     }
 
     // kind === "ingest"
+    // triggeredBy defaults to author (the common case); agent ingests pass it
+    // explicitly so author=agent while triggeredBy=human owner.
+    const triggeredBy = task.triggeredBy ?? task.author;
     const opts = {
       ...(task.owner ? { owner: task.owner } : {}),
-      ...(task.author ? { author: task.author, triggeredBy: task.author } : {}),
+      ...(task.author ? { author: task.author } : {}),
+      ...(triggeredBy ? { triggeredBy } : {}),
+      // Agent ingests carry a scoped page type + (text) provenance url/type.
+      ...(task.pageType ? { pageType: task.pageType } : {}),
+      ...(task.sourceUrl ? { sourceUrl: task.sourceUrl } : {}),
+      ...(task.sourceType ? { sourceType: task.sourceType } : {}),
       ...(task.tags && task.tags.length > 0 ? { tags: task.tags } : {}),
       // A user-supplied title must survive the queue hop — ingestPdf/ingestImage
       // use it to override the derived title (and, for images, the slug). The
@@ -150,6 +158,16 @@ export async function POST(req: Request) {
         status: "done",
         slug: result.primarySlug,
       });
+    }
+
+    // Agent-scoped ingest: attach the page to the agent's learnings (fail-soft;
+    // addAgentLearningPage already no-ops + logs if the agent is gone).
+    if (task.learningFor) {
+      try {
+        await addAgentLearningPage(task.learningFor, result.primarySlug);
+      } catch (err) {
+        logger.warn("tasks", `learning-page attach failed for agent="${task.learningFor}" slug="${result.primarySlug}": ${(err as Error).message}`);
+      }
     }
 
     // Auto-file into vault if requested (fail-soft: never fail the ingest).

--- a/src/app/api/tasks/run/route.ts
+++ b/src/app/api/tasks/run/route.ts
@@ -160,13 +160,19 @@ export async function POST(req: Request) {
       });
     }
 
-    // Agent-scoped ingest: attach the page to the agent's learnings (fail-soft;
-    // addAgentLearningPage already no-ops + logs if the agent is gone).
+    // Agent-scoped ingest: attach the page to the agent's learnings. Fail-soft —
+    // the job is already `done` and the page exists; we won't fail the ingest over
+    // this. But a THROW here means the page is orphaned from the agent (it won't
+    // surface under the profile / `agent:` scope), so log it at error (matching
+    // addAgentLearningPage's own severity for the missing-agent case).
     if (task.learningFor) {
       try {
         await addAgentLearningPage(task.learningFor, result.primarySlug);
       } catch (err) {
-        logger.warn("tasks", `learning-page attach failed for agent="${task.learningFor}" slug="${result.primarySlug}": ${(err as Error).message}`);
+        logger.error(
+          "tasks",
+          `learning-page attach failed for agent="${task.learningFor}" slug="${result.primarySlug}": ${getErrorMessage(err)}`,
+        );
       }
     }
 

--- a/src/lib/__tests__/agent-ingest-route.test.ts
+++ b/src/lib/__tests__/agent-ingest-route.test.ts
@@ -20,12 +20,22 @@ vi.mock("@/lib/vault", () => ({
   vaultOwnedBy: vi.fn(() => false),
 }));
 
+// Keep parseTask etc. real; only stub the queue producer. Default false ⇒
+// off-Workers, so enqueueOrInline runs the inline path (the existing tests
+// exercise that). Override to true to test the QUEUED (prod) path.
+vi.mock("@/lib/tasks", async (orig) => ({
+  ...(await orig<typeof import("@/lib/tasks")>()),
+  enqueueTask: vi.fn(async () => false),
+}));
+
 import { verifyAgentToken, addAgentLearningPage, getAgent } from "@/lib/agents";
 import { getServicePrincipal } from "@/lib/auth";
 import { ingestUrl, ingest } from "@/lib/ingest";
 import { addToVault, vaultOwnedBy } from "@/lib/vault";
+import { enqueueTask } from "@/lib/tasks";
 import { POST } from "@/app/api/agents/[id]/ingest/route";
 
+const mockedEnqueue = vi.mocked(enqueueTask);
 const mockedVerify = vi.mocked(verifyAgentToken);
 const mockedAddLearning = vi.mocked(addAgentLearningPage);
 const mockedGetAgent = vi.mocked(getAgent);
@@ -49,6 +59,7 @@ function req(body: unknown, token?: string): Request {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockedEnqueue.mockResolvedValue(false); // default: inline path
   mockedVerify.mockResolvedValue("alice--yoyo");
   mockedServicePrincipal.mockReturnValue(null);
   mockedAddLearning.mockResolvedValue();
@@ -86,7 +97,7 @@ describe("POST /api/agents/[id]/ingest", () => {
     expect(mockedAddLearning).toHaveBeenCalledWith("alice--yoyo", "ingested-page");
   });
 
-  it("returns a queued job (async contract — no longer blocks on the slug)", async () => {
+  it("returns the async response contract { queued, jobId }", async () => {
     const res = await POST(req({ url: "https://example.com" }, "alice--yoyo.s"), {
       params,
     });
@@ -94,6 +105,32 @@ describe("POST /api/agents/[id]/ingest", () => {
     const body = await res.json();
     expect(body.queued).toBe(true);
     expect(typeof body.jobId).toBe("string");
+  });
+
+  it("on Workers (queue available) enqueues the agent Task and does NOT run inline", async () => {
+    // This is the PROD path — assert the producer/consumer field seam directly,
+    // not just the off-Workers inline fallback the other tests exercise.
+    mockedEnqueue.mockResolvedValue(true);
+    const res = await POST(req({ url: "https://example.com" }, "alice--yoyo.s"), {
+      params,
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).queued).toBe(true);
+    expect(mockedEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "ingest",
+        url: "https://example.com",
+        owner: "alice--yoyo",
+        author: "alice--yoyo",
+        triggeredBy: "alice--yoyo",
+        pageType: "agent-knowledge",
+        learningFor: "alice--yoyo",
+        jobId: expect.any(String),
+      }),
+    );
+    // Enqueued ⇒ the inline ingest must NOT have run.
+    expect(mockedIngestUrl).not.toHaveBeenCalled();
+    expect(mockedAddLearning).not.toHaveBeenCalled();
   });
 
   it("ingests text", async () => {

--- a/src/lib/__tests__/agent-ingest-route.test.ts
+++ b/src/lib/__tests__/agent-ingest-route.test.ts
@@ -86,6 +86,16 @@ describe("POST /api/agents/[id]/ingest", () => {
     expect(mockedAddLearning).toHaveBeenCalledWith("alice--yoyo", "ingested-page");
   });
 
+  it("returns a queued job (async contract — no longer blocks on the slug)", async () => {
+    const res = await POST(req({ url: "https://example.com" }, "alice--yoyo.s"), {
+      params,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.queued).toBe(true);
+    expect(typeof body.jobId).toBe("string");
+  });
+
   it("ingests text", async () => {
     const res = await POST(
       req({ text: "hello", title: "Note" }, "alice--yoyo.s"),

--- a/src/lib/__tests__/tasks-route.test.ts
+++ b/src/lib/__tests__/tasks-route.test.ts
@@ -98,6 +98,44 @@ describe("POST /api/tasks/run", () => {
     expect(mockedIngest).not.toHaveBeenCalled();
   });
 
+  it("agent ingest: threads pageType/triggeredBy/sourceType to the pipeline", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedIngest.mockResolvedValue({ primarySlug: "k" } as any);
+    const res = await run({
+      kind: "ingest",
+      content: "note",
+      title: "N",
+      owner: "alice--yoyo",
+      author: "alice--yoyo",
+      triggeredBy: "alice--yoyo",
+      pageType: "agent-knowledge",
+      sourceType: "text",
+      learningFor: "alice--yoyo", // real addAgentLearningPage is fail-soft (no agent)
+    });
+    expect(res.status).toBe(200);
+    expect(mockedIngest).toHaveBeenCalledWith(
+      "N",
+      "note",
+      expect.objectContaining({
+        owner: "alice--yoyo",
+        author: "alice--yoyo",
+        triggeredBy: "alice--yoyo",
+        pageType: "agent-knowledge",
+        sourceType: "text",
+      }),
+    );
+  });
+
+  it("ingest triggeredBy defaults to author when not provided", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedIngestUrl.mockResolvedValue({ primarySlug: "x" } as any);
+    await run({ kind: "ingest", url: "https://e.com", owner: "o", author: "a" });
+    expect(mockedIngestUrl).toHaveBeenCalledWith(
+      "https://e.com",
+      expect.objectContaining({ author: "a", triggeredBy: "a" }),
+    );
+  });
+
   it("routes a URL pdf task (source:pdf) to ingestPdf", async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockedIngestPdf.mockResolvedValue({ primarySlug: "pdf-page" } as any);

--- a/src/lib/__tests__/tasks-route.test.ts
+++ b/src/lib/__tests__/tasks-route.test.ts
@@ -10,6 +10,12 @@ vi.mock("@/lib/ingest", () => ({
   reingest: vi.fn(),
 }));
 vi.mock("@/lib/lint-fix", () => ({ fixLintIssue: vi.fn() }));
+// Keep agentIdFor / DEFAULT_AGENT_NAME real (the reconcile path uses them);
+// only stub addAgentLearningPage so we can assert the learning attach + fail-soft.
+vi.mock("@/lib/agents", async (orig) => ({
+  ...(await orig<typeof import("@/lib/agents")>()),
+  addAgentLearningPage: vi.fn(async () => {}),
+}));
 vi.mock("@/lib/ingest-jobs", () => ({ updateIngestJob: vi.fn(async () => ({})) }));
 vi.mock("@/lib/ingest-staging", () => ({
   readStagedBytes: vi.fn(async () => new Uint8Array([1, 2, 3]).buffer),
@@ -42,6 +48,9 @@ const mockedDeleteStaged = vi.mocked(deleteStaged);
 
 import { addToVault } from "@/lib/vault";
 const mockedAddToVault = vi.mocked(addToVault);
+
+import { addAgentLearningPage } from "@/lib/agents";
+const mockedAddLearning = vi.mocked(addAgentLearningPage);
 
 async function run(body: unknown) {
   const { POST } = await import("@/app/api/tasks/run/route");
@@ -124,6 +133,33 @@ describe("POST /api/tasks/run", () => {
         sourceType: "text",
       }),
     );
+  });
+
+  it("attaches the page to the agent's learnings on success (learningFor)", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedIngest.mockResolvedValue({ primarySlug: "k" } as any);
+    const res = await run({
+      kind: "ingest",
+      content: "note",
+      owner: "alice--yoyo",
+      author: "alice--yoyo",
+      pageType: "agent-knowledge",
+      learningFor: "alice--yoyo",
+    });
+    expect(res.status).toBe(200);
+    expect(mockedAddLearning).toHaveBeenCalledWith("alice--yoyo", "k");
+  });
+
+  it("learning-page attach failure is fail-soft (the ingest still completes)", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedIngest.mockResolvedValue({ primarySlug: "k" } as any);
+    mockedAddLearning.mockRejectedValueOnce(new Error("storage down"));
+    const res = await run({
+      kind: "ingest",
+      content: "note",
+      learningFor: "alice--yoyo",
+    });
+    expect(res.status).toBe(200); // not failed by the orphan
   });
 
   it("ingest triggeredBy defaults to author when not provided", async () => {

--- a/src/lib/__tests__/tasks.test.ts
+++ b/src/lib/__tests__/tasks.test.ts
@@ -95,6 +95,38 @@ describe("parseTask", () => {
     ).toMatchObject({ kind: "ingest", staged: { key: "raw/uploads/j/text.md", kind: "text" } });
   });
 
+  it("preserves agent ingest fields (pageType, triggeredBy, sourceUrl, sourceType, learningFor)", () => {
+    expect(
+      parseTask({
+        kind: "ingest",
+        content: "note",
+        owner: "alice--yoyo",
+        author: "alice--yoyo",
+        triggeredBy: "alice--yoyo",
+        pageType: "agent-knowledge",
+        sourceUrl: "https://example.com/post",
+        sourceType: "text",
+        learningFor: "alice--yoyo",
+      }),
+    ).toMatchObject({
+      kind: "ingest",
+      pageType: "agent-knowledge",
+      triggeredBy: "alice--yoyo",
+      sourceUrl: "https://example.com/post",
+      sourceType: "text",
+      learningFor: "alice--yoyo",
+    });
+    // Invalid pageType / sourceType are dropped (not trusted from the queue).
+    const bad = parseTask({
+      kind: "ingest",
+      content: "x",
+      pageType: "evil",
+      sourceType: "bogus",
+    });
+    expect(bad).not.toHaveProperty("pageType");
+    expect(bad).not.toHaveProperty("sourceType");
+  });
+
   it("rejects a malformed staged descriptor", () => {
     // Empty key, bad kind, or non-object → staged dropped; with no url/content → null.
     expect(parseTask({ kind: "ingest", staged: { key: "", kind: "pdf" } })).toBeNull();

--- a/src/lib/__tests__/tasks.test.ts
+++ b/src/lib/__tests__/tasks.test.ts
@@ -116,15 +116,22 @@ describe("parseTask", () => {
       sourceType: "text",
       learningFor: "alice--yoyo",
     });
-    // Invalid pageType / sourceType are dropped (not trusted from the queue).
+    // Invalid pageType / sourceType, and empty/whitespace string fields, are
+    // dropped (not trusted from the queue).
     const bad = parseTask({
       kind: "ingest",
       content: "x",
       pageType: "evil",
       sourceType: "bogus",
+      triggeredBy: "",
+      sourceUrl: "   ",
+      learningFor: "",
     });
     expect(bad).not.toHaveProperty("pageType");
     expect(bad).not.toHaveProperty("sourceType");
+    expect(bad).not.toHaveProperty("triggeredBy");
+    expect(bad).not.toHaveProperty("sourceUrl");
+    expect(bad).not.toHaveProperty("learningFor");
   });
 
   it("rejects a malformed staged descriptor", () => {

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -60,6 +60,21 @@ export type Task =
       };
       /** Optional vault to auto-file the resulting page into (fail-soft). */
       vaultId?: string;
+      /** Agent ingests: the page `type` (scoped knowledge/identity), so the page
+       *  stays out of the public commons/feed. */
+      pageType?: "agent-knowledge" | "agent-identity";
+      /** Provenance actor; when absent the executor falls back to `author`. Lets
+       *  an agent ingest attribute `triggeredBy` to the human owner while `author`
+       *  stays the agent. */
+      triggeredBy?: string;
+      /** Provenance URL for a text ingest (the original source link). */
+      sourceUrl?: string;
+      /** Explicit source classification (e.g. agent `asOwner` ingests set
+       *  x-mention/url/text); when absent the pipeline derives it. */
+      sourceType?: "x-mention" | "url" | "text";
+      /** Agent id to attach the resulting page to as one of its learning pages
+       *  (agent-scoped ingests). */
+      learningFor?: string;
     }
   | {
       /** Autonomous maintenance, enqueued by the scan cron (Q2). `reconcile` a
@@ -210,6 +225,23 @@ export function parseTask(body: unknown): Task | null {
         ...(staged ? { staged } : {}),
         ...(typeof t.vaultId === "string" && t.vaultId.trim() !== ""
           ? { vaultId: t.vaultId }
+          : {}),
+        ...(t.pageType === "agent-knowledge" || t.pageType === "agent-identity"
+          ? { pageType: t.pageType }
+          : {}),
+        ...(typeof t.triggeredBy === "string" && t.triggeredBy.trim() !== ""
+          ? { triggeredBy: t.triggeredBy }
+          : {}),
+        ...(typeof t.sourceUrl === "string" && t.sourceUrl.trim() !== ""
+          ? { sourceUrl: t.sourceUrl }
+          : {}),
+        ...(t.sourceType === "x-mention" ||
+        t.sourceType === "url" ||
+        t.sourceType === "text"
+          ? { sourceType: t.sourceType }
+          : {}),
+        ...(typeof t.learningFor === "string" && t.learningFor.trim() !== ""
+          ? { learningFor: t.learningFor }
           : {}),
       };
     }

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -70,7 +70,9 @@ export type Task =
       /** Provenance URL for a text ingest (the original source link). */
       sourceUrl?: string;
       /** Explicit source classification (e.g. agent `asOwner` ingests set
-       *  x-mention/url/text); when absent the pipeline derives it. */
+       *  x-mention/url/text); when absent the pipeline derives it. Intentionally a
+       *  SUBSET of `IngestOptions["sourceType"]` — image/pdf/youtube are set
+       *  internally by the ingest functions, never carried over the queue. */
       sourceType?: "x-mention" | "url" | "text";
       /** Agent id to attach the resulting page to as one of its learning pages
        *  (agent-scoped ingests). */


### PR DESCRIPTION
The token-authed agent ingest endpoint (`POST /api/agents/<id>/ingest`) ran the **full pipeline synchronously** — fetch → LLM synth → embed → write — and only then returned the slug. Every call blocked for seconds and held a Worker invocation. This routes it through the **existing async framework** (`enqueueOrInline` + `ingest-jobs` + the task-consumer Worker), exactly like the interactive ingest routes.

## Changes
- **`ingest` Task + `parseTask`** (`src/lib/tasks.ts`): carry the agent fields the executor lacked — `pageType` (agent-knowledge), `triggeredBy` (so `author`=agent while `triggeredBy`=owner), `sourceUrl`, `sourceType`, and `learningFor` (agent id to attach the page to its learnings). Invalid `pageType`/`sourceType` are dropped (untrusted queue input).
- **Executor** (`/api/tasks/run`): apply those in opts; on success attach the page to the agent's learnings (fail-soft) — mirroring the old route's post-steps. `triggeredBy` defaults to `author` for all existing callers (no behavior change).
- **Agent route**: validate token/body, resolve+validate the target vault (ownership check stays synchronous), `createIngestJob`, then `enqueueOrInline`. Large text is staged to R2 (queue msg cap 128 KB).

## Breaking change (intended)
Response is now `{ queued: true, jobId }` instead of `{ slug, deduped }` — the slug doesn't exist at return time. **Fire-and-forget** (per decision): the page lands under the agent profile / its vault shortly after; the owner can watch progress in the UI. `public/agent-api.md` updated.

## Tests
- `parseTask`: preserves the new fields; drops invalid `pageType`/`sourceType`.
- Executor: threads `pageType`/`triggeredBy`/`sourceType`; `triggeredBy` defaults to `author`.
- Agent route: returns a queued job; all prior behavior (attribution, learnings, vault filing, `asOwner` sourceType incl. x-mention) preserved via the off-Workers inline path.

Gates: lint 0 errors · vitest 3409 passed · `pnpm build` + `pnpm build:cloudflare` clean.

Note: rate-limiting the (now-enqueue) path is still the separate Tier-1 item in the gap-analysis doc — async offloads the work but doesn't cap enqueue volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)