### PR TITLE
yoyo: parallelize agent recall reads (context + content search)

### DIFF
--- a/src/app/api/agents/[id]/context/route.ts
+++ b/src/app/api/agents/[id]/context/route.ts
@@ -3,6 +3,7 @@ import { getAgent, resolveAgentPages } from "@/lib/agents";
 import { readWikiPageWithFrontmatter } from "@/lib/wiki";
 import { getPrincipal, type Principal } from "@/lib/auth";
 import { canReadFrontmatter } from "@/lib/authz";
+import { mapWithConcurrency, READ_CONCURRENCY } from "@/lib/concurrency";
 import { getErrorMessage } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 
@@ -21,18 +22,23 @@ async function loadPages(
   slugs: string[],
   principal: Principal | null,
 ): Promise<{ content: string; count: number }> {
+  // Read every page in parallel (bounded) — this was a serial per-slug loop and
+  // the dominant latency of the endpoint. Order is preserved so the assembled
+  // context stays stable; unreadable/missing pages drop out below.
+  const pages = await mapWithConcurrency(slugs, READ_CONCURRENCY, (slug) =>
+    readWikiPageWithFrontmatter(slug),
+  );
   const contents: string[] = [];
-  for (const slug of slugs) {
-    const page = await readWikiPageWithFrontmatter(slug);
+  pages.forEach((page, i) => {
     if (page) {
       // Skip pages the caller can't read (an agent's list may reference a
       // third party's private page).
-      if (!canReadFrontmatter(page.frontmatter, principal)) continue;
+      if (!canReadFrontmatter(page.frontmatter, principal)) return;
       contents.push(page.body);
     } else {
-      logger.warn("agents", `Wiki page "${slug}" not found — skipping`);
+      logger.warn("agents", `Wiki page "${slugs[i]}" not found — skipping`);
     }
-  }
+  });
   return {
     content: contents.join(PAGE_SEPARATOR),
     count: contents.length,

--- a/src/lib/__tests__/concurrency.test.ts
+++ b/src/lib/__tests__/concurrency.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { mapWithConcurrency } from "../concurrency";
+
+describe("mapWithConcurrency", () => {
+  it("preserves input order regardless of completion order", async () => {
+    // Later items resolve first (descending delay) — a naive push-on-resolve
+    // would scramble the output; the result must still match input order.
+    const items = [0, 1, 2, 3, 4];
+    const out = await mapWithConcurrency(items, 8, async (n) => {
+      await new Promise((r) => setTimeout(r, (items.length - n) * 5));
+      return n * 10;
+    });
+    expect(out).toEqual([0, 10, 20, 30, 40]);
+  });
+
+  it("passes the index to the mapper", async () => {
+    const out = await mapWithConcurrency(["a", "b", "c"], 2, async (item, i) => `${i}:${item}`);
+    expect(out).toEqual(["0:a", "1:b", "2:c"]);
+  });
+
+  it("never exceeds the concurrency limit", async () => {
+    let active = 0;
+    let peak = 0;
+    await mapWithConcurrency(Array.from({ length: 20 }, (_, i) => i), 4, async () => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 2));
+      active--;
+    });
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(peak).toBeGreaterThan(1); // sanity: it actually parallelized
+  });
+
+  it("runs every item even when there are fewer than the limit", async () => {
+    const out = await mapWithConcurrency([1, 2], 10, async (n) => n + 1);
+    expect(out).toEqual([2, 3]);
+  });
+
+  it("returns an empty array for empty input without spawning workers", async () => {
+    const out = await mapWithConcurrency([], 4, async () => {
+      throw new Error("should not be called");
+    });
+    expect(out).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/concurrency.test.ts
+++ b/src/lib/__tests__/concurrency.test.ts
@@ -42,4 +42,16 @@ describe("mapWithConcurrency", () => {
     });
     expect(out).toEqual([]);
   });
+
+  it("rejects the whole call when any fn rejects (documented contract)", async () => {
+    // Callers (search, context) rely on a failed read surfacing as an error
+    // rather than being swallowed. Lock that in so a future "skip-on-failure"
+    // refactor can't silently change the contract.
+    await expect(
+      mapWithConcurrency([1, 2, 3], 2, async (n) => {
+        if (n === 2) throw new Error("boom");
+        return n;
+      }),
+    ).rejects.toThrow("boom");
+  });
 });

