### PR TITLE
yoyo: show filed agent-knowledge in a vault's Browse view

### DIFF
--- a/src/lib/__tests__/browse.test.ts
+++ b/src/lib/__tests__/browse.test.ts
@@ -176,7 +176,7 @@ describe("searchCommons — vault scope", () => {
     expect(r.results).toEqual([]);
   });
 
-  it("intersects a public vault's refs with readable pages and excludes agent pages", async () => {
+  it("intersects a public vault's refs with readable pages, INCLUDING filed agent-knowledge", async () => {
     mockedGetVault.mockResolvedValue({
       id: "v1",
       visibility: "public",
@@ -184,11 +184,17 @@ describe("searchCommons — vault scope", () => {
     } as never);
     mockedReadable.mockResolvedValue([
       entry("transformers", { title: "Transformers", updated: "2026-06-05" }),
+      // Agent-knowledge deliberately filed into the vault — must now show (it's
+      // in the vault's refs and readable). Readability is the only gate.
       entry("agent-note", { type: "agent-knowledge", updated: "2026-06-06" }),
       entry("unreferenced", { updated: "2026-06-07" }),
     ]);
     const r = await searchCommons(null, { scope: "vault:v1" });
-    // Only the referenced, non-agent page survives.
-    expect(r.results.map((p) => p.slug)).toEqual(["transformers"]);
+    // Both referenced pages survive (recent sort → newest first); the
+    // unreferenced page is excluded. Agent-knowledge is no longer stripped.
+    expect(r.results.map((p) => p.slug).sort()).toEqual([
+      "agent-note",
+      "transformers",
+    ]);
   });
 });

--- a/src/lib/__tests__/browse.test.ts
+++ b/src/lib/__tests__/browse.test.ts
@@ -8,8 +8,6 @@ vi.mock("../commons", () => ({
 }));
 vi.mock("../wiki", () => ({
   listReadableWikiPages: vi.fn(async () => [] as IndexEntry[]),
-  // Agent pages are `type: agent-*` — mirror the real predicate.
-  isAgentScopedType: (t?: string) => !!t && t.startsWith("agent-"),
 }));
 vi.mock("../vault", () => ({
   getVault: vi.fn(async () => null),
@@ -192,9 +190,24 @@ describe("searchCommons — vault scope", () => {
     const r = await searchCommons(null, { scope: "vault:v1" });
     // Both referenced pages survive (recent sort → newest first); the
     // unreferenced page is excluded. Agent-knowledge is no longer stripped.
-    expect(r.results.map((p) => p.slug).sort()).toEqual([
-      "agent-note",
-      "transformers",
+    // Order asserted directly (newest first) to also pin the recency sort.
+    expect(r.results.map((p) => p.slug)).toEqual(["agent-note", "transformers"]);
+  });
+
+  it("readability is the gate: a vault ref the viewer can't read is excluded", async () => {
+    // The agent-scoped filter was the only secondary layer; now readability
+    // (listReadableWikiPages) is the SOLE gate, so a filed-but-unreadable page
+    // (e.g. someone else's private page) must not surface via the public vault.
+    mockedGetVault.mockResolvedValue({
+      id: "v1",
+      visibility: "public",
+      slugs: ["transformers", "secret"],
+    } as never);
+    mockedReadable.mockResolvedValue([
+      entry("transformers", { title: "Transformers", updated: "2026-06-05" }),
+      // "secret" is in the vault refs but NOT in the readable set → must be dropped.
     ]);
+    const r = await searchCommons(null, { scope: "vault:v1" });
+    expect(r.results.map((p) => p.slug)).toEqual(["transformers"]);
   });
 });

--- a/src/lib/browse.ts
+++ b/src/lib/browse.ts
@@ -20,7 +20,7 @@
 import type { IndexEntry } from "./types";
 import type { Principal } from "./auth";
 import { listCommonsPages } from "./commons";
-import { listReadableWikiPages, isAgentScopedType } from "./wiki";
+import { listReadableWikiPages } from "./wiki";
 import { getVault } from "./vault";
 import { getDiscussionStatsForSlugs } from "./talk";
 import { tokenize, buildCorpusStats, bm25Score } from "./bm25";
@@ -75,9 +75,12 @@ export const BROWSE_PAGE_SIZE = 30;
 /**
  * Resolve the candidate pool for a scope. `"all"` → the public commons (already
  * public + non-agent by construction). `"vault:<id>"` → a PUBLIC vault's
- * referenced pages the viewer may read, with agent-scoped pages excluded (the
- * readable set can include the owner's own agent/private pages, the commons
- * cannot — so re-apply the agent filter here).
+ * referenced pages the viewer may read — INCLUDING agent-knowledge filed into it.
+ * A vault is the owner's deliberate collection, so readability is the only gate:
+ * the owner always sees their own filed pages, and a public vault's agent-knowledge
+ * (which is publicly readable) is visible to any viewer — matching the vault-scope
+ * search API. (The `"all"` commons lens still excludes agent-scoped by construction.)
+ * Private vaults aren't resolved here yet (owner+agent view is a separate feature).
  */
 async function resolveCandidates(
   scope: string,
@@ -88,9 +91,7 @@ async function resolveCandidates(
     const vault = await getVault(vaultId);
     if (!vault || vault.visibility !== "public") return [];
     const refs = new Set(vault.slugs);
-    return (await listReadableWikiPages(principal))
-      .filter((p) => refs.has(p.slug))
-      .filter((p) => !isAgentScopedType(p.type));
+    return (await listReadableWikiPages(principal)).filter((p) => refs.has(p.slug));
   }
   return listCommonsPages();
 }

--- a/src/lib/browse.ts
+++ b/src/lib/browse.ts
@@ -12,9 +12,11 @@
  * visibility-scoped candidate pool, so a search never WIDENS visibility beyond
  * what the scope's pool already allows (same guard as the /query retrieval). For
  * `scope=all` that pool is public + non-agent by construction; for a `vault:<id>`
- * scope it's the viewer's readable vault refs with agent-scoped pages excluded —
- * so a viewer's OWN private page in their public vault stays visible to them (and
- * only them), but no search can surface another user's private page.
+ * scope it's the viewer's readable refs of a PUBLIC vault — INCLUDING agent-knowledge
+ * filed into it. Readability is the only gate: a viewer's OWN private page in their
+ * public vault stays visible to them (and only them), a public vault's
+ * publicly-readable agent-knowledge is visible to all, and no search can surface
+ * another user's private page.
  */
 
 import type { IndexEntry } from "./types";


### PR DESCRIPTION
**Bug:** ingesting yoyo's research with a `vaultId` filed the pages into the vault correctly (the vault-scope **search** API returns them), but `/wiki?scope=vault:<id>` Browse rendered **empty** — because `resolveCandidates` stripped agent-scoped pages (`!isAgentScopedType`). So "save my agent's research into a vault" looked broken.

## Fix
For a **public** vault, readability is now the only gate — the agent-scoped strip is removed (`src/lib/browse.ts`):
- the **owner always** sees their own filed pages (readability includes their agent/private pages),
- a **public** vault's agent-knowledge is publicly readable, so **any viewer** sees it — consistent with the vault-scope search API and with these pages being publicly readable.
- The `all` commons lens is unchanged (still public + non-agent by construction).

Per the chosen model: *public vault → publicly viewable; owner always sees; private vault → owner+agent only.* The private-vault view (owner+agent) is still **deferred** — private vaults return `[]` here as before.

No backfill needed: the pages are already in the vault (search proves it), so they appear in Browse as soon as this deploys.

## Tests
Updated the vault-scope browse test: a public vault now surfaces filed agent-knowledge (was: excluded). Full suite green (3412).

Gates: lint 0 errors · vitest 3412 · `pnpm build` + `pnpm build:cloudflare` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)