--- a/src/lib/__tests__/context-route.test.ts
+++ b/src/lib/__tests__/context-route.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the data SOURCES only. canReadFrontmatter (authz) and mapWithConcurrency
+// (concurrency) stay REAL, so the test exercises the route's actual ordering +
+// access-control behavior — the two invariants the parallel-read refactor put at
+// risk (see context/route.ts loadPages).
+// Partial mock: override only the two data lookups; keep the rest real so
+// canReadFrontmatter's call into agentOwnerHandle (also from this module) works.
+vi.mock("@/lib/agents", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/agents")>()),
+  getAgent: vi.fn(),
+  resolveAgentPages: vi.fn(),
+}));
+vi.mock("@/lib/wiki", () => ({
+  readWikiPageWithFrontmatter: vi.fn(),
+}));
+vi.mock("@/lib/auth", () => ({
+  getPrincipal: vi.fn(),
+}));
+
+import { getAgent, resolveAgentPages } from "@/lib/agents";
+import { readWikiPageWithFrontmatter } from "@/lib/wiki";
+import { getPrincipal } from "@/lib/auth";
+import { GET } from "@/app/api/agents/[id]/context/route";
+
+const mockedGetAgent = vi.mocked(getAgent);
+const mockedResolve = vi.mocked(resolveAgentPages);
+const mockedRead = vi.mocked(readWikiPageWithFrontmatter);
+const mockedPrincipal = vi.mocked(getPrincipal);
+
+type Page = { frontmatter: Record<string, unknown>; body: string };
+
+/** Build a slug→page table and wire the read mock to resolve from it, with an
+ *  optional per-slug delay so later slugs can finish FIRST — that catches a
+ *  zip/order-preservation regression that a uniform-latency mock would miss. */
+function wirePages(table: Record<string, Page | null>, delays: Record<string, number> = {}) {
+  mockedRead.mockImplementation(async (slug: string) => {
+    const delay = delays[slug] ?? 0;
+    if (delay) await new Promise((r) => setTimeout(r, delay));
+    const page = table[slug] ?? null;
+    // The route only reads .frontmatter and .body; cast covers the wider type.
+    return page as never;
+  });
+}
+
+const pub = (body: string): Page => ({ frontmatter: {}, body });
+const priv = (body: string, owner: string): Page => ({
+  frontmatter: { visibility: "private", owner },
+  body,
+});
+
+function call(id = "alice--yoyo") {
+  return GET(new Request("http://x/api/agents/x/context"), {
+    params: Promise.resolve({ id }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetAgent.mockResolvedValue({ id: "alice--yoyo", name: "yoyo" } as never);
+  mockedPrincipal.mockResolvedValue(null);
+});
+
+describe("GET /api/agents/[id]/context — loadPages ordering + access control", () => {
+  it("preserves slug order within a section even when later pages resolve first", async () => {
+    mockedResolve.mockResolvedValue({
+      identityPages: ["id-a", "id-b", "id-c"],
+      learningPages: ["learn-a"],
+      socialPages: [],
+    } as never);
+    // id-a is SLOWEST so a naive push-on-resolve would put it last.
+    wirePages(
+      { "id-a": pub("A"), "id-b": pub("B"), "id-c": pub("C"), "learn-a": pub("L") },
+      { "id-a": 15, "id-b": 5, "id-c": 1 },
+    );
+
+    const res = await call();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.context.identity).toBe("A\n\n---\n\nB\n\n---\n\nC");
+    expect(json.context.learnings).toBe("L");
+    expect(json.meta.pageCount).toBe(4);
+  });
+
+  it("skips a missing page (read returns null) and counts only the survivors", async () => {
+    mockedResolve.mockResolvedValue({
+      identityPages: ["id-a", "gone", "id-c"],
+      learningPages: [],
+      socialPages: [],
+    } as never);
+    wirePages({ "id-a": pub("A"), gone: null, "id-c": pub("C") });
+
+    const json = await (await call()).json();
+    expect(json.context.identity).toBe("A\n\n---\n\nC");
+    expect(json.meta.pageCount).toBe(2);
+  });
+
+  it("excludes a third party's private page from a non-owner's context", async () => {
+    mockedResolve.mockResolvedValue({
+      identityPages: ["mine"],
+      learningPages: ["mine", "bobs-secret"],
+      socialPages: [],
+    } as never);
+    wirePages({ mine: pub("MINE"), "bobs-secret": priv("SECRET", "bob") });
+    mockedPrincipal.mockResolvedValue({ id: "alice", handle: "alice" });
+
+    const json = await (await call()).json();
+    // The private page Bob owns is gated out; Alice's learnings hold only "MINE".
+    expect(json.context.learnings).toBe("MINE");
+    expect(json.context.learnings).not.toContain("SECRET");
+    expect(json.meta.pageCount).toBe(2); // identity:mine + learnings:mine
+  });
+
+  it("includes an owner's own private page for that owner", async () => {
+    mockedResolve.mockResolvedValue({
+      identityPages: [],
+      learningPages: ["bobs-secret"],
+      socialPages: [],
+    } as never);
+    wirePages({ "bobs-secret": priv("SECRET", "bob") });
+    mockedPrincipal.mockResolvedValue({ id: "bob", handle: "bob" });
+
+    const json = await (await call()).json();
+    expect(json.context.learnings).toBe("SECRET");
+    expect(json.meta.pageCount).toBe(1);
+  });
+
+  it("404s for an unknown agent", async () => {
+    mockedGetAgent.mockResolvedValue(null as never);
+    expect((await call()).status).toBe(404);
+  });
+});

--- a/src/lib/concurrency.ts
+++ b/src/lib/concurrency.ts
@@ -7,7 +7,11 @@
  * pool. Use it anywhere a `for (… of …) await` loop reads/writes per item.
  */
 
-/** Default cap on concurrent R2 reads/writes for a fan-out over pages. */
+/**
+ * Default cap on concurrent R2 reads/writes for a fan-out over pages. Matches
+ * `lifecycle.ts`'s independent `LIFECYCLE_CONCURRENCY` (kept separate so the two
+ * fan-out classes can be tuned apart); keep them in mind together if you retune.
+ */
 export const READ_CONCURRENCY = 12;
 
 /**

--- a/src/lib/concurrency.ts
+++ b/src/lib/concurrency.ts
@@ -1,0 +1,36 @@
+/**
+ * Bounded-concurrency parallel map.
+ *
+ * Keeps the parallelism win on large wikis (reads/writes fan out instead of
+ * running serially) WITHOUT firing thousands of simultaneous R2 subrequests —
+ * which would blow the Workers subrequest budget and starve the connection
+ * pool. Use it anywhere a `for (… of …) await` loop reads/writes per item.
+ */
+
+/** Default cap on concurrent R2 reads/writes for a fan-out over pages. */
+export const READ_CONCURRENCY = 12;
+
+/**
+ * Map over `items` running at most `limit` calls of `fn` at once. The result
+ * array is order-preserving (index i holds `fn(items[i])`), so callers can zip
+ * it back against the input. A `fn` that rejects rejects the whole call — wrap
+ * per-item work in try/catch if partial failure should be tolerated.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await fn(items[i], i);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  );
+  return results;
+}

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -23,6 +23,7 @@ import { getStorage } from "./storage";
 import { withFileLock } from "./lock";
 import { escapeRegex } from "./links";
 import { getErrorMessage } from "./errors";
+import { mapWithConcurrency } from "./concurrency";
 import { removeAliasForPage, updateAliasIndexForPage } from "./alias-index";
 import { removeSourceForPage } from "./source-index";
 import { syncCommonsForPage, removeCommonsEntryBySlug, belongsInCommons } from "./commons";
@@ -185,29 +186,6 @@ function stripBacklinksTo(slug: string, content: string): string {
  * Shared lifecycle-op pipeline for write and delete. See the block comment
  * above for the full 5-step shape.
  */
-/**
- * Map over items with bounded concurrency. Keeps the parallelism win on large
- * wikis without firing thousands of simultaneous R2 subrequests. Order-preserving.
- */
-async function mapWithConcurrency<T, R>(
-  items: T[],
-  limit: number,
-  fn: (item: T, index: number) => Promise<R>,
-): Promise<R[]> {
-  const results = new Array<R>(items.length);
-  let next = 0;
-  async function worker(): Promise<void> {
-    while (next < items.length) {
-      const i = next++;
-      results[i] = await fn(items[i], i);
-    }
-  }
-  await Promise.all(
-    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
-  );
-  return results;
-}
-
 /** Max concurrent R2 reads/writes during a page lifecycle op. */
 const LIFECYCLE_CONCURRENCY = 12;
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -15,6 +15,7 @@ import {
   tenantForOwner,
 } from "./wiki";
 import { writeWikiPageWithSideEffects } from "./lifecycle";
+import { mapWithConcurrency, READ_CONCURRENCY } from "./concurrency";
 import { canReadFrontmatter } from "./authz";
 import type { Principal } from "./auth";
 import { getAgent, resolveAgentPages } from "./agents";
@@ -518,18 +519,25 @@ export async function searchWikiContent(
     score: number;
   }> = [];
 
-  for (const entry of allPages) {
-    if (SKIP.has(entry.slug)) continue;
-
-    // Scope filtering: skip pages not in the scope's slug set
-    if (scopeSlugs && !scopeSlugs.has(entry.slug)) continue;
-    // Skip artifacts (always) and, when unscoped, agent-scoped pages.
-    if (excludedSlugs.has(entry.slug)) continue;
-
-    const slug = entry.slug;
-
+  // Cheap index-only filters first (skip-list, scope, artifacts/agent-scoped),
+  // then read the surviving candidates' bodies in parallel (bounded). The read
+  // used to run serially inside this loop — the dominant cost of content search.
+  const candidates = allPages.filter(
+    (entry) =>
+      !SKIP.has(entry.slug) &&
+      !(scopeSlugs && !scopeSlugs.has(entry.slug)) &&
+      !excludedSlugs.has(entry.slug),
+  );
+  const candidatePages = await mapWithConcurrency(
+    candidates,
+    READ_CONCURRENCY,
     // Read via readWikiPage (silo-primary after #749)
-    const page = await readWikiPage(slug);
+    (entry) => readWikiPage(entry.slug),
+  );
+
+  for (let i = 0; i < candidates.length; i++) {
+    const slug = candidates[i].slug;
+    const page = candidatePages[i];
     if (!page) continue;
     const content = page.content;
 
@@ -637,20 +645,26 @@ export async function fuzzySearchWikiContent(
 
   const fuzzyResults: ContentSearchResult[] = [];
 
-  for (const entry of allPages) {
-    if (SKIP.has(entry.slug)) continue;
-    const slug = entry.slug;
-
-    // Scope filtering: skip pages not in the scope's slug set
-    if (scopeSlugs && !scopeSlugs.has(slug)) continue;
-    // Skip artifacts (always) and, when unscoped, agent-scoped pages.
-    if (excludedSlugs.has(slug)) continue;
-
-    // Skip pages already in exact results
-    if (exactSlugs.has(slug)) continue;
-
+  // Cheap index-only filters first (skip-list, scope, artifacts/agent-scoped,
+  // already-exact), then read the survivors' bodies in parallel (bounded). The
+  // read used to run serially inside this loop.
+  const candidates = allPages.filter(
+    (entry) =>
+      !SKIP.has(entry.slug) &&
+      !(scopeSlugs && !scopeSlugs.has(entry.slug)) &&
+      !excludedSlugs.has(entry.slug) &&
+      !exactSlugs.has(entry.slug),
+  );
+  const candidatePages = await mapWithConcurrency(
+    candidates,
+    READ_CONCURRENCY,
     // Read via readWikiPage (silo-primary after #749)
-    const page = await readWikiPage(slug);
+    (entry) => readWikiPage(entry.slug),
+  );
+
+  for (let i = 0; i < candidates.length; i++) {
+    const slug = candidates[i].slug;
+    const page = candidatePages[i];
     if (!page) continue;
     const content = page.content;
 


### PR DESCRIPTION
## Why

Both agent recall endpoints are dominated by **serial R2 reads** — one page at a time in a `for…await` loop. No LLM, no compute; just waiting on storage round-trips.

Measured live (yuanhao--yoyo):
- `GET /api/agents/<id>/context` — **~3s** (79 KB, no LLM)
- `GET /api/wiki/search?scope=agent:<id>` — **~4-5s** (no LLM)

## What

Read the candidate page bodies **in parallel with bounded concurrency** instead of serially.

- **`context/route.ts`** — `loadPages` now reads all slugs via `mapWithConcurrency` (the three sections already parallelized, but the big one — learnings — read its pages serially).
- **`search.ts`** — `searchWikiContent` + the fuzzy fallback now run the cheap index-only filters first (skip-list, scope, artifact/agent-scoped, already-exact), then read only the survivors' bodies in parallel.
- **`concurrency.ts`** (new) — promoted `lifecycle.ts`'s private `mapWithConcurrency` to a shared, order-preserving, capped helper (`READ_CONCURRENCY = 12`) so the unscoped commons search doesn't fire hundreds of simultaneous R2 subrequests. `lifecycle.ts` now imports it.

Expected: context **~3s → sub-second**, scoped search **~4-5s → sub-second**.

## Notes / follow-ups (not in this PR)
- **#2 index-prefilter search** — score on title/summary from the index and only read top-K bodies for snippets (mirrors what `browse.ts` already does), cutting the *number* of reads.
- **#3 short-TTL cache** the assembled context blob.

## Test
- New `concurrency.test.ts`: order preservation, index passthrough, concurrency-bound never exceeded, empty input.
- `pnpm lint` · `pnpm vitest run` (3418 pass) · `pnpm build` · `pnpm build:cloudflare` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